### PR TITLE
torch.distributed locking and local-rank arg order fix

### DIFF
--- a/scripts/pytorch_vision.py
+++ b/scripts/pytorch_vision.py
@@ -898,15 +898,14 @@ def _create_val_dataset_and_loader(
         or not (args.is_main_process and args.dataset != "imagefolder")
     ):
         return None, None  # val dataset not needed
-    with torch_distributed_zero_first(args.local_rank):  # only download once locally
-        val_dataset = DatasetRegistry.create(
-            args.dataset,
-            root=args.dataset_path,
-            train=False,
-            rand_trans=False,
-            image_size=image_size,
-            **args.dataset_kwargs,
-        )
+    val_dataset = DatasetRegistry.create(
+        args.dataset,
+        root=args.dataset_path,
+        train=False,
+        rand_trans=False,
+        image_size=image_size,
+        **args.dataset_kwargs,
+    )
     if args.is_main_process:
         is_training = args.command == TRAIN_COMMAND
         val_loader = DataLoader(


### PR DESCRIPTION
* torch.distributed injects `--local-rank` as the first arg. this causes conflicts with the command structure in `scripts/pytorch_vision.py`. This PR addresses the issue by adding a hidden variable for local rank as the first in the general parser for the script.
* in a multi-gpu environment with DDP, the script only has the main worker download and run the validation dataset, there was a lingering worker barrier at the validation dataset load point. Because the main worker was the only one to run this section, it would wait for the other processes reach it, hanging indefinitely and producing no output. This PR addresses this issue by removing the distributed worker barrier.