### PR TITLE
quantized inputs optimization for qat exports

### DIFF
--- a/integrations/ultralytics/train.py
+++ b/integrations/ultralytics/train.py
@@ -521,13 +521,17 @@ def train(hyp, opt, device, tb_writer=None, wandb=None):
         # Start SparseML ONNX Export
         #################################################################################
             from sparseml.pytorch.utils import ModuleExporter
+            from sparseml.pytorch.utils.quantization import skip_onnx_input_quantize
 
+            onnx_path = f"{save_dir}/model.onnx"
             logger.info(
-                f"training complete, exporting ONNX to {save_dir}/model.onnx"
+                f"training complete, exporting ONNX to {onnx_path}"
             )
             model.model[-1].export = True  # do not export grid post-procesing
             exporter = ModuleExporter(model, save_dir)
             exporter.export_onnx(torch.randn((1, 3, *imgsz)), convert_qat=True)
+            if qat:
+                skip_onnx_input_quantize(onnx_path, onnx_path)
         #################################################################################
         # End SparseML ONNX Export
         #################################################################################

--- a/tests/sparseml/pytorch/utils/quantization/test_quantize_qat_export.py
+++ b/tests/sparseml/pytorch/utils/quantization/test_quantize_qat_export.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import onnx
+import pytest
+from onnx import TensorProto
+
+from sparseml.pytorch.utils.quantization import skip_onnx_input_quantize
+
+
+def test_skip_onnx_input_quantize():
+    # make sample graph of fp32 input -> QuantizeLinear -> QLinearConv
+    # verify that it is transformed to uint8 input -> QLinearConv
+
+    float_input = onnx.helper.make_tensor_value_info(
+        "input", TensorProto.FLOAT, [1, 3, None, None]
+    )
+    quant_node = onnx.helper.make_node(
+        "QuantizeLinear",
+        ["input", "scale", "zp"],
+        ["quant_output"],
+    )
+    qconv_node = onnx.helper.make_node(
+        "QLinearConv",
+        ["quant_output", "scale", "zp", "w", "w_scale", "w_zp", "y_scale", "y_zp"],
+        ["qconv_output"],
+    )
+
+    qconv_output = onnx.helper.make_tensor_value_info(
+        "qconv_output", TensorProto.UINT8, [1, 1, None, None]
+    )
+
+    graph = onnx.helper.make_graph(
+        [quant_node, qconv_node],
+        "test_graph",
+        [float_input],
+        [qconv_output],
+        [],
+    )
+    model = onnx.helper.make_model(graph)
+
+    # initial model checks
+    assert model.graph.input[0].type.tensor_type.elem_type == TensorProto.FLOAT
+    assert len(model.graph.node) == 2
+    assert model.graph.node[0].op_type == "QuantizeLinear"
+    assert model.graph.node[1].op_type == "QLinearConv"
+
+    assert model.graph.node[0].input[0] == model.graph.input[0].name
+    assert model.graph.node[1].input[0] == model.graph.node[0].output[0]
+
+    # run optimization
+    skip_onnx_input_quantize(model)
+
+    # check model has uint8 inputs and no qlinear input node
+    assert model.graph.input[0].type.tensor_type.elem_type == TensorProto.UINT8
+    assert len(model.graph.node) == 1
+    assert model.graph.node[0].op_type == "QLinearConv"
+
+    assert model.graph.node[0].input[0] == model.graph.input[0].name


### PR DESCRIPTION
there are instances where we want quantized graphs to take uint8 inputs instead of regular preprocessed fp32 inputs.  this optimization pass enables this by updating the input tensor of a quantized graph and deleting initial `QuantizeLinear` node.

As an example, this saves redundant operations in YOLOv3 preprocessing since inputs don't need to be converted from int to float and then back in the first step of the model.

Before:
<img width="899" alt="Screen Shot 2021-03-22 at 9 47 20 PM" src="https://user-images.githubusercontent.com/11316925/112080365-3f480700-8b58-11eb-9c31-b4002142afee.png">

After:
<img width="925" alt="Screen Shot 2021-03-22 at 9 47 36 PM" src="https://user-images.githubusercontent.com/11316925/112080375-43742480-8b58-11eb-8069-389377edb3f8.png">
