### PR TITLE
YOLOv3 benchmarking static input shape override

### DIFF
--- a/integrations/ultralytics/README.md
+++ b/integrations/ultralytics/README.md
@@ -130,8 +130,8 @@ performance with DeepSparse.  For a full list of options run `python benchmarkin
 To run a benchmark run:
 ```bash
 python benchmark.py
-    zoo:cv/detection/yolo_v3-spp/pytorch/ultralytics/coco/pruned_quant-aggressive_90 \
-    --batch-size 32 \
+    zoo:cv/detection/yolo_v3-spp/pytorch/ultralytics/coco/pruned_quant-aggressive_94 \
+    --batch-size 1 \
     --quantized-inputs
 ```
 

--- a/integrations/ultralytics/deepsparse/SERVER.md
+++ b/integrations/ultralytics/deepsparse/SERVER.md
@@ -49,11 +49,12 @@ pip install deepsparse sparseml flask flask-cors
 
 ### Server
 
-First, start up the host `server.py` with your model of choice.
+First, start up the host `server.py` with your model of choice, SparseZoo stubs are
+also supported.
 
 Example command:
 ```bash
-python server.py ~/models/yolov3-pruned_quant.onnx
+python server.py zoo:cv/detection/yolo_v3-spp/pytorch/ultralytics/coco/pruned_quant-aggressive_94
 ```
 
 You can leave that running as a detached process or in a spare terminal.

--- a/integrations/ultralytics/deepsparse/benchmark.py
+++ b/integrations/ultralytics/deepsparse/benchmark.py
@@ -21,8 +21,9 @@ Command help:
 usage: benchmark.py [-h] [-e {deepsparse,onnxruntime,torch}]
                     [--data-path DATA_PATH]
                     [--image-shape IMAGE_SHAPE [IMAGE_SHAPE ...]]
-                    [-b BATCH_SIZE] [-c NUM_CORES] [-i NUM_ITERATIONS]
-                    [-w NUM_WARMUP_ITERATIONS] [-q] [--fp16] [--device DEVICE]
+                    [-b BATCH_SIZE] [-c NUM_CORES] [-s NUM_SOCKETS]
+                    [-i NUM_ITERATIONS] [-w NUM_WARMUP_ITERATIONS] [-q]
+                    [--fp16] [--device DEVICE]
                     model_filepath
 
 Benchmark sparsified YOLOv3 models
@@ -53,7 +54,13 @@ optional arguments:
                         The batch size to run the benchmark for
   -c NUM_CORES, --num-cores NUM_CORES
                         The number of physical cores to run the benchmark on,
-                        defaults to all physical cores available on the system
+                        defaults to None where it uses all physical cores
+                        available on the system. For DeepSparse benchmarks,
+                        this value is the number of cores per socket
+  -s NUM_SOCKETS, --num-sockets NUM_SOCKETS
+                        For DeepSparse benchmarks only. The number of physical
+                        cores to run the benchmark on. Defaults to None where
+                        is uses all sockets available on the system
   -i NUM_ITERATIONS, --num-iterations NUM_ITERATIONS
                         The number of iterations the benchmark will be run for
   -w NUM_WARMUP_ITERATIONS, --num-warmup-iterations NUM_WARMUP_ITERATIONS
@@ -121,8 +128,6 @@ from sparsezoo.models.detection import yolo_v3 as zoo_yolo_v3
 from sparsezoo.utils import load_numpy_list
 
 
-CORES_PER_SOCKET, AVX_TYPE, _ = cpu.cpu_details()
-
 DEEPSPARSE_ENGINE = "deepsparse"
 ORT_ENGINE = "onnxruntime"
 TORCH_ENGINE = "torch"
@@ -185,10 +190,22 @@ def parse_args():
         "-c",
         "--num-cores",
         type=int,
-        default=CORES_PER_SOCKET,
+        default=None,
         help=(
             "The number of physical cores to run the benchmark on, "
-            "defaults to all physical cores available on the system"
+            "defaults to None where it uses all physical cores available on the system. "
+            "For DeepSparse benchmarks, this value is the number of cores per socket"
+        ),
+    )
+    parser.add_argument(
+        "-s",
+        "--num-sockets",
+        type=int,
+        default=None,
+        help=(
+            "For DeepSparse benchmarks only. The number of physical cores to run the "
+            "benchmark on. Defaults to None where is uses all sockets available on the "
+            "system"
         ),
     )
     parser.add_argument(
@@ -232,7 +249,6 @@ def parse_args():
     )
 
     args = parser.parse_args()
-
     if args.engine == TORCH_ENGINE and args.device is None:
         args.device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
@@ -278,20 +294,22 @@ def _load_model(args) -> Any:
         raise ValueError(f"half precision is not supported for {args.engine}")
     if args.quantized_inputs and args.engine == TORCH_ENGINE:
         raise ValueError(f"quantized inputs not supported for {args.engine}")
-    if args.num_cores != CORES_PER_SOCKET and args.engine == TORCH_ENGINE:
+    if args.num_cores is not None and args.engine == TORCH_ENGINE:
         raise ValueError(
             f"overriding default num_cores not supported for {args.engine}"
         )
     if (
-        args.num_cores != CORES_PER_SOCKET
+        args.num_cores is not None
         and args.engine == ORT_ENGINE
         and onnxruntime.__version__ < "1.7"
     ):
-        print(
+        raise ValueError(
             "overriding default num_cores not supported for onnxruntime < 1.7.0. "
             "If using an older build with OpenMP, try setting the OMP_NUM_THREADS "
             "environment variable"
         )
+    if args.num_sockets is not None and args.engine != DEEPSPARSE_ENGINE:
+        raise ValueError(f"Overriding num_sockets is not supported for {args.engine}")
 
     # scale static ONNX graph to desired image shape
     if args.engine in [DEEPSPARSE_ENGINE, ORT_ENGINE]:
@@ -302,12 +320,20 @@ def _load_model(args) -> Any:
     # load model
     if args.engine == DEEPSPARSE_ENGINE:
         print(f"Compiling deepsparse model for {args.model_filepath}")
-        model = compile_model(args.model_filepath, args.batch_size, args.num_cores)
+        model = compile_model(
+            args.model_filepath, args.batch_size, args.num_cores, args.num_sockets
+        )
+        if args.quantized_inputs and not model.cpu_vnni:
+            print(
+                "WARNING: VNNI instructions not detected, "
+                "quantization speedup not well supported"
+            )
     elif args.engine == ORT_ENGINE:
         print(f"loading onnxruntime model for {args.model_filepath}")
 
         sess_options = onnxruntime.SessionOptions()
-        sess_options.intra_op_num_threads = args.num_cores
+        if args.num_cores is not None:
+            sess_options.intra_op_num_threads = args.num_cores
         sess_options.log_severity_level = 3
         sess_options.graph_optimization_level = (
             onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL

--- a/integrations/ultralytics/deepsparse/deepsparse_utils.py
+++ b/integrations/ultralytics/deepsparse/deepsparse_utils.py
@@ -129,19 +129,23 @@ def modify_yolo_onnx_input_shape(
     model_path: str, image_shape: Tuple[int]
 ) -> Tuple[str, Optional[NamedTemporaryFile]]:
     """
+    Creates a new YOLOv3 ONNX model from the given path that accepts the given input
+    shape. If the given model already has the given input shape no modifications are
+    made. Uses a tempfile to store the modified model file.
+
     :param model_path: file path to YOLOv3 ONNX model or SparseZoo stub of the model
         to be loaded
     :param image_shape: 2-tuple of the image shape to resize this yolo model to
-    :return: filepath to an onnx model reshaped to the given input shape and tempfile
-        object that the modified model is written to. if the given model has the given
-        input shape, then the path to the original model will be returned with no
-        tempfile. tempfile returned so caller can control when the tempfile is destroyed
+    :return: filepath to an onnx model reshaped to the given input shape will be the
+        original path if the shape is the same.  Additionally returns the
+        NamedTemporaryFile for managing the scope of the object for file deletion
     """
     original_model_path = model_path
     if model_path.startswith("zoo:"):
         # load SparseZoo Model from stub
         model = Zoo.load_model_from_stub(model_path)
         model_path = model.onnx_file.downloaded_path()
+        print(f"Downloaded {original_model_path} to {model_path}")
 
     model = onnx.load(model_path)
     model_input = model.graph.input[0]

--- a/src/sparseml/onnx/utils/helpers.py
+++ b/src/sparseml/onnx/utils/helpers.py
@@ -70,6 +70,8 @@ __all__ = [
     "get_kernel_shape",
     "calculate_flops",
     "get_quantize_parent_for_dequantize_node",
+    "get_tensor_dim_shape",
+    "set_tensor_dim_shape",
 ]
 
 
@@ -1189,3 +1191,23 @@ def get_quantize_parent_for_dequantize_node(
         input_nodes = get_node_input_nodes(quantized_model, curr_node)
         curr_node = input_nodes[0] if input_nodes else None
     return curr_node
+
+
+def get_tensor_dim_shape(tensor: onnx.TensorProto, dim: int) -> int:
+    """
+    :param tensor: ONNX tensor to get the shape of a dimension of
+    :param dim: dimension index of the tensor to get the shape of
+    :return: shape of the tensor at the given dimension
+    """
+    return tensor.type.tensor_type.shape.dim[dim].dim_value
+
+
+def set_tensor_dim_shape(tensor: onnx.TensorProto, dim: int, value: int):
+    """
+    Sets the shape of the tensor at the given dimension to the given value
+
+    :param tensor: ONNX tensor to modify the shape of
+    :param dim: dimension index of the tensor to modify the shape of
+    :param value: new shape for the given dimension
+    """
+    tensor.type.tensor_type.shape.dim[dim].dim_value = value


### PR DESCRIPTION
* in YOLOv3 benchmarking, create a temporary ONNX model with the given input shape if `--image-shape` does not match the ONNX model's static input shape
* fix for yolo `train.py` to unwrap DP/DDP models before applying recipes
* support for `--num-sockets`