### PR TITLE
load qat onnx models for conversion from file path

### DIFF
--- a/src/sparseml/pytorch/optim/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/optim/quantization/quantize_qat_export.py
@@ -583,6 +583,9 @@ def quantize_torch_qat_export(
         operations. All quantized Convs and FC inputs and outputs be surrounded by
         fake quantize ops
     """
+    if isinstance(model, str):
+        model = onnx.load(model)
+
     if not inplace:
         model = deepcopy(model)
 


### PR DESCRIPTION
this functionality was built in, but overwritten. useful for QAT ONNX export flows