### PR TITLE
prevent tf2onnx conv-bn fusing, enable wider tf prune param match

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ _deps = [
 ]
 _pytorch_deps = ["torch>=1.1.0", "tensorboard>=1.0", "tensorboardX>=1.0"]
 _pytorch_vision_deps = _pytorch_deps + ["torchvision>=0.3.0"]
-_tensorflow_v1_deps = ["tensorflow<2.0.0", "tensorboard<2.0.0", "tf2onnx>=1.0.0"]
+_tensorflow_v1_deps = ["tensorflow<2.0.0", "tensorboard<2.0.0", "tf2onnx>=1.0.0,<1.6"]
 _keras_deps = ["tensorflow>=2.2.0", "keras2onnx>=1.0.0"]
 
 _dev_deps = [


### PR DESCRIPTION
* downgrade maximum `tf2onnx` version to version before bn fusing was added. this is to prevent variable names from changing during export as well as parameter values for WMA
* add regex pattern to clean tensor names from older tf2onnx exports
* allow full variable names to be matched as a parameter in Pruning modifiers

The end effect of these changes is that a config created from a tf2onnx export in sparsify will work with sparseml.