### PR TITLE
Fix incorrect loss scaling in DDP setup

### DIFF
--- a/src/sparseml/pytorch/utils/module.py
+++ b/src/sparseml/pytorch/utils/module.py
@@ -974,8 +974,7 @@ class ModuleTrainer(ModuleRunner):
 
             # loss calculation
             losses = self._loss(data, pred)
-            # scale loss by world size
-            losses[DEFAULT_LOSS_KEY] *= self.device_context.world_size
+
             self._run_hooks.invoke_batch_loss(
                 counter, batch, batch_size, data, pred, losses
             )


### PR DESCRIPTION
According to the PyTorch documentation, DDP syncs models by calculating mean of gradients across all processes.
Since the default reduction used by almost all PyTorch loss functions is `mean`, this loss scaling would result with `world_size` times larger gradients and the DDP experiment won't be mathematically equivalent to the corresponding one-process experiment.