### PR TITLE
Fix TF dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ _tensorflow_v1_gpu_deps = [
     "tensorboard<2.0.0",
     "tf2onnx>=1.0.0,<1.6",
 ]
-_keras_deps = ["tensorflow~=2.2", "keras2onnx>=1.0.0"]
+_keras_deps = ["tensorflow~=2.2.0", "keras2onnx>=1.0.0"]
 
 _dev_deps = [
     "black>=20.8b1",


### PR DESCRIPTION
Without this fix, "tensorflow~=2.2" still installs 2.4 version.
I tested with "pip install .[tf_keras]" and verified that TF 2.2.2 was installed. 