### PR TITLE
Native Keras support

### DIFF
--- a/src/sparseml/keras/__init__.py
+++ b/src/sparseml/keras/__init__.py
@@ -22,11 +22,24 @@ editing models for performance in the Neural Magic System
 try:
     import tensorflow
 
-    version = [int(v) for v in tensorflow.__version__.split(".")]
-    if version[0] != 2 or version[1] < 2:
-        raise Exception
+    if tensorflow.__version__ < "2.1.0":
+        raise RuntimeError("TensorFlow >= 2.1.0 is required, found {}".format(version))
 except:
     raise RuntimeError(
-        "Unable to import tensorflow. tensorflow>=2.2 is required"
+        "Unable to import tensorflow. TensorFlow>=2.1.0 is required"
         " to use sparseml.keras."
     )
+
+
+try:
+    import keras
+
+    v = keras.__version__
+    if v < "2.4.3":
+        raise RuntimeError(
+            "Native keras is found and will be used, but required >= 2.4.3, found {}".format(
+                v
+            )
+        )
+except:
+    pass

--- a/src/sparseml/keras/optim/manager.py
+++ b/src/sparseml/keras/optim/manager.py
@@ -23,6 +23,7 @@ from typing import List, Union
 import tensorflow as tf
 
 from sparseml.keras.optim.modifier import Modifier, ScheduledModifier
+from sparseml.keras.utils.compat import keras
 from sparseml.keras.utils.logger import KerasLogger
 from sparseml.optim import BaseManager
 from sparseml.utils import load_recipe_yaml_str
