### PR TITLE
update yolo initialize fn for torch 1.8

### DIFF
--- a/src/sparseml/pytorch/models/detection/yolo_v3.py
+++ b/src/sparseml/pytorch/models/detection/yolo_v3.py
@@ -177,7 +177,7 @@ class _YoloDetectionBlock(Module):
         _init_conv(self.conv)
 
         # smart bias initialization
-        b = self.conv.bias.view(3, -1)
+        b = self.conv.bias.view(3, -1).detach()
         b[:, 4] += math.log(8 / 640 ** 2)  # 8 objects per 640 image
         b[:, 5:] += math.log(0.6 / (self.num_classes - 0.99))
         self.conv.bias = Parameter(b.view(-1), requires_grad=True)


### PR DESCRIPTION
currently fails with the following error on torch 1.8.0. detach is ok since we overwrite this parameter with a new one that requires grad.

```
        # smart bias initialization
        b = self.conv.bias.view(3, -1)
>       b[:, 4] += math.log(8 / 640 ** 2)  # 8 objects per 640 image
E       RuntimeError: a view of a leaf Variable that requires grad is being used in an in-place operation.
```