### PR TITLE
add decorator for flaky tf sparsity tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ _dev_deps = [
     "sphinx-markdown-tables>=0.0.15",
     "wheel>=0.36.2",
     "pytest>=6.0.0",
+    "flaky>=3.0.0",
     "sphinx-rtd-theme",
 ]
 

--- a/tests/sparseml/tensorflow_v1/optim/test_analyzer_module.py
+++ b/tests/sparseml/tensorflow_v1/optim/test_analyzer_module.py
@@ -85,6 +85,7 @@ def resnet_v2_50(init_weights):
         return tf_compat.get_default_graph()
 
 
+@pytest.mark.flaky
 @pytest.mark.skipif(
     os.getenv("NM_ML_SKIP_TENSORFLOW_TESTS", False),
     reason="Skipping tensorflow_v1 tests",

--- a/tests/sparseml/tensorflow_v1/optim/test_mask_creator_pruning.py
+++ b/tests/sparseml/tensorflow_v1/optim/test_mask_creator_pruning.py
@@ -26,6 +26,7 @@ from sparseml.tensorflow_v1.optim import (
 from sparseml.tensorflow_v1.utils import eval_tensor_sparsity, tf_compat
 
 
+@pytest.mark.flaky
 @pytest.mark.parametrize(
     ("tensor_shape,mask_creator"),
     [

--- a/tests/sparseml/tensorflow_v1/optim/test_mask_pruning.py
+++ b/tests/sparseml/tensorflow_v1/optim/test_mask_pruning.py
@@ -202,6 +202,7 @@ def test_create_op_pruning_conv(sparsity_val: float, mask_creator: PruningMaskCr
                 assert sess.run(mask_vals_are_grouped)
 
 
+@pytest.mark.flaky
 @pytest.mark.skipif(
     os.getenv("NM_ML_SKIP_TENSORFLOW_TESTS", False),
     reason="Skipping tensorflow_v1 tests",
@@ -391,6 +392,7 @@ def test_apply_op_vars_masks(
                 assert abs(var_sparsity - sparsity_val) < 1e-2
 
 
+@pytest.mark.flaky
 @pytest.mark.skipif(
     os.getenv("NM_ML_SKIP_TENSORFLOW_TESTS", False),
     reason="Skipping tensorflow_v1 tests",
@@ -502,6 +504,7 @@ def _expected_sparsity(
     )
 
 
+@pytest.mark.flaky
 @pytest.mark.skipif(
     os.getenv("NM_ML_SKIP_TENSORFLOW_TESTS", False),
     reason="Skipping tensorflow_v1 tests",


### PR DESCRIPTION
Some of our tensorflow_v1 sparsity mask tests use randomly initialized tensors for testing. This can cause errors on the unlikely (but not impossible) chance that the randomly initialized tensor has a 0 in it as well as other situations.  We've seen this happen less than 5 times over the last 6 months, but it's happened twice in the last week now, so am nipping this in the bud.  @kevinaer suggested looking into flaky tests when this first occured.

Adding the flaky decorator, has pytest rerun the flaky test once (can be set to other values) if it fails.  This should be greatly decrease the chance that one of these tests will fail due to a 0 popping up in the test tensor.

https://pypi.org/project/flaky/

even though the decorator is called through pytest, I've checked that flaky must be installed for the logic to properly function.