### PR TITLE
ScheduledModifierManager load support from yaml front matter in markdown card

### DIFF
--- a/src/sparseml/keras/optim/manager.py
+++ b/src/sparseml/keras/optim/manager.py
@@ -7,14 +7,10 @@ Also handles loading modifiers from yaml files
 from typing import List, Union
 
 import tensorflow as tf
-
-from sparseml.optim import BaseManager
-from sparseml.keras.optim.modifier import (
-    Modifier,
-    ScheduledModifier,
-)
-
+from sparseml.keras.optim.modifier import Modifier, ScheduledModifier
 from sparseml.keras.utils import KerasLogger
+from sparseml.optim import BaseManager
+from sparseml.utils import load_recipe_yaml_str
 
 
 __all__ = ["ScheduledModifierManager"]
@@ -36,9 +32,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
             returned manager alongside the ones loaded from the yaml file
         :return: ScheduledModifierManager() created from the yaml file
         """
-        with open(file_path, "r") as yaml_file:
-            yaml_str = yaml_file.read()
-
+        yaml_str = load_recipe_yaml_str(file_path)
         modifiers = Modifier.load_list(yaml_str)
         if add_modifiers:
             modifiers.extend(add_modifiers)

--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Union
 from sparseml.optim import BaseManager
 from sparseml.pytorch.optim.modifier import Modifier, ScheduledModifier
 from sparseml.pytorch.utils import PyTorchLogger
+from sparseml.utils import load_recipe_yaml_str
 from torch import Tensor
 from torch.nn import Module
 from torch.optim.optimizer import Optimizer
@@ -49,9 +50,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
             returned manager alongside the ones loaded from the yaml file
         :return: ScheduledModifierManager() created from the yaml file
         """
-        with open(file_path, "r") as yaml_file:
-            yaml_str = yaml_file.read()
-
+        yaml_str = load_recipe_yaml_str(file_path)
         modifiers = Modifier.load_list(yaml_str)
 
         if add_modifiers:

--- a/src/sparseml/tensorflow_v1/optim/manager.py
+++ b/src/sparseml/tensorflow_v1/optim/manager.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 from sparseml.optim import BaseManager, BaseScheduled
 from sparseml.tensorflow_v1.optim.modifier import NM_RECAL, Modifier, ScheduledModifier
 from sparseml.tensorflow_v1.utils import tf_compat
+from sparseml.utils import load_recipe_yaml_str
 
 
 __all__ = ["ScheduledModifierManager"]
@@ -70,9 +71,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
             returned manager alongside the ones loaded from the yaml file
         :return: ScheduledModifierManager() created from the yaml file
         """
-        with open(file_path, "r") as yaml_file:
-            yaml_str = yaml_file.read()
-
+        yaml_str = load_recipe_yaml_str(file_path)
         modifiers = Modifier.load_list(yaml_str)
         if add_modifiers:
             modifiers.extend(add_modifiers)


### PR DESCRIPTION
To support loading modifiers from sparsezoo markdown based model cards.

Example:

```
---
version: 1.1.0

modifiers:
  - !EpochRangeModifier
    start_epoch: 0.0
    end_epoch: 10.0

  - !SetLearningRateModifier
    start_epoch: 0.0
    learning_rate: 0.005

  - !GMPruningModifier
    params:
      - __ALL__
    init_sparsity: 0.05
    final_sparsity: 0.8
    start_epoch: 1.0
    end_epoch: 8.0
    update_frequency: 0.5
---

model info

source info

markdown etc
```

Known Issues:
when loading with Keras, encountered
```
yaml.constructor.ConstructorError: could not determine a constructor for the tag '!keras.GMPruningModifier'
  in "<unicode string>", line 13, column 5:
      - !keras.GMPruningModifier
```
proceeding for now due to Keras being WIP