@@ -71,8 +72,8 @@ class ScheduledModifierManager(BaseManager, Modifier):
 
     def modify(
         self,
-        model: Union[tf.keras.Model, tf.keras.Sequential],
-        optimizer: tf.keras.optimizers.Optimizer,
+        model: Union[keras.Model, keras.Sequential],
+        optimizer: keras.optimizers.Optimizer,
         steps_per_epoch: int,
         loggers: Union[KerasLogger, List[KerasLogger]] = None,
         input_tensors: tf.Tensor = None,
@@ -106,14 +107,14 @@ class ScheduledModifierManager(BaseManager, Modifier):
                 continue
             if isinstance(callback, list):
                 callbacks = callbacks + callback
-            elif isinstance(callback, tf.keras.callbacks.Callback):
+            elif isinstance(callback, keras.callbacks.Callback):
                 callbacks.append(callback)
             else:
                 raise RuntimeError("Invalid callback type")
         self._optimizer = optimizer
         return model, optimizer, callbacks
 
-    def finalize(self, model: tf.keras.Model):
+    def finalize(self, model: keras.Model):
         """
         Remove extra information related to the modifier from the model that is
         not necessary for exporting

--- a/src/sparseml/keras/optim/manager.py
+++ b/src/sparseml/keras/optim/manager.py
@@ -20,7 +20,7 @@ Also handles loading modifiers from yaml files
 
 from typing import List, Union
 
-import tensorflow as tf
+from tensorflow import Tensor
 
 from sparseml.keras.optim.modifier import Modifier, ScheduledModifier
 from sparseml.keras.utils.compat import keras
@@ -76,7 +76,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
         optimizer: keras.optimizers.Optimizer,
         steps_per_epoch: int,
         loggers: Union[KerasLogger, List[KerasLogger]] = None,
-        input_tensors: tf.Tensor = None,
+        input_tensors: Tensor = None,
     ):
         """
         Modify the model and optimizer based on the requirements of modifiers

--- a/src/sparseml/keras/optim/modifier.py
+++ b/src/sparseml/keras/optim/modifier.py
@@ -23,6 +23,12 @@ from typing import List, Tuple, Union
 
 import tensorflow as tf
 
+
+try:
+    import keras
+except ModuleNotFoundError:
+    import tensorflow.keras as keras
+
 from sparseml.keras.utils import KerasLogger
 from sparseml.optim import (
     BaseModifier,
@@ -107,7 +113,7 @@ class Modifier(BaseModifier):
         callback = None
         return model, optimizer, callback
 
-    def finalize(self, model: tf.keras.Model):
+    def finalize(self, model: keras.Model):
         """
         Remove extra information related to the modifier from the model that is
         not necessary for exporting

--- a/src/sparseml/keras/optim/modifier.py
+++ b/src/sparseml/keras/optim/modifier.py
@@ -21,15 +21,9 @@ are implemented as modifiers.
 
 from typing import List, Tuple, Union
 
-import tensorflow as tf
+from tensorflow import Tensor
 
-
-try:
-    import keras
-except ModuleNotFoundError:
-    import tensorflow.keras as keras
-
-from sparseml.keras.utils import KerasLogger
+from sparseml.keras.utils import KerasLogger, keras
 from sparseml.optim import (
     BaseModifier,
     BaseScheduled,
@@ -98,7 +92,7 @@ class Modifier(BaseModifier):
         optimizer,
         steps_per_epoch: int,
         loggers: Union[KerasLogger, List[KerasLogger]] = None,
-        input_tensors: tf.Tensor = None,
+        input_tensors: Tensor = None,
     ):
         """
         Modify model, optimizer based on the logic of the modifier. Return the modified

--- a/src/sparseml/keras/optim/modifier_lr.py
+++ b/src/sparseml/keras/optim/modifier_lr.py
@@ -18,24 +18,14 @@ Learning rate modifiers for Keras models
 
 from typing import Dict, List, Union
 
-import tensorflow as tf
-
-
-try:
-    import keras
-    from keras import backend as K
-    from keras.optimizers.schedules import LearningRateSchedule
-except ModuleNotFoundError:
-    import tensorflow.keras as keras
-    from tensorflow.keras import backend as K
-    from tensorflow.keras.optimizers.schedules import LearningRateSchedule
+from tensorflow import Tensor
 
 from sparseml.keras.optim.modifier import (
     KerasModifierYAML,
     ScheduledModifier,
     ScheduledUpdateModifier,
 )
-from sparseml.keras.utils import KerasLogger, LoggerSettingCallback, LoggingMode
+from sparseml.keras.utils import KerasLogger, LoggerSettingCallback, LoggingMode, keras
 from sparseml.optim import LearningRate, SetLearningRate
 from sparseml.utils import ALL_TOKEN
 
@@ -136,7 +126,7 @@ class LearningRateLoggingCallback(LoggerSettingCallback):
         :param logs: dictionary of logs (see Keras Callback doc)
         """
         super().on_train_begin(logs)
-        self._step = K.get_value(self.model.optimizer.iterations)
+        self._step = keras.backend.get_value(self.model.optimizer.iterations)
 
     def on_epoch_begin(self, epoch, logs=None):
         """
@@ -183,10 +173,10 @@ class LearningRateLoggingCallback(LoggerSettingCallback):
 
     def _get_lr(self):
         lr = self.model.optimizer.lr
-        if isinstance(lr, LearningRateSchedule):
+        if isinstance(lr, keras.optimizers.schedules.LearningRateSchedule):
             lr_val = lr(self.model.optimizer.iterations)
         else:
-            lr_val = K.get_value(lr)
+            lr_val = keras.backend.get_value(lr)
         return lr_val
 
     def _is_logging_step(self):
@@ -241,7 +231,7 @@ class SetLearningRateModifier(ScheduledModifier, SetLearningRate):
         optimizer,
         steps_per_epoch: int,
         loggers: Union[KerasLogger, List[KerasLogger]] = None,
-        input_tensors: tf.Tensor = None,
+        input_tensors: Tensor = None,
     ):
         """
         Modify model and optimizer, and provide callbacks to process the model
@@ -422,7 +412,7 @@ class LearningRateModifier(ScheduledUpdateModifier, LearningRate):
         optimizer,
         steps_per_epoch: int,
         loggers: Union[KerasLogger, List[KerasLogger]] = None,
-        input_tensors: tf.Tensor = None,
+        input_tensors: Tensor = None,
     ):
         """
         Modify model and optimizer, and provide callbacks to process the model

--- a/src/sparseml/keras/optim/modifier_params.py
+++ b/src/sparseml/keras/optim/modifier_params.py
@@ -19,7 +19,13 @@ certain update formulas or patterns.
 
 from typing import List, Union
 
-import tensorflow
+import tensorflow as tf
+
+
+try:
+    import keras
+except ModuleNotFoundError:
+    import tensorflow.keras as keras
 
 from sparseml.keras.optim.modifier import (
     KerasModifierYAML,
@@ -33,7 +39,7 @@ from sparseml.utils import ALL_TOKEN, convert_to_bool, flatten_iterable
 __all__ = ["TrainableParamsModifier"]
 
 
-class TrainableParamsCallback(tensorflow.keras.callbacks.Callback):
+class TrainableParamsCallback(keras.callbacks.Callback):
     def __init__(self, model, optimizer, layers, trainable, start_step, end_step):
         self.model = model
         self.optimizer = optimizer
@@ -45,7 +51,7 @@ class TrainableParamsCallback(tensorflow.keras.callbacks.Callback):
         self.step = None
 
     def on_train_begin(self, logs=None):
-        self.step = tensorflow.keras.backend.get_value(self.optimizer.iterations)
+        self.step = keras.backend.get_value(self.optimizer.iterations)
 
     def on_train_batch_begin(self, batch, logs=None):
         if self.step == self.start_step:
@@ -195,7 +201,7 @@ class TrainableParamsModifier(ScheduledModifier):
         model,
         optimizer,
         steps_per_epoch: int,
-        input_tensors: tensorflow.Tensor = None,
+        input_tensors: tf.Tensor = None,
     ):
         model, optimizer, callback = super(TrainableParamsModifier, self).modify(
             model, optimizer, steps_per_epoch, input_tensors=input_tensors

--- a/src/sparseml/keras/optim/modifier_params.py
+++ b/src/sparseml/keras/optim/modifier_params.py
@@ -19,13 +19,7 @@ certain update formulas or patterns.
 
 from typing import List, Union
 
-import tensorflow as tf
-
-
-try:
-    import keras
-except ModuleNotFoundError:
-    import tensorflow.keras as keras
+from tensorflow import Tensor
 
 from sparseml.keras.optim.modifier import (
     KerasModifierYAML,
@@ -33,6 +27,7 @@ from sparseml.keras.optim.modifier import (
     ScheduledModifier,
 )
 from sparseml.keras.optim.utils import get_layer_name_from_param
+from sparseml.keras.utils import keras
 from sparseml.utils import ALL_TOKEN, convert_to_bool, flatten_iterable
 
 
@@ -201,7 +196,7 @@ class TrainableParamsModifier(ScheduledModifier):
         model,
         optimizer,
         steps_per_epoch: int,
-        input_tensors: tf.Tensor = None,
+        input_tensors: Tensor = None,
     ):
         model, optimizer, callback = super(TrainableParamsModifier, self).modify(
             model, optimizer, steps_per_epoch, input_tensors=input_tensors

--- a/src/sparseml/keras/utils/__init__.py
+++ b/src/sparseml/keras/utils/__init__.py
@@ -18,7 +18,6 @@ Generic code used as utilities and helpers for Keras
 
 # flake8: noqa
 
-from .compat import *
 from .callbacks import *
 from .compat import *
 from .exporter import *

--- a/src/sparseml/keras/utils/callbacks.py
+++ b/src/sparseml/keras/utils/callbacks.py
@@ -20,7 +20,7 @@ from typing import List, Union
 
 from tensorflow import Tensor
 
-from sparseml.keras.utils import keras
+from sparseml.keras.utils.compat import keras
 from sparseml.keras.utils.logger import KerasLogger, LoggingMode
 
 

--- a/src/sparseml/keras/utils/callbacks.py
+++ b/src/sparseml/keras/utils/callbacks.py
@@ -18,7 +18,6 @@ Built-in callbacks for Keras
 
 from typing import List, Union
 
-import tensorflow
 from tensorflow import Tensor
 
 from sparseml.keras.utils import keras
@@ -205,7 +204,7 @@ class LossesAndMetricsLoggingCallback(LoggerSettingCallback):
         :param logs: dictionary of logs (see Keras Callback doc)
         """
         super().on_train_begin(logs)
-        self._step = tensorflow.keras.backend.get_value(self._start_step)
+        self._step = keras.backend.get_value(self._start_step)
 
     def on_epoch_end(self, epoch, logs=None):
         """

--- a/src/sparseml/keras/utils/exporter.py
+++ b/src/sparseml/keras/utils/exporter.py
@@ -19,7 +19,11 @@ Export Keras models to the local device.
 import os
 from typing import Any, List
 
-from tensorflow.keras import Model
+
+try:
+    import keras
+except ModuleNotFoundError:
+    import tensorflow.keras as keras
 
 from sparseml.utils import clean_path, create_parent_dirs, tensors_export
 
@@ -49,7 +53,7 @@ class ModelExporter(object):
 
     def __init__(
         self,
-        model: Model,
+        model: keras.Model,
         output_dir: str,
     ):
         self._model = model

--- a/src/sparseml/keras/utils/exporter.py
+++ b/src/sparseml/keras/utils/exporter.py
@@ -19,12 +19,7 @@ Export Keras models to the local device.
 import os
 from typing import Any, List
 
-
-try:
-    import keras
-except ModuleNotFoundError:
-    import tensorflow.keras as keras
-
+from sparseml.keras.utils import keras
 from sparseml.utils import clean_path, create_parent_dirs, tensors_export
 
 

--- a/src/sparseml/keras/utils/model.py
+++ b/src/sparseml/keras/utils/model.py
@@ -16,8 +16,9 @@
 Utils for Keras model
 """
 
-import tensorflow as tf
-from tensorflow import keras
+import tensorflow
+
+from sparseml.keras.utils import keras
 
 
 __all__ = ["sparsity"]
@@ -30,7 +31,7 @@ def sparsity(model: keras.Model):
     :param model: a Keras model
     :return: (1) model sparsity, (2) dictionary of layer sparsity
     """
-    zero = tf.constant(0, dtype=tf.float32)
+    zero = tensorflow.constant(0, dtype=tensorflow.float32)
     model_weight_size = 0
     model_zeros = 0
     sparsity_dict = {}
@@ -39,10 +40,12 @@ def sparsity(model: keras.Model):
         layer_sparsity_dict = {}
 
         for i, weight in enumerate(layer.trainable_weights):
-            mask = tf.cast(tf.equal(weight, zero), tf.uint8)
+            mask = tensorflow.cast(tensorflow.equal(weight, zero), tensorflow.uint8)
 
-            weight_size = tf.size(weight)
-            zeros = tf.cast(tf.math.count_nonzero(mask), tf.int32)
+            weight_size = tensorflow.size(weight)
+            zeros = tensorflow.cast(
+                tensorflow.math.count_nonzero(mask), tensorflow.int32
+            )
             layer_sparsity_dict[weight.name] = zeros / weight_size
 
             model_weight_size += weight_size

--- a/tests/sparseml/keras/optim/mock.py
+++ b/tests/sparseml/keras/optim/mock.py
@@ -16,7 +16,12 @@ from typing import List, Tuple
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.keras.models import Model
+
+
+try:
+    import keras
+except ModuleNotFoundError:
+    import tensorflow.keras as keras
 
 from sparseml.keras.optim import PruningScheduler
 
@@ -52,21 +57,21 @@ class MockPruningScheduler(PruningScheduler):
         }
 
 
-class DenseLayer(tf.keras.layers.Dense):
+class DenseLayer(keras.layers.Dense):
     def __init__(self, weight: np.ndarray):
         super(DenseLayer, self).__init__(weight.shape[1], activation=None)
 
         self.kernel = self.add_weight(
             "kernel",
             shape=weight.shape,
-            initializer=tf.keras.initializers.Constant(weight),
+            initializer=keras.initializers.Constant(weight),
             dtype=tf.float32,
             trainable=False,
         )
         self.bias = self.add_weight(
             "bias",
             shape=(weight.shape[1],),
-            initializer=tf.keras.initializers.Constant(0.0),
+            initializer=keras.initializers.Constant(0.0),
             dtype=tf.float32,
             trainable=False,
         )
@@ -84,7 +89,7 @@ class DenseLayerCreator(LayerCreator):
         self.name = name
 
     def __call__(self, delay_build=False):
-        layer = tf.keras.layers.Dense(
+        layer = keras.layers.Dense(
             self.kernel.shape[-1], activation=None, name=self.name
         )
         if not delay_build:
@@ -101,7 +106,7 @@ class SequentialModelCreator:
         self.layer_creators = layer_creators
 
     def __call__(self):
-        model = tf.keras.Sequential()
+        model = keras.Sequential()
         for layer_creator in self.layer_creators:
             model.add(layer_creator(delay_build=True))
         input_shape = tf.TensorShape((None, self.layer_creators[0].kernel.shape[-2]))
@@ -110,10 +115,10 @@ class SequentialModelCreator:
 
 
 def model_01():
-    inputs = tf.keras.Input(shape=(5))
-    x = tf.keras.layers.Dense(10, name="dense_01")(inputs)
-    outputs = tf.keras.layers.Dense(10, name="dense_02")(x)
-    model = Model(inputs=inputs, outputs=outputs)
+    inputs = keras.Input(shape=(5))
+    x = keras.layers.Dense(10, name="dense_01")(inputs)
+    outputs = keras.layers.Dense(10, name="dense_02")(x)
+    model = keras.Model(inputs=inputs, outputs=outputs)
     return model
 
 

--- a/tests/sparseml/keras/optim/mock.py
+++ b/tests/sparseml/keras/optim/mock.py
@@ -15,15 +15,10 @@
 from typing import List, Tuple
 
 import numpy as np
-import tensorflow as tf
-
-
-try:
-    import keras
-except ModuleNotFoundError:
-    import tensorflow.keras as keras
+import tensorflow
 
 from sparseml.keras.optim import PruningScheduler
+from sparseml.keras.utils import keras
 
 
 __all__ = [
@@ -65,14 +60,14 @@ class DenseLayer(keras.layers.Dense):
             "kernel",
             shape=weight.shape,
             initializer=keras.initializers.Constant(weight),
-            dtype=tf.float32,
+            dtype=tensorflow.float32,
             trainable=False,
         )
         self.bias = self.add_weight(
             "bias",
             shape=(weight.shape[1],),
             initializer=keras.initializers.Constant(0.0),
-            dtype=tf.float32,
+            dtype=tensorflow.float32,
             trainable=False,
         )
 
@@ -109,7 +104,9 @@ class SequentialModelCreator:
         model = keras.Sequential()
         for layer_creator in self.layer_creators:
             model.add(layer_creator(delay_build=True))
-        input_shape = tf.TensorShape((None, self.layer_creators[0].kernel.shape[-2]))
+        input_shape = tensorflow.TensorShape(
+            (None, self.layer_creators[0].kernel.shape[-2])
+        )
         model.build(input_shape=input_shape)
         return model
 
@@ -123,30 +120,30 @@ def model_01():
 
 
 def mnist_model():
-    inputs = tf.keras.Input(shape=(28, 28, 1), name="inputs")
+    inputs = tensorflow.keras.Input(shape=(28, 28, 1), name="inputs")
 
     # Block 1
-    x = tf.keras.layers.Conv2D(16, 5, strides=1)(inputs)
-    x = tf.keras.layers.BatchNormalization()(x)
-    x = tf.keras.layers.ReLU()(x)
+    x = tensorflow.keras.layers.Conv2D(16, 5, strides=1)(inputs)
+    x = tensorflow.keras.layers.BatchNormalization()(x)
+    x = tensorflow.keras.layers.ReLU()(x)
 
     # Block 2
-    x = tf.keras.layers.Conv2D(32, 5, strides=2)(x)
-    x = tf.keras.layers.BatchNormalization()(x)
-    x = tf.keras.layers.ReLU()(x)
+    x = tensorflow.keras.layers.Conv2D(32, 5, strides=2)(x)
+    x = tensorflow.keras.layers.BatchNormalization()(x)
+    x = tensorflow.keras.layers.ReLU()(x)
 
     # Block 3
-    x = tf.keras.layers.Conv2D(64, 5, strides=1)(x)
-    x = tf.keras.layers.BatchNormalization()(x)
-    x = tf.keras.layers.ReLU()(x)
+    x = tensorflow.keras.layers.Conv2D(64, 5, strides=1)(x)
+    x = tensorflow.keras.layers.BatchNormalization()(x)
+    x = tensorflow.keras.layers.ReLU()(x)
 
     # Block 4
-    x = tf.keras.layers.Conv2D(128, 5, strides=2)(x)
-    x = tf.keras.layers.BatchNormalization()(x)
-    x = tf.keras.layers.ReLU()(x)
+    x = tensorflow.keras.layers.Conv2D(128, 5, strides=2)(x)
+    x = tensorflow.keras.layers.BatchNormalization()(x)
+    x = tensorflow.keras.layers.ReLU()(x)
 
-    x = tf.keras.layers.AveragePooling2D(pool_size=1)(x)
-    x = tf.keras.layers.Flatten()(x)
-    outputs = tf.keras.layers.Dense(10, activation="softmax", name="outputs")(x)
+    x = tensorflow.keras.layers.AveragePooling2D(pool_size=1)(x)
+    x = tensorflow.keras.layers.Flatten()(x)
+    outputs = tensorflow.keras.layers.Dense(10, activation="softmax", name="outputs")(x)
 
-    return tf.keras.Model(inputs=inputs, outputs=outputs)
+    return tensorflow.keras.Model(inputs=inputs, outputs=outputs)

--- a/tests/sparseml/keras/optim/test_mask_pruning.py
+++ b/tests/sparseml/keras/optim/test_mask_pruning.py
@@ -19,7 +19,7 @@ from typing import Dict, Union
 
 import numpy as np
 import pytest
-import tensorflow as tf
+import tensorflow
 
 from sparseml.keras.optim import (
     GMPruningModifier,
@@ -220,9 +220,9 @@ def test_save_load_masked_model(modifier_lambdas, epochs, batch_size):
     x_train = x_train[:N, :]
     y_train = y_train[:N, :]
 
-    if tf.__version__ < "2.2.0":
-        x_train = tf.expand_dims(x_train, axis=-1)
-        y_train = tf.expand_dims(y_train, axis=-1)
+    if tensorflow.__version__ < "2.2.0":
+        x_train = tensorflow.expand_dims(x_train, axis=-1)
+        y_train = tensorflow.expand_dims(y_train, axis=-1)
 
     # Model
     model = mnist_model()

--- a/tests/sparseml/keras/optim/test_modifier_pruning.py
+++ b/tests/sparseml/keras/optim/test_modifier_pruning.py
@@ -16,6 +16,12 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
+
+try:
+    import keras
+except ModuleNotFoundError:
+    import tensorflow.keras as keras
+
 from sparseml.keras.optim import GMPruningModifier
 from tests.sparseml.keras.optim.mock import model_01
 
@@ -64,8 +70,8 @@ class TestGMPruningModifier:
     def test_lifecycle(self, model_lambda, modifier_lambda, steps_per_epoch):
         model = model_lambda()
         modifier = modifier_lambda()
-        loss = tf.keras.losses.categorical_crossentropy
-        optimizer = tf.keras.optimizers.Adam()
+        loss = keras.losses.categorical_crossentropy
+        optimizer = keras.optimizers.Adam()
         model, optimizer, callbacks = modifier.modify(model, optimizer, steps_per_epoch)
         assert len(callbacks) == 1
         step_callback = callbacks[0]
@@ -78,7 +84,7 @@ class TestGMPruningModifier:
         M = 10
         X_train = np.random.normal(size=(N, model.inputs[0].shape[1]))
         classes = np.random.randint(0, M, size=N)
-        y_train = tf.keras.utils.to_categorical(classes, num_classes=M)
+        y_train = keras.utils.to_categorical(classes, num_classes=M)
 
         step_callback.on_train_begin()
         for epoch in range(epochs):

--- a/tests/sparseml/keras/optim/test_modifier_pruning.py
+++ b/tests/sparseml/keras/optim/test_modifier_pruning.py
@@ -14,15 +14,10 @@
 
 import numpy as np
 import pytest
-import tensorflow as tf
-
-
-try:
-    import keras
-except ModuleNotFoundError:
-    import tensorflow.keras as keras
+import tensorflow
 
 from sparseml.keras.optim import GMPruningModifier
+from sparseml.keras.utils import keras
 from tests.sparseml.keras.optim.mock import model_01
 
 
@@ -90,7 +85,7 @@ class TestGMPruningModifier:
         for epoch in range(epochs):
             for batch in range(batches):
                 step_callback.on_train_batch_begin(batch=unused_arg)
-                with tf.GradientTape() as tape:
+                with tensorflow.GradientTape() as tape:
                     logits = model(X_train, training=True)
                     loss_value = loss(y_train, logits)
                     grads = tape.gradient(loss_value, model.trainable_variables)


### PR DESCRIPTION
Allow to use native Keras. Only Keras >= 2.4.3 is supported due to the following reasons:
- for Keras < 2.4.0, the `clone_model` function does not have the param `clone_layer` required by the modifiers;
- the model's `fit` functions in 2.4.0/2.4.1/2.4.2 do not work with the current custom callbacks such as `LRModifierCallback` w/ error `AttributeError: 'LRModifierCallback' object has no attribute '_implements_train_batch_hooks'`

For TF2.0, model save hit an assertion inside TF, and therefore we only enable >=TF2.1.