### PR TITLE
Fix infinite recursion bug in ScheduledOptimizer for certain integrations

### DIFF
--- a/src/sparseml/pytorch/optim/optimizer.py
+++ b/src/sparseml/pytorch/optim/optimizer.py
@@ -101,6 +101,7 @@ class ScheduledOptimizer(Optimizer):
             "_epoch",
             "learning_rate",
             "param_groups",
+            "step",
         ]:
             super().__setattr__(key, value)
         else:


### PR DESCRIPTION
the current `__setattr__` set up for `ScheduledOptimizer` does not allow the `step` method to be explicitly set / overridden instead providing the child optimizer's step method.  This can cause infinite recursion in certain scenarios such as this LR scheduler:
https://github.com/pytorch/pytorch/blob/a389b30bfc12a22f12686c7be09693abd9604d80/torch/optim/lr_scheduler.py#L72.

This has caused issues when integrating with Apex and Huggingface flows.

Providing the correct step function to override fixes this issue.