### PR TITLE
generic onnx quantized residual add fusor graph optimization

### DIFF
--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -74,12 +74,6 @@ class ONNXGraph(object):
             init.name: init for init in self._model.graph.initializer
         }
 
-    def _store_node_edges(self, node: NodeProto):
-        for output_id in node.output:
-            self._output_id_to_node[output_id] = node
-        for input_id in node.input:
-            self._input_id_to_nodes[input_id].append(node)
-
     def get_init_by_name(self, name: str) -> Optional[TensorProto]:
         """
         :param name: name of initializer
@@ -119,6 +113,7 @@ class ONNXGraph(object):
     def add_node(self, node: NodeProto):
         """
         Adds the given node to the model and graph state
+
         :param node: node to add to the model
         """
         self._model.graph.node.append(node)
@@ -140,6 +135,12 @@ class ONNXGraph(object):
         else:
             node.input.append(input_id)
         self._input_id_to_nodes[input_id].append(node)
+
+    def _store_node_edges(self, node: NodeProto):
+        for output_id in node.output:
+            self._output_id_to_node[output_id] = node
+        for input_id in node.input:
+            self._input_id_to_nodes[input_id].append(node)
 
 
 def update_model_param(

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -61,17 +61,17 @@ class ONNXGraph(object):
 
         :param model: model to represent. defaults to current loaded model state
         """
-        model = model or self._model
+        self._model = model or self._model
 
         # nodes
         self._output_id_to_node = {}
         self._input_id_to_nodes = defaultdict(list)
-        for node in model.graph.node:
+        for node in self._model.graph.node:
             self._store_node_edges(node)
 
         # initializers
         self._name_to_initializer = {
-            init.name: init for init in model.graph.initializer
+            init.name: init for init in self._model.graph.initializer
         }
 
     def _store_node_edges(self, node: NodeProto):

--- a/src/sparseml/onnx/utils/graph_optimizer.py
+++ b/src/sparseml/onnx/utils/graph_optimizer.py
@@ -23,6 +23,7 @@ import numpy as np
 import onnx
 
 from sparseml.onnx.utils.graph_editor import (
+    ONNXGraph,
     remove_node_and_params_from_graph,
     swap_node_output,
     update_model_param,
@@ -40,6 +41,7 @@ from sparseml.onnx.utils.helpers import (
 __all__ = [
     "fold_conv_bns",
     "quantize_resnet_identity_add_inputs",
+    "quantized_residual_add_optim",
 ]
 
 
@@ -140,7 +142,7 @@ def quantize_resnet_identity_add_inputs(quantized_model: onnx.ModelProto) -> boo
     or add op and a quantize -> de-quantize block that takes the same relu as input.
     Performs this optimization in place.
 
-    :param quantized_model: A loaded quantized model to performed this optimization on
+    :param quantized_model: A loaded quantized model to perform this optimization on
     :return: True if an in-place optimization was made
     """
 
@@ -189,6 +191,61 @@ def quantize_resnet_identity_add_inputs(quantized_model: onnx.ModelProto) -> boo
         ][0]
         add_node.input[relu_input_idx] = dequantize_identity_output_name
 
+        optimization_made = True
+
+    return optimization_made
+
+
+def quantized_residual_add_optim(quantized_model: onnx.ModelProto) -> bool:
+    """
+    This optimization adds a quant/dequant block to the identity branch of a
+    residual whose non-identity branch is quantized. This enables the add at the
+    end of the residual to be fused at runtime.
+
+    Function will match to any node who has two children nodes - one add node
+    and one quantize node whose branch eventually leads to the other add node.
+
+    :param quantized_model: A loaded quantized model to perform this optimization on
+    :return: True if an in-place optimization was made
+    """
+    graph = ONNXGraph(quantized_model)
+    optimization_made = False
+    for node in quantized_model.graph.node:
+        children_nodes = graph.get_node_children(node)
+        if len(children_nodes) != 2:
+            continue
+
+        add_node = [node for node in children_nodes if node.op_type == "Add"]
+        quant_node = [
+            node for node in children_nodes if node.op_type == "QuantizeLinear"
+        ]
+        if not add_node or not quant_node:
+            continue
+        add_node = add_node[0]
+        quant_node = quant_node[0]
+
+        # verify that quant_node eventually leads to add_node
+        curr_node = [quant_node]
+        iter = 0
+        max_iter = 20  # avoid cycles
+        while curr_node and curr_node[0] != add_node and iter < max_iter:
+            curr_node = graph.get_node_children(curr_node[0])
+            iter += 1
+        if curr_node[0] != add_node:
+            continue
+
+        # create de-quantize node for identity
+        dequant_node = onnx.helper.make_node(
+            "DequantizeLinear",
+            [quant_node.output[0]] + quant_node.input[1:],  # new inputs
+            [f"{quant_node.output[0]}_dequantized"],  # output name
+            f"{quant_node.name or quant_node.output[0]}_dequantized",  # node name
+        )
+
+        # update graph
+        identity_edge_idx = 0 if add_node.input[0] == node.output[0] else 1
+        graph.add_node(dequant_node)
+        graph.update_node_input(add_node, dequant_node.output[0], identity_edge_idx)
         optimization_made = True
 
     return optimization_made

--- a/src/sparseml/pytorch/optim/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/optim/quantization/quantize_qat_export.py
@@ -33,6 +33,7 @@ from sparseml.onnx.utils import (
     get_node_output_nodes,
     get_nodes_by_output_id,
     quantize_resnet_identity_add_inputs,
+    quantized_residual_add_optim,
     remove_node_and_params_from_graph,
     swap_node_output,
     update_model_param,
@@ -585,6 +586,7 @@ def quantize_torch_qat_export(
     _delete_repeated_qat_blocks(model)
     _convert_quantizable_ops(model)
     quantize_resnet_identity_add_inputs(model)
+    quantized_residual_add_optim(model)
     _remove_duplicate_quantize__ops(model)
 
     if output_file_path:


### PR DESCRIPTION
To fuse quantized adds, the DeepSparse engine needs both inputs to be near dequantize nodes.  this is not the immediate structure of common target models (ie Yolo-v3, BERT).  This change adds an optimization pass to the QAT->Quantized ONNX export flow that adds an additional dequantize node to the identity brach of quantized residual blocks, enabling the DeepSparse engine to fuse the residual adds as quantized operations.

Additionally, this PR adds the `ONNXGraph` object that caches the edges in an ONNX model graph, enabling common lookups and edits to run an order of magnitude or two quicker.  This will be used in the general effort to overhaul and improve the QAT export flow.  Using this object, this optimization runs in less than 10ms on yolo-v3.

Example residual before optimization:
<img width="126" alt="Screen Shot 2021-03-16 at 1 31 59 PM" src="https://user-images.githubusercontent.com/11316925/111370829-106cf500-866f-11eb-92f6-70fca09c6da2.png">

After:
<img width="243" alt="Screen Shot 2021-03-16 at 3 50 32 PM" src="https://user-images.githubusercontent.com/11316925/111371106-5cb83500-866f-11eb-84a9-cc994143f21e.png">
