### PR TITLE
enable modifier groups in SparseML recipes

### DIFF
--- a/docs/source/recipes.md
+++ b/docs/source/recipes.md
@@ -25,8 +25,7 @@ The files are written in [YAML](https://yaml.org/) and stored in YAML or
 The rest of the SparseML system is coded to parse the recipe files into a native format for the desired framework
 and apply the modifications to the model and training pipeline.
 
-In a recipe, any top level list with "modifiers" in its name will be included
-in the parsed list of modifiers during SparseML optimization.
+In a recipe, modifiers must be written in a list that includes "modifiers" in its name.
 
 The easiest ways to get or create optimization recipes are by either using 
 the pre-configured recipes in [SparseZoo](https://github.com/neuralmagic/sparsezoo) or 

--- a/docs/source/recipes.md
+++ b/docs/source/recipes.md
@@ -25,6 +25,9 @@ The files are written in [YAML](https://yaml.org/) and stored in YAML or
 The rest of the SparseML system is coded to parse the recipe files into a native format for the desired framework
 and apply the modifications to the model and training pipeline.
 
+In a recipe, any top level list with "modifiers" in its name will be included
+in the parsed list of modifiers during SparseML optimization.
+
 The easiest ways to get or create optimization recipes are by either using 
 the pre-configured recipes in [SparseZoo](https://github.com/neuralmagic/sparsezoo) or 
 using [Sparsify's](https://github.com/neuralmagic/sparsify) autoML style creation.

--- a/src/sparseml/optim/modifier.py
+++ b/src/sparseml/optim/modifier.py
@@ -296,9 +296,22 @@ class BaseModifier(BaseObject):
             modifiers = container
         else:  # Dict
             modifiers = []
-            for key, modifier_list in container.items():
-                if "modifiers" in key and isinstance(modifier_list, List):
-                    modifiers.extend(modifier_list)
+            for name, item in container.items():
+                if "modifiers" in name and isinstance(item, List):
+                    modifiers.extend(item)
+                elif isinstance(item, BaseModifier):
+                    modifiers.append(item)
+                elif isinstance(item, List) and any(
+                    isinstance(element, BaseModifier) for element in item
+                ):
+                    modifier_type = type(
+                        [mod for mod in item if isinstance(mod, BaseModifier)][0]
+                    )
+                    raise ValueError(
+                        "Invalid modifier location. Grouped modifiers in recipes must "
+                        "be listed in lists with 'modifiers' in its name. A modifier of "
+                        f"type {modifier_type} was found in recipe list {name}"
+                    )
 
         return modifiers
 

--- a/src/sparseml/optim/modifier.py
+++ b/src/sparseml/optim/modifier.py
@@ -294,8 +294,11 @@ class BaseModifier(BaseObject):
             modifiers = [container]
         elif isinstance(container, List):
             modifiers = container
-        else:
-            modifiers = container["modifiers"]
+        else:  # Dict
+            modifiers = []
+            for key, modifier_list in container.items():
+                if "modifiers" in key and isinstance(modifier_list, List):
+                    modifiers.extend(modifier_list)
 
         return modifiers
 


### PR DESCRIPTION
This change will enable SparseML to parse multiple lists of modifiers (groups) from a recipe.  The resulting structure will look like this:
```
training_modifiers:
  - !EpochRangeModifier
    ...

  - !SetLearningRateModifier
    ...

pruning_modifiers:
  - !GMPruningModifier
      ...
  - !GMPruningModifier
        ...
  - !GMPruningModifier
        ...

quantization_modifiers:
  - !QuantizationModifier
      ...
  - !SetWeightDecayModifier
      ...
```

All modifiers will be parsed into a single `Modifier` list at run time.  Not adding any filtering in the lists to see if they are actually of modifiers, so the user will be able to see any errors if the recipe is incorrect.