### PR TITLE
match types explicitly in torch qat quant observer wrappers

### DIFF
--- a/src/sparseml/pytorch/optim/quantization/helpers.py
+++ b/src/sparseml/pytorch/optim/quantization/helpers.py
@@ -17,7 +17,6 @@ Helper functions for performing quantization aware training with PyTorch
 """
 
 from copy import deepcopy
-from inspect import getmembers, isclass
 
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Module, ReLU
@@ -42,10 +41,23 @@ __all__ = [
 
 _QUANTIZABLE_MODULE_TYPES = (
     {
-        module
-        for name, module in getmembers(nni.modules.fused, isclass)
-        if "Conv" in name or "Linear" in name
-    }  # i.e. Conv2d, ConvBnReLU2d, LinearReLU, etc
+        # Conv based layers
+        torch.nn.Conv1d,
+        torch.nn.Conv2d,
+        torch.nn.Conv3d,
+        nni.ConvBn1d,
+        nni.ConvBn2d,
+        nni.ConvBn3d,
+        nni.ConvReLU1d,
+        nni.ConvReLU2d,
+        nni.ConvReLU3d,
+        nni.ConvBnReLU1d,
+        nni.ConvBnReLU2d,
+        nni.ConvBnReLU3d,
+        # Linear Layers
+        torch.nn.Linear,
+        nni.LinearReLU,
+    }
     if nni
     else None
 )

--- a/src/sparseml/pytorch/optim/quantization/helpers.py
+++ b/src/sparseml/pytorch/optim/quantization/helpers.py
@@ -58,7 +58,7 @@ _QUANTIZABLE_MODULE_TYPES = (
         torch.nn.Linear,
         nni.LinearReLU,
     }
-    if nni
+    if nni  # nni will always import if torch.quantization is available
     else None
 )
 


### PR DESCRIPTION
this fixes bugs in Yolo V3 QAT where quant/dequant observers were placed in incorrect parts within the model graph