### PR TITLE
auto labels for Issues templates, + doc changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,31 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
 labels: ''
-assignees: ''
 
 ---
 
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Environment**
+Include all relevant environment information:
+1. OS [e.g. Ubuntu 18.04]:
+2. Python version [e.g. 3.7]:
+3. SparseML version or commit hash [e.g. 0.1.0, `f7245c8`]:
+4. ML framework version(s) [e.g. torch 1.7.1]:
+5. Other Python package versions [e.g. SparseZoo, DeepSparse, numpy, ONNX]:
+6. Other relevant environment information [e.g. hardware, CUDA version]:
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**To Reproduce**
+Exact steps to reproduce the behavior:
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+**Errors**
+If applicable, add a full print-out of any errors or exceptions that are raised or include screenshots to help explain your problem.
 
 **Additional context**
-Add any other context about the problem here.
+Add any other context about the problem here. Also include any relevant files.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: ''
+labels: bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/doc-edit.md
+++ b/.github/ISSUE_TEMPLATE/doc-edit.md
@@ -1,0 +1,18 @@
+---
+name: Doc edit
+about: Propose changes to project documentation
+labels: documentation
+
+---
+
+**What is the URL, file, or UI containing proposed doc change**
+Where does one find the original content or where would this change go?
+
+**What is the current content or situation in question**
+Copy/paste the source content or describe gap.
+
+**What is the proposed change**
+Add new content.
+
+**Additional context**
+Add any other context about the change here. Also include any relevant files or URLs.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: documentation
+labels: enhancement
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
+labels: documentation
 
 ---
 


### PR DESCRIPTION
configured auto labels to appear on Issues posted:
bug
enhancement
documentation

added a new documentation template
- created manually outside GH template builder; seeing if it will work once committed to main 