### PR TITLE
test fix for torch quantization modifier YAML check

### DIFF
--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -193,9 +193,9 @@ def test_quantization_modifier_yaml():
         == obj_modifier.start_epoch
     )
     assert (
-        yaml_modifier.submodules
-        == serialized_modifier.submodules
-        == obj_modifier.submodules
+        sorted(yaml_modifier.submodules)
+        == sorted(serialized_modifier.submodules)
+        == sorted(obj_modifier.submodules)
     )
     assert (
         yaml_modifier.model_fuse_fn_name


### PR DESCRIPTION
the submodules list is converted to a set inside the modifier, which for some reason less than 1/10 times will crash the test comparison when converted back to a list