### PR TITLE
BERT QAT post-processing support

### DIFF
--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -87,8 +87,8 @@ class ONNXGraph(object):
     ) -> List[Union[NodeProto, TensorProto, None]]:
         """
         :param node: node to get the input objects for
-        :return: input nodes or tensors of this node in order.
-            if an input doesn't exist, None will be returned in its place
+        :return: input nodes or tensors of this node in order. if an input does not
+            exist, None will be returned in its place
         """
         inputs = []
         for input_id in node.input:

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -87,8 +87,8 @@ class ONNXGraph(object):
     ) -> List[Union[NodeProto, TensorProto, None]]:
         """
         :param node: node to get the input objects for
-        :return: input nodes or tensors of this node in order. if an input doesn't exist,
-            None will be returned in its place
+        :return: input nodes or tensors of this node in order.
+            if an input doesn't exist, None will be returned in its place
         """
         inputs = []
         for input_id in node.input:

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -83,7 +83,7 @@ class ONNXGraph(object):
         return self._name_to_initializer.get(name)
 
     def get_node_parents(
-        self, node: NodeProto, index: Union[int, None] = None
+        self, node: NodeProto
     ) -> List[Union[NodeProto, TensorProto, None]]:
         """
         :param node: node to get the input objects for
@@ -91,9 +91,8 @@ class ONNXGraph(object):
         :return: input nodes or tensors of this node in order. if an input doesn't exist,
             None will be returned in its place
         """
-        input_ids = [node.input[index]] if index else node.input
         inputs = []
-        for input_id in input_ids:
+        for input_id in node.input:
             inp = None
             if input_id in self._output_id_to_node:
                 inp = self._output_id_to_node[input_id]
@@ -103,15 +102,17 @@ class ONNXGraph(object):
         return inputs
 
     def get_node_single_parent(
-        self, node: NodeProto, index: Union[int, None] = None
-    ) -> Union[NodeProto, TensorProto, None]:
+        self, node: NodeProto, index: int
+    ) -> Union[NodeProto, None]:
         """
         :param node: the node to get the parent node of
         :param index: choose which input to search, or all if None
         :return: parent of node if it only has one parent, otherwise None
         """
-        parents = self.get_node_parents(node, index)
-        return parents[0] if len(parents) == 1 else None
+        input_id = node.input[index]
+        if input_id not in self._output_id_to_node:
+            return None
+        return self._output_id_to_node[input_id]
 
     def get_node_children(self, node: NodeProto) -> List[NodeProto]:
         """

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -230,7 +230,11 @@ class ONNXGraph(object):
             self._input_id_to_nodes[input_id].remove(node)
 
 
-def update_model_param(model: ModelProto, param_name: str, val: numpy.ndarray,) -> None:
+def update_model_param(
+    model: ModelProto,
+    param_name: str,
+    val: numpy.ndarray,
+) -> None:
     """
     Removes the parameter with name param_name from the model
     Creates a new parameter using val
@@ -262,7 +266,9 @@ def swap_node_output(node: onnx.NodeProto, output: str) -> None:
 
 
 def remove_node_and_params_from_graph(
-    model: ModelProto, node: onnx.NodeProto, keep_params: Iterable[str] = None,
+    model: ModelProto,
+    node: onnx.NodeProto,
+    keep_params: Iterable[str] = None,
 ) -> None:
     """
     Deletes a node from the mdoel graph as well as its parameters listed in node.input

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -87,7 +87,6 @@ class ONNXGraph(object):
     ) -> List[Union[NodeProto, TensorProto, None]]:
         """
         :param node: node to get the input objects for
-        :param index: choose which input to search, or all if None
         :return: input nodes or tensors of this node in order. if an input doesn't exist,
             None will be returned in its place
         """
@@ -106,7 +105,7 @@ class ONNXGraph(object):
     ) -> Union[NodeProto, None]:
         """
         :param node: the node to get the parent node of
-        :param index: choose which input to search, or all if None
+        :param index: choose which input to search
         :return: parent of node if it only has one parent, otherwise None
         """
         input_id = node.input[index]

--- a/src/sparseml/onnx/utils/graph_optimizer.py
+++ b/src/sparseml/onnx/utils/graph_optimizer.py
@@ -33,7 +33,6 @@ from sparseml.onnx.utils.helpers import (
     NodeParam,
     conv_node_params,
     get_batch_norm_params,
-    get_node_input_nodes,
     get_quantize_parent_for_dequantize_node,
 )
 

--- a/src/sparseml/onnx/utils/graph_optimizer.py
+++ b/src/sparseml/onnx/utils/graph_optimizer.py
@@ -149,7 +149,10 @@ def quantize_resnet_identity_add_inputs(quantized_model: onnx.ModelProto) -> boo
     add_nodes = [node for node in quantized_model.graph.node if node.op_type == "Add"]
     optimization_made = False
     for add_node in add_nodes:
-        add_inputs = get_node_input_nodes(quantized_model, add_node)
+        graph = ONNXGraph(quantized_model)
+        add_inputs = [
+            i for i in graph.get_node_parents(add_node) if isinstance(i, onnx.NodeProto)
+        ]
         if len(add_inputs) != 2:
             continue
         # extract dequantize input and relu/add input

--- a/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
@@ -620,7 +620,7 @@ def _convert_quantizable_matmul_and_add(model: ModelProto):
         )
         model.graph.initializer.append(quantized_weight_initializer)
 
-        """ QLinearMatMul """
+        # QLinearMatMul
         # get qmatmul inputs and outputs
         qmatmul_input = input_quantize_node.input[0]
         qmatmul_inputs = [
@@ -645,7 +645,7 @@ def _convert_quantizable_matmul_and_add(model: ModelProto):
         )
         model.graph.node.append(qmatmul_node)
 
-        """ QLinearAdd """
+        # QLinearAdd
         # quantize bias
         bias_initializer = get_init_by_name(model, bias_add_node.input[1])
         if bias_initializer is None:
@@ -698,7 +698,7 @@ def _convert_quantizable_matmul_and_add(model: ModelProto):
         )
         model.graph.node.append(qadd_node)
 
-        """ Cleanup """
+        # Cleanup
         # delete folded quantization ops
         delete_quant_node(model, weight_dequantize_node, keep_params=False)
         delete_quant_node(model, weight_quantize_node, keep_params=True)

--- a/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
@@ -40,7 +40,6 @@ from sparseml.onnx.utils import (
     swap_node_output,
     update_model_param,
 )
-from sparseml.onnx.utils.graph_editor import ONNXGraph
 
 
 __all__ = [
@@ -621,7 +620,7 @@ def _convert_quantizable_matmul_and_add(model: ModelProto):
         )
         model.graph.initializer.append(quantized_weight_initializer)
 
-        ### QLinearMatMul
+        """ QLinearMatMul """
         # get qmatmul inputs and outputs
         qmatmul_input = input_quantize_node.input[0]
         qmatmul_inputs = [
@@ -646,7 +645,7 @@ def _convert_quantizable_matmul_and_add(model: ModelProto):
         )
         model.graph.node.append(qmatmul_node)
 
-        ### QLinearAdd
+        """ QLinearAdd """
         # quantize bias
         bias_initializer = get_init_by_name(model, bias_add_node.input[1])
         if bias_initializer is None:
@@ -699,7 +698,7 @@ def _convert_quantizable_matmul_and_add(model: ModelProto):
         )
         model.graph.node.append(qadd_node)
 
-        ### Cleanup
+        """ Cleanup """
         # delete folded quantization ops
         delete_quant_node(model, weight_dequantize_node, keep_params=False)
         delete_quant_node(model, weight_quantize_node, keep_params=True)

--- a/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
@@ -515,8 +515,8 @@ def _convert_quantizable_gemm(
 
 
 def _convert_quantizable_matmul_and_add(model: ModelProto):
-    quantizable_nodes = [n for n in model.graph.node if n.op_type in ["MatMul"]]
-    for gemm_node in quantizable_nodes:
+    matmul_nodes = [n for n in model.graph.node if n.op_type in ["MatMul"]]
+    for gemm_node in matmul_nodes:
         graph = ONNXGraph(model)
         #############
         # Matching
@@ -710,14 +710,6 @@ def _convert_quantizable_ops(model: ModelProto):
                 weight_quant,
                 output_quant,
             )
-
-
-def _convert_quantizable_matmul_ops(model: ModelProto):
-    quantizable_nodes = [n for n in model.graph.node if n.op_type in ["MatMul"]]
-    for quantizable_node in quantizable_nodes:
-        _convert_quantizable_matmul_and_add(
-            model, quantizable_node,
-        )
 
 
 def _replace_input_id_model(model: ModelProto, old_id: str, new_id: str):

--- a/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
@@ -27,7 +27,6 @@ import numpy
 import onnx
 from onnx import ModelProto, NodeProto, numpy_helper
 
-from sparseml.onnx.utils.graph_editor import ONNXGraph
 from sparseml.onnx.utils import (
     ONNXGraph,
     get_batch_norm_params,
@@ -41,6 +40,7 @@ from sparseml.onnx.utils import (
     swap_node_output,
     update_model_param,
 )
+from sparseml.onnx.utils.graph_editor import ONNXGraph
 
 
 __all__ = [

--- a/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
@@ -27,6 +27,7 @@ import numpy
 import onnx
 from onnx import ModelProto, NodeProto, numpy_helper
 
+from sparseml.onnx.utils.graph_editor import ONNXGraph
 from sparseml.onnx.utils import (
     ONNXGraph,
     get_batch_norm_params,
@@ -234,23 +235,29 @@ def _convert_single_constants_to_initializers(model: ModelProto):
 def _delete_repeated_qat_blocks(model: ModelProto):
     # removes repeated qat quant/dequant blocks with the same parameters
     # (Quant -> Dequant -> Quant -> Dequant) -> (Quant -> Dequant)
+    graph = ONNXGraph(model)
+    nodes_to_delete = []
     quant_nodes = [n for n in model.graph.node if n.op_type == "QuantizeLinear"]
     for quant_node_1 in quant_nodes:
-        dequant_node_1 = _get_single_node_child(model, quant_node_1)
+        dequant_node_1 = graph.get_node_single_child(quant_node_1)
         if not dequant_node_1 or dequant_node_1.op_type != "DequantizeLinear":
             continue
-        quant_node_2 = _get_single_node_child(model, dequant_node_1)
+        quant_node_2 = graph.get_node_single_child(dequant_node_1)
         if not quant_node_2 or quant_node_2.op_type != "QuantizeLinear":
             continue
-        dequant_node_2 = _get_single_node_child(model, quant_node_2)
+        dequant_node_2 = graph.get_node_single_child(quant_node_2)
         if not dequant_node_2 or dequant_node_2.op_type != "DequantizeLinear":
             continue
 
         # forward first qat block input to that of the second
         quant_node_2.input[0] = quant_node_1.input[0]
-        # delete repeated qunat/dequant block
-        delete_quant_node(model, quant_node_1)
-        delete_quant_node(model, dequant_node_1)
+
+        # remove repeated quant/dequant block
+        nodes_to_delete.append(quant_node_1)
+        nodes_to_delete.append(dequant_node_1)
+
+    for n in nodes_to_delete:
+        delete_quant_node(model, n)
 
 
 def _delete_multi_qat_blocks(model: ModelProto):
@@ -526,179 +533,180 @@ def _convert_quantizable_gemm(
         remove_node_and_params_from_graph(model, gemm_node, keep_params=params_to_keep)
 
 
-def _convert_quantizable_matmul_and_add(
-    model: ModelProto, gemm_node: NodeProto,
-):
-    #############
-    # Matching
-    #############
+def _convert_quantizable_matmul_and_add(model: ModelProto):
+    quantizable_nodes = [n for n in model.graph.node if n.op_type in ["MatMul"]]
+    for gemm_node in quantizable_nodes:
+        graph = ONNXGraph(model)
+        #############
+        # Matching
+        #############
+        weight_transpose_node = graph.get_node_single_parent(gemm_node, 1)
+        if not weight_transpose_node or weight_transpose_node.op_type != "Transpose":
+            continue
 
-    weight_transpose_node = _get_single_node_parent(model, gemm_node, 1)
-    if not weight_transpose_node or weight_transpose_node.op_type != "Transpose":
-        return
+        weight_dequantize_node = graph.get_node_single_parent(weight_transpose_node, 0)
+        if (
+            not weight_dequantize_node
+            or weight_dequantize_node.op_type != "DequantizeLinear"
+        ):
+            continue
+        weight_quantize_node = graph.get_node_single_parent(weight_dequantize_node, 0)
+        if not weight_quantize_node or weight_quantize_node.op_type != "QuantizeLinear":
+            continue
 
-    weight_dequantize_node = _get_single_node_parent(model, weight_transpose_node, 0)
-    if (
-        not weight_dequantize_node
-        or weight_dequantize_node.op_type != "DequantizeLinear"
-    ):
-        return
-    weight_quantize_node = _get_single_node_parent(model, weight_dequantize_node, 0)
-    if not weight_quantize_node or weight_quantize_node.op_type != "QuantizeLinear":
-        return
+        input_quantize_node = graph.get_node_single_parent(gemm_node, 0)
+        if (
+            not input_quantize_node
+            or input_quantize_node.op_type not in _QUANTIZE_OP_NAMES
+        ):
+            continue
 
-    input_quantize_node = _get_single_node_parent(model, gemm_node, 0)
-    if not input_quantize_node or input_quantize_node.op_type not in _QUANTIZE_OP_NAMES:
-        return
+        bias_add_node = graph.get_node_single_child(gemm_node)
+        if not bias_add_node or bias_add_node.op_type != "Add":
+            continue
+        output_quantize_node = graph.get_node_single_child(bias_add_node)
+        if (
+            not output_quantize_node
+            or output_quantize_node.op_type not in _QUANTIZE_OP_NAMES
+        ):
+            continue
 
-    bias_add_node = _get_single_node_child(model, gemm_node)
-    if not bias_add_node or bias_add_node.op_type != "Add":
-        return
-    output_quantize_node = _get_single_node_child(model, bias_add_node)
-    if (
-        not output_quantize_node
-        or output_quantize_node.op_type not in _QUANTIZE_OP_NAMES
-    ):
-        return
-
-    print(f"MATCHED MatMul {gemm_node.name}")
-
-    #############
-    # Conversion
-    #############
-
-    # MatMul -> (QLinearMatMul -> Add(bias))
-    input_quantize_params = get_quantization_params(
-        model, input_quantize_node, include_target=False
-    )
-    weight_quantize_params = get_quantization_params(
-        model, weight_quantize_node, include_target=True
-    )
-    if weight_quantize_params.target is None:
-        # weight initializer not included
-        return
-
-    # can fold the input/output quant ops if they are trivial
-    if input_quantize_node.op_type != "DequantizeLinear":
-        return
-    if output_quantize_node.op_type != "QuantizeLinear":
-        return
-
-    # quantize weight
-    quantized_weight = _quantize_array(
-        weight_quantize_params.target,
-        weight_quantize_params.scale,
-        weight_quantize_params.zero_point,
-    )
-    quantized_weight = quantized_weight.transpose()  # Gemm has implicit transpose
-    quantized_weight_name = "{}.weight_quantized".format(gemm_node.name)
-    quantized_weight_initializer = numpy_helper.from_array(
-        quantized_weight, name=quantized_weight_name
-    )
-    model.graph.initializer.append(quantized_weight_initializer)
-
-    ### QLinearMatMul
-    # get qmatmul inputs and outputs
-    qmatmul_input = input_quantize_node.input[0]
-    qmatmul_inputs = [
-        qmatmul_input,  # x
-        input_quantize_node.input[1],  # x_scale
-        input_quantize_node.input[2],  # x_zero_point
-        quantized_weight_name,  # w
-        weight_quantize_node.input[1],  # w_scale
-        weight_quantize_node.input[2],  # w_zero_point
-        output_quantize_node.input[1],  # y_scale
-        output_quantize_node.input[2],  # y_zero_point
-    ]
-    # qmatmul_output = gemm_node.output[0]
-    qmatmul_output = output_quantize_node.output[0]
-    qmatmul_name = "{}_quant".format(gemm_node.name)
-
-    # create qmatmul node and add it to graph
-    qmatmul_node = onnx.helper.make_node(
-        "QLinearMatMul", qmatmul_inputs, [qmatmul_output], qmatmul_name,
-    )
-    model.graph.node.append(qmatmul_node)
-
-    ### QLinearAdd
-    # quantize bias
-    bias_initializer = get_init_by_name(model, bias_add_node.input[1])
-    if bias_initializer is None:
-        return
-    bias_initializer = numpy_helper.to_array(bias_initializer)
-    bias_scale = input_quantize_params.scale * weight_quantize_params.scale
-    bias_zero_point = 0
-    quantized_bias = _quantize_array(bias_initializer, bias_scale, bias_zero_point)
-    quantized_bias_name = "{}.bias_quantized".format(bias_add_node.name)
-    quantized_bias_initializer = numpy_helper.from_array(
-        quantized_bias, name=quantized_bias_name
-    )
-    model.graph.initializer.append(quantized_bias_initializer)
-    quantized_bias_scale_name = "{}.scale".format(quantized_bias_name)
-    model.graph.initializer.append(
-        numpy_helper.from_array(
-            numpy.asarray(bias_scale), name=quantized_bias_scale_name
+        #############
+        # Conversion
+        #############
+        # MatMul -> (QLinearMatMul -> Add(bias))
+        input_quantize_params = get_quantization_params(
+            model, input_quantize_node, include_target=False
         )
-    )
-    quantized_bias_zero_point_name = "{}.zero_point".format(quantized_bias_name)
-    model.graph.initializer.append(
-        numpy_helper.from_array(
-            numpy.asarray(bias_zero_point, dtype=numpy.uint8),
-            name=quantized_bias_zero_point_name,
+        weight_quantize_params = get_quantization_params(
+            model, weight_quantize_node, include_target=True
         )
-    )
+        if weight_quantize_params.target is None:
+            # weight initializer not included
+            continue
 
-    # get qadd inputs and outputs
-    qadd_input = qmatmul_output
-    # TODO: need to get different scales/zero points here
-    qadd_inputs = [
-        qadd_input,  # x
-        output_quantize_node.input[1],  # x_scale
-        output_quantize_node.input[2],  # x_zero_point
-        quantized_bias_name,  # b
-        quantized_bias_scale_name,  # b_scale
-        quantized_bias_zero_point_name,  # b_zero_point
-        output_quantize_node.input[1],  # y_scale
-        output_quantize_node.input[2],  # y_zero_point
-    ]
-    qadd_output = output_quantize_node.output[0]
-    qadd_name = "{}_quant".format(bias_add_node.name)
-    kwargs = {"domain": "com.microsoft"}
-    # create qlinearadd node and add it to graph
-    qadd_node = onnx.helper.make_node(
-        "QLinearAdd", qadd_inputs, [qadd_output], qadd_name, **kwargs,
-    )
-    model.graph.node.append(qadd_node)
+        # can fold the input/output quant ops if they are trivial
+        if input_quantize_node.op_type != "DequantizeLinear":
+            continue
+        if output_quantize_node.op_type != "QuantizeLinear":
+            continue
 
-    ### Cleanup
-    # delete folded quantization ops
-    delete_quant_node(model, weight_dequantize_node, keep_params=False)
-    delete_quant_node(model, weight_quantize_node, keep_params=True)
-    remove_node_and_params_from_graph(model, weight_transpose_node)
-    delete_quant_node(model, input_quantize_node, keep_params=True)
-    delete_quant_node(model, output_quantize_node, keep_params=True)
+        # quantize weight
+        quantized_weight = _quantize_array(
+            weight_quantize_params.target,
+            weight_quantize_params.scale,
+            weight_quantize_params.zero_point,
+        )
+        quantized_weight = quantized_weight.transpose()  # Gemm has implicit transpose
+        quantized_weight_name = "{}.weight_quantized".format(gemm_node.name)
+        quantized_weight_initializer = numpy_helper.from_array(
+            quantized_weight, name=quantized_weight_name
+        )
+        model.graph.initializer.append(quantized_weight_initializer)
 
-    # delete original Gemm node
-    remove_node_and_params_from_graph(model, gemm_node, keep_params=None)
-    # delete original Add node
-    remove_node_and_params_from_graph(model, bias_add_node, keep_params=None)
+        ### QLinearMatMul
+        # get qmatmul inputs and outputs
+        qmatmul_input = input_quantize_node.input[0]
+        qmatmul_inputs = [
+            qmatmul_input,  # x
+            input_quantize_node.input[1],  # x_scale
+            input_quantize_node.input[2],  # x_zero_point
+            quantized_weight_name,  # w
+            weight_quantize_node.input[1],  # w_scale
+            weight_quantize_node.input[2],  # w_zero_point
+            output_quantize_node.input[1],  # y_scale
+            output_quantize_node.input[2],  # y_zero_point
+        ]
+        qmatmul_output = gemm_node.output[0]
+        qmatmul_name = "{}_quant".format(gemm_node.name)
+
+        # create qmatmul node and add it to graph
+        qmatmul_node = onnx.helper.make_node(
+            "QLinearMatMul", qmatmul_inputs, [qmatmul_output], qmatmul_name,
+        )
+        model.graph.node.append(qmatmul_node)
+
+        ### QLinearAdd
+        # quantize bias
+        bias_initializer = get_init_by_name(model, bias_add_node.input[1])
+        if bias_initializer is None:
+            return
+        bias_initializer = numpy_helper.to_array(bias_initializer)
+        bias_scale = input_quantize_params.scale * weight_quantize_params.scale
+        bias_zero_point = 0
+        quantized_bias = _quantize_array(bias_initializer, bias_scale, bias_zero_point)
+        quantized_bias_name = "{}.bias_quantized".format(bias_add_node.name)
+        quantized_bias_initializer = numpy_helper.from_array(
+            quantized_bias, name=quantized_bias_name
+        )
+        model.graph.initializer.append(quantized_bias_initializer)
+        quantized_bias_scale_name = "{}.scale".format(quantized_bias_name)
+        model.graph.initializer.append(
+            numpy_helper.from_array(
+                numpy.asarray(bias_scale), name=quantized_bias_scale_name
+            )
+        )
+        quantized_bias_zero_point_name = "{}.zero_point".format(quantized_bias_name)
+        model.graph.initializer.append(
+            numpy_helper.from_array(
+                numpy.asarray(bias_zero_point, dtype=numpy.uint8),
+                name=quantized_bias_zero_point_name,
+            )
+        )
+
+        # get qadd inputs and outputs
+        qadd_input = qmatmul_output
+        # TODO: need to get different scales/zero points here
+        qadd_inputs = [
+            qadd_input,  # x
+            output_quantize_node.input[1],  # x_scale
+            output_quantize_node.input[2],  # x_zero_point
+            quantized_bias_name,  # b
+            quantized_bias_scale_name,  # b_scale
+            quantized_bias_zero_point_name,  # b_zero_point
+            output_quantize_node.input[1],  # y_scale
+            output_quantize_node.input[2],  # y_zero_point
+        ]
+        qadd_output = output_quantize_node.output[0]
+        qadd_name = "{}_quant".format(bias_add_node.name)
+        kwargs = {"domain": "com.microsoft"}
+        # create qlinearadd node and add it to graph
+        qadd_node = onnx.helper.make_node(
+            "QLinearAdd", qadd_inputs, [qadd_output], qadd_name, **kwargs,
+        )
+        model.graph.node.append(qadd_node)
+
+        ### Cleanup
+        # delete folded quantization ops
+        delete_quant_node(model, weight_dequantize_node, keep_params=False)
+        delete_quant_node(model, weight_quantize_node, keep_params=True)
+        remove_node_and_params_from_graph(model, weight_transpose_node)
+        delete_quant_node(model, input_quantize_node, keep_params=True)
+        delete_quant_node(model, output_quantize_node, keep_params=True)
+
+        # delete original Gemm node
+        remove_node_and_params_from_graph(model, gemm_node, keep_params=None)
+        # delete original Add node
+        remove_node_and_params_from_graph(model, bias_add_node, keep_params=None)
 
 
 def _convert_quantizable_ops(model: ModelProto):
     quantizable_nodes = [n for n in model.graph.node if n.op_type in ["Conv", "Gemm"]]
     for quantizable_node in quantizable_nodes:
-        weight_dequant = _get_single_node_parent(model, quantizable_node, 1)
+        graph = ONNXGraph(model)
+
+        weight_dequant = graph.get_node_single_parent(quantizable_node, 1)
         if not weight_dequant or weight_dequant.op_type != "DequantizeLinear":
             continue
-        weight_quant = _get_single_node_parent(model, weight_dequant, 0)
+        weight_quant = graph.get_node_single_parent(weight_dequant, 0)
         if not weight_quant or weight_quant.op_type != "QuantizeLinear":
             continue
 
-        input_quant = _get_single_node_parent(model, quantizable_node, 0)
+        input_quant = graph.get_node_single_parent(quantizable_node, 0)
         if not input_quant or input_quant.op_type not in _QUANTIZE_OP_NAMES:
             continue
 
-        output_quant = _get_single_node_child(model, quantizable_node)
+        output_quant = graph.get_node_single_child(model, quantizable_node)
         if not output_quant or output_quant.op_type not in _QUANTIZE_OP_NAMES:
             continue
 
@@ -721,14 +729,6 @@ def _convert_quantizable_ops(model: ModelProto):
                 weight_quant,
                 output_quant,
             )
-
-
-def _convert_quantizable_matmul_ops(model: ModelProto):
-    quantizable_nodes = [n for n in model.graph.node if n.op_type in ["MatMul"]]
-    for quantizable_node in quantizable_nodes:
-        _convert_quantizable_matmul_and_add(
-            model, quantizable_node,
-        )
 
 
 def _replace_input_id_model(model: ModelProto, old_id: str, new_id: str):
@@ -778,7 +778,7 @@ def quantize_torch_qat_export(
     _fold_relu_quants(model)
     _convert_single_constants_to_initializers(model)
     _delete_repeated_qat_blocks(model)
-    _convert_quantizable_matmul_ops(model)
+    _convert_quantizable_matmul_and_add(model)
     _convert_quantizable_ops(model)
     quantize_resnet_identity_add_inputs(model)
     quantized_residual_add_optim(model)

--- a/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
@@ -713,7 +713,8 @@ def _convert_quantizable_matmul_and_add(model: ModelProto):
         conversion_count += 1
 
     _LOGGER.info(
-        f"Converted {conversion_count} quantizable MatMul ops with weight and bias to QLinearMatMul and QLinearAdd"
+        f"Converted {conversion_count} quantizable MatMul ops with weight and bias "
+        "to QLinearMatMul and QLinearAdd"
     )
 
 


### PR DESCRIPTION
Added passes to `quantize_qat_export.py` for Transformer-related structures, mainly supporting quantized MatMuls with kernels and biases. 
Also used @bfineran 's new `ONNXGraph` structure to speed up the passes that were taking the longest. With these changes, we can post-process a BERT with 1000+ nodes in just a few seconds on a MacBook Pro