### PR TITLE
[WIP] Phase two - framework and base implementations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_markdown_tables",
     "sphinx_multiversion",
+    "sphinx-pydantic",
     "sphinx_rtd_theme",
     "recommonmark",
 ]
@@ -111,8 +112,8 @@ html_theme = "sphinx_rtd_theme"
 html_logo = "source/icon-sparseml.png"
 
 html_theme_options = {
-    'analytics_id': 'UA-128364174-1',  #  Provided by Google in your dashboard
-    'analytics_anonymize_ip': False,
+    "analytics_id": "UA-128364174-1",  #  Provided by Google in your dashboard
+    "analytics_anonymize_ip": False,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/integrations/transformers/README.md
+++ b/integrations/transformers/README.md
@@ -10,6 +10,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 lim itations under the License.
 -->
+
+<!--
+Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 # Transformers-SparseML Integration
 This folder contains an example on how to use sparseml with transformers. 
 We focus on Question answering and use a modified implementation from the BERT SQuAD in transformers. 

--- a/integrations/transformers/README.md
+++ b/integrations/transformers/README.md
@@ -10,22 +10,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 lim itations under the License.
 -->
-
-<!--
-Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
 # Transformers-SparseML Integration
 This folder contains an example on how to use sparseml with transformers. 
 We focus on Question answering and use a modified implementation from the BERT SQuAD in transformers. 

--- a/integrations/transformers/trainer_qa.py
+++ b/integrations/transformers/trainer_qa.py
@@ -12,6 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 A subclass of `Trainer` specific to Question-Answering tasks
 """
@@ -26,6 +41,7 @@ if is_datasets_available():
 if is_torch_tpu_available():
     import torch_xla.core.xla_model as xm
     import torch_xla.debug.metrics as met
+
 
 class QuestionAnsweringTrainer(Trainer):
     def __init__(self, *args, eval_examples=None, post_process_function=None, **kwargs):

--- a/integrations/transformers/trainer_qa.py
+++ b/integrations/transformers/trainer_qa.py
@@ -12,21 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 """
 A subclass of `Trainer` specific to Question-Answering tasks
 """
@@ -41,7 +26,6 @@ if is_datasets_available():
 if is_torch_tpu_available():
     import torch_xla.core.xla_model as xm
     import torch_xla.debug.metrics as met
-
 
 class QuestionAnsweringTrainer(Trainer):
     def __init__(self, *args, eval_examples=None, post_process_function=None, **kwargs):

--- a/integrations/transformers/utils_qa.py
+++ b/integrations/transformers/utils_qa.py
@@ -12,21 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 """
 Post-processing utilities for question answering.
 """
@@ -86,14 +71,10 @@ def postprocess_qa_predictions(
         is_world_process_zero (:obj:`bool`, `optional`, defaults to :obj:`True`):
             Whether this process is the main process or not (used to determine if logging/saves should be done).
     """
-    assert (
-        len(predictions) == 2
-    ), "`predictions` should be a tuple with two elements (start_logits, end_logits)."
+    assert len(predictions) == 2, "`predictions` should be a tuple with two elements (start_logits, end_logits)."
     all_start_logits, all_end_logits = predictions
 
-    assert len(predictions[0]) == len(
-        features
-    ), f"Got {len(predictions[0])} predictions and {len(features)} features."
+    assert len(predictions[0]) == len(features), f"Got {len(predictions[0])} predictions and {len(features)} features."
 
     # Build a map example to its corresponding features.
     example_id_to_index = {k: i for i, k in enumerate(examples["id"])}
@@ -109,9 +90,7 @@ def postprocess_qa_predictions(
 
     # Logging.
     logger.setLevel(logging.INFO if is_world_process_zero else logging.WARN)
-    logger.info(
-        f"Post-processing {len(examples)} example predictions split into {len(features)} features."
-    )
+    logger.info(f"Post-processing {len(examples)} example predictions split into {len(features)} features.")
 
     # Let's loop over all the examples!
     for example_index, example in enumerate(tqdm(examples)):
@@ -131,16 +110,11 @@ def postprocess_qa_predictions(
             offset_mapping = features[feature_index]["offset_mapping"]
             # Optional `token_is_max_context`, if provided we will remove answers that do not have the maximum context
             # available in the current feature.
-            token_is_max_context = features[feature_index].get(
-                "token_is_max_context", None
-            )
+            token_is_max_context = features[feature_index].get("token_is_max_context", None)
 
             # Update minimum null prediction.
             feature_null_score = start_logits[0] + end_logits[0]
-            if (
-                min_null_prediction is None
-                or min_null_prediction["score"] > feature_null_score
-            ):
+            if min_null_prediction is None or min_null_prediction["score"] > feature_null_score:
                 min_null_prediction = {
                     "offsets": (0, 0),
                     "score": feature_null_score,
@@ -149,9 +123,7 @@ def postprocess_qa_predictions(
                 }
 
             # Go through all possibilities for the `n_best_size` greater start and end logits.
-            start_indexes = np.argsort(start_logits)[
-                -1 : -n_best_size - 1 : -1
-            ].tolist()
+            start_indexes = np.argsort(start_logits)[-1 : -n_best_size - 1 : -1].tolist()
             end_indexes = np.argsort(end_logits)[-1 : -n_best_size - 1 : -1].tolist()
             for start_index in start_indexes:
                 for end_index in end_indexes:
@@ -165,24 +137,15 @@ def postprocess_qa_predictions(
                     ):
                         continue
                     # Don't consider answers with a length that is either < 0 or > max_answer_length.
-                    if (
-                        end_index < start_index
-                        or end_index - start_index + 1 > max_answer_length
-                    ):
+                    if end_index < start_index or end_index - start_index + 1 > max_answer_length:
                         continue
                     # Don't consider answer that don't have the maximum context available (if such information is
                     # provided).
-                    if (
-                        token_is_max_context is not None
-                        and not token_is_max_context.get(str(start_index), False)
-                    ):
+                    if token_is_max_context is not None and not token_is_max_context.get(str(start_index), False):
                         continue
                     prelim_predictions.append(
                         {
-                            "offsets": (
-                                offset_mapping[start_index][0],
-                                offset_mapping[end_index][1],
-                            ),
+                            "offsets": (offset_mapping[start_index][0], offset_mapping[end_index][1]),
                             "score": start_logits[start_index] + end_logits[end_index],
                             "start_logit": start_logits[start_index],
                             "end_logit": end_logits[end_index],
@@ -194,14 +157,10 @@ def postprocess_qa_predictions(
             null_score = min_null_prediction["score"]
 
         # Only keep the best `n_best_size` predictions.
-        predictions = sorted(
-            prelim_predictions, key=lambda x: x["score"], reverse=True
-        )[:n_best_size]
+        predictions = sorted(prelim_predictions, key=lambda x: x["score"], reverse=True)[:n_best_size]
 
         # Add back the minimum null prediction if it was removed because of its low score.
-        if version_2_with_negative and not any(
-            p["offsets"] == (0, 0) for p in predictions
-        ):
+        if version_2_with_negative and not any(p["offsets"] == (0, 0) for p in predictions):
             predictions.append(min_null_prediction)
 
         # Use the offsets to gather the answer text in the original context.
@@ -212,12 +171,8 @@ def postprocess_qa_predictions(
 
         # In the very rare edge case we have not a single non-null prediction, we create a fake prediction to avoid
         # failure.
-        if len(predictions) == 0 or (
-            len(predictions) == 1 and predictions[0]["text"] == ""
-        ):
-            predictions.insert(
-                0, {"text": "empty", "start_logit": 0.0, "end_logit": 0.0, "score": 0.0}
-            )
+        if len(predictions) == 0 or (len(predictions) == 1 and predictions[0]["text"] == ""):
+            predictions.insert(0, {"text": "empty", "start_logit": 0.0, "end_logit": 0.0, "score": 0.0})
 
         # Compute the softmax of all scores (we do it with numpy to stay independent from torch/tf in this file, using
         # the LogSumExp trick).
@@ -240,14 +195,8 @@ def postprocess_qa_predictions(
             best_non_null_pred = predictions[i]
 
             # Then we compare to the null prediction using the threshold.
-            score_diff = (
-                null_score
-                - best_non_null_pred["start_logit"]
-                - best_non_null_pred["end_logit"]
-            )
-            scores_diff_json[example["id"]] = float(
-                score_diff
-            )  # To be JSON-serializable.
+            score_diff = null_score - best_non_null_pred["start_logit"] - best_non_null_pred["end_logit"]
+            scores_diff_json[example["id"]] = float(score_diff)  # To be JSON-serializable.
             if score_diff > null_score_diff_threshold:
                 all_predictions[example["id"]] = ""
             else:
@@ -255,14 +204,7 @@ def postprocess_qa_predictions(
 
         # Make `predictions` JSON-serializable by casting np.float back to float.
         all_nbest_json[example["id"]] = [
-            {
-                k: (
-                    float(v)
-                    if isinstance(v, (np.float16, np.float32, np.float64))
-                    else v
-                )
-                for k, v in pred.items()
-            }
+            {k: (float(v) if isinstance(v, (np.float16, np.float32, np.float64)) else v) for k, v in pred.items()}
             for pred in predictions
         ]
 
@@ -271,19 +213,14 @@ def postprocess_qa_predictions(
         assert os.path.isdir(output_dir), f"{output_dir} is not a directory."
 
         prediction_file = os.path.join(
-            output_dir,
-            "predictions.json" if prefix is None else f"predictions_{prefix}".json,
+            output_dir, "predictions.json" if prefix is None else f"predictions_{prefix}".json
         )
         nbest_file = os.path.join(
-            output_dir,
-            "nbest_predictions.json"
-            if prefix is None
-            else f"nbest_predictions_{prefix}".json,
+            output_dir, "nbest_predictions.json" if prefix is None else f"nbest_predictions_{prefix}".json
         )
         if version_2_with_negative:
             null_odds_file = os.path.join(
-                output_dir,
-                "null_odds.json" if prefix is None else f"null_odds_{prefix}".json,
+                output_dir, "null_odds.json" if prefix is None else f"null_odds_{prefix}".json
             )
 
         logger.info(f"Saving predictions to {prediction_file}.")
@@ -344,13 +281,7 @@ def postprocess_qa_predictions_with_beam_search(
             Whether this process is the main process or not (used to determine if logging/saves should be done).
     """
     assert len(predictions) == 5, "`predictions` should be a tuple with five elements."
-    (
-        start_top_log_probs,
-        start_top_index,
-        end_top_log_probs,
-        end_top_index,
-        cls_logits,
-    ) = predictions
+    start_top_log_probs, start_top_index, end_top_log_probs, end_top_index, cls_logits = predictions
 
     assert len(predictions[0]) == len(
         features
@@ -369,9 +300,7 @@ def postprocess_qa_predictions_with_beam_search(
 
     # Logging.
     logger.setLevel(logging.INFO if is_world_process_zero else logging.WARN)
-    logger.info(
-        f"Post-processing {len(examples)} example predictions split into {len(features)} features."
-    )
+    logger.info(f"Post-processing {len(examples)} example predictions split into {len(features)} features.")
 
     # Let's loop over all the examples!
     for example_index, example in enumerate(tqdm(examples)):
@@ -394,9 +323,7 @@ def postprocess_qa_predictions_with_beam_search(
             offset_mapping = features[feature_index]["offset_mapping"]
             # Optional `token_is_max_context`, if provided we will remove answers that do not have the maximum context
             # available in the current feature.
-            token_is_max_context = features[feature_index].get(
-                "token_is_max_context", None
-            )
+            token_is_max_context = features[feature_index].get("token_is_max_context", None)
 
             # Update minimum null prediction
             if min_null_score is None or feature_null_score < min_null_score:
@@ -418,24 +345,15 @@ def postprocess_qa_predictions_with_beam_search(
                     ):
                         continue
                     # Don't consider answers with a length negative or > max_answer_length.
-                    if (
-                        end_index < start_index
-                        or end_index - start_index + 1 > max_answer_length
-                    ):
+                    if end_index < start_index or end_index - start_index + 1 > max_answer_length:
                         continue
                     # Don't consider answer that don't have the maximum context available (if such information is
                     # provided).
-                    if (
-                        token_is_max_context is not None
-                        and not token_is_max_context.get(str(start_index), False)
-                    ):
+                    if token_is_max_context is not None and not token_is_max_context.get(str(start_index), False):
                         continue
                     prelim_predictions.append(
                         {
-                            "offsets": (
-                                offset_mapping[start_index][0],
-                                offset_mapping[end_index][1],
-                            ),
+                            "offsets": (offset_mapping[start_index][0], offset_mapping[end_index][1]),
                             "score": start_log_prob[i] + end_log_prob[j_index],
                             "start_log_prob": start_log_prob[i],
                             "end_log_prob": end_log_prob[j_index],
@@ -443,9 +361,7 @@ def postprocess_qa_predictions_with_beam_search(
                     )
 
         # Only keep the best `n_best_size` predictions.
-        predictions = sorted(
-            prelim_predictions, key=lambda x: x["score"], reverse=True
-        )[:n_best_size]
+        predictions = sorted(prelim_predictions, key=lambda x: x["score"], reverse=True)[:n_best_size]
 
         # Use the offsets to gather the answer text in the original context.
         context = example["context"]
@@ -456,10 +372,7 @@ def postprocess_qa_predictions_with_beam_search(
         # In the very rare edge case we have not a single non-null prediction, we create a fake prediction to avoid
         # failure.
         if len(predictions) == 0:
-            predictions.insert(
-                0,
-                {"text": "", "start_logit": -1e-6, "end_logit": -1e-6, "score": -2e-6},
-            )
+            predictions.insert(0, {"text": "", "start_logit": -1e-6, "end_logit": -1e-6, "score": -2e-6})
 
         # Compute the softmax of all scores (we do it with numpy to stay independent from torch/tf in this file, using
         # the LogSumExp trick).
@@ -478,14 +391,7 @@ def postprocess_qa_predictions_with_beam_search(
 
         # Make `predictions` JSON-serializable by casting np.float back to float.
         all_nbest_json[example["id"]] = [
-            {
-                k: (
-                    float(v)
-                    if isinstance(v, (np.float16, np.float32, np.float64))
-                    else v
-                )
-                for k, v in pred.items()
-            }
+            {k: (float(v) if isinstance(v, (np.float16, np.float32, np.float64)) else v) for k, v in pred.items()}
             for pred in predictions
         ]
 
@@ -494,19 +400,14 @@ def postprocess_qa_predictions_with_beam_search(
         assert os.path.isdir(output_dir), f"{output_dir} is not a directory."
 
         prediction_file = os.path.join(
-            output_dir,
-            "predictions.json" if prefix is None else f"predictions_{prefix}".json,
+            output_dir, "predictions.json" if prefix is None else f"predictions_{prefix}".json
         )
         nbest_file = os.path.join(
-            output_dir,
-            "nbest_predictions.json"
-            if prefix is None
-            else f"nbest_predictions_{prefix}".json,
+            output_dir, "nbest_predictions.json" if prefix is None else f"nbest_predictions_{prefix}".json
         )
         if version_2_with_negative:
             null_odds_file = os.path.join(
-                output_dir,
-                "null_odds.json" if prefix is None else f"null_odds_{prefix}".json,
+                output_dir, "null_odds.json" if prefix is None else f"null_odds_{prefix}".json
             )
 
         print(f"Saving predictions to {prediction_file}.")

--- a/integrations/transformers/utils_qa.py
+++ b/integrations/transformers/utils_qa.py
@@ -12,6 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Post-processing utilities for question answering.
 """
@@ -71,10 +86,14 @@ def postprocess_qa_predictions(
         is_world_process_zero (:obj:`bool`, `optional`, defaults to :obj:`True`):
             Whether this process is the main process or not (used to determine if logging/saves should be done).
     """
-    assert len(predictions) == 2, "`predictions` should be a tuple with two elements (start_logits, end_logits)."
+    assert (
+        len(predictions) == 2
+    ), "`predictions` should be a tuple with two elements (start_logits, end_logits)."
     all_start_logits, all_end_logits = predictions
 
-    assert len(predictions[0]) == len(features), f"Got {len(predictions[0])} predictions and {len(features)} features."
+    assert len(predictions[0]) == len(
+        features
+    ), f"Got {len(predictions[0])} predictions and {len(features)} features."
 
     # Build a map example to its corresponding features.
     example_id_to_index = {k: i for i, k in enumerate(examples["id"])}
@@ -90,7 +109,9 @@ def postprocess_qa_predictions(
 
     # Logging.
     logger.setLevel(logging.INFO if is_world_process_zero else logging.WARN)
-    logger.info(f"Post-processing {len(examples)} example predictions split into {len(features)} features.")
+    logger.info(
+        f"Post-processing {len(examples)} example predictions split into {len(features)} features."
+    )
 
     # Let's loop over all the examples!
     for example_index, example in enumerate(tqdm(examples)):
@@ -110,11 +131,16 @@ def postprocess_qa_predictions(
             offset_mapping = features[feature_index]["offset_mapping"]
             # Optional `token_is_max_context`, if provided we will remove answers that do not have the maximum context
             # available in the current feature.
-            token_is_max_context = features[feature_index].get("token_is_max_context", None)
+            token_is_max_context = features[feature_index].get(
+                "token_is_max_context", None
+            )
 
             # Update minimum null prediction.
             feature_null_score = start_logits[0] + end_logits[0]
-            if min_null_prediction is None or min_null_prediction["score"] > feature_null_score:
+            if (
+                min_null_prediction is None
+                or min_null_prediction["score"] > feature_null_score
+            ):
                 min_null_prediction = {
                     "offsets": (0, 0),
                     "score": feature_null_score,
@@ -123,7 +149,9 @@ def postprocess_qa_predictions(
                 }
 
             # Go through all possibilities for the `n_best_size` greater start and end logits.
-            start_indexes = np.argsort(start_logits)[-1 : -n_best_size - 1 : -1].tolist()
+            start_indexes = np.argsort(start_logits)[
+                -1 : -n_best_size - 1 : -1
+            ].tolist()
             end_indexes = np.argsort(end_logits)[-1 : -n_best_size - 1 : -1].tolist()
             for start_index in start_indexes:
                 for end_index in end_indexes:
@@ -137,15 +165,24 @@ def postprocess_qa_predictions(
                     ):
                         continue
                     # Don't consider answers with a length that is either < 0 or > max_answer_length.
-                    if end_index < start_index or end_index - start_index + 1 > max_answer_length:
+                    if (
+                        end_index < start_index
+                        or end_index - start_index + 1 > max_answer_length
+                    ):
                         continue
                     # Don't consider answer that don't have the maximum context available (if such information is
                     # provided).
-                    if token_is_max_context is not None and not token_is_max_context.get(str(start_index), False):
+                    if (
+                        token_is_max_context is not None
+                        and not token_is_max_context.get(str(start_index), False)
+                    ):
                         continue
                     prelim_predictions.append(
                         {
-                            "offsets": (offset_mapping[start_index][0], offset_mapping[end_index][1]),
+                            "offsets": (
+                                offset_mapping[start_index][0],
+                                offset_mapping[end_index][1],
+                            ),
                             "score": start_logits[start_index] + end_logits[end_index],
                             "start_logit": start_logits[start_index],
                             "end_logit": end_logits[end_index],
@@ -157,10 +194,14 @@ def postprocess_qa_predictions(
             null_score = min_null_prediction["score"]
 
         # Only keep the best `n_best_size` predictions.
-        predictions = sorted(prelim_predictions, key=lambda x: x["score"], reverse=True)[:n_best_size]
+        predictions = sorted(
+            prelim_predictions, key=lambda x: x["score"], reverse=True
+        )[:n_best_size]
 
         # Add back the minimum null prediction if it was removed because of its low score.
-        if version_2_with_negative and not any(p["offsets"] == (0, 0) for p in predictions):
+        if version_2_with_negative and not any(
+            p["offsets"] == (0, 0) for p in predictions
+        ):
             predictions.append(min_null_prediction)
 
         # Use the offsets to gather the answer text in the original context.
@@ -171,8 +212,12 @@ def postprocess_qa_predictions(
 
         # In the very rare edge case we have not a single non-null prediction, we create a fake prediction to avoid
         # failure.
-        if len(predictions) == 0 or (len(predictions) == 1 and predictions[0]["text"] == ""):
-            predictions.insert(0, {"text": "empty", "start_logit": 0.0, "end_logit": 0.0, "score": 0.0})
+        if len(predictions) == 0 or (
+            len(predictions) == 1 and predictions[0]["text"] == ""
+        ):
+            predictions.insert(
+                0, {"text": "empty", "start_logit": 0.0, "end_logit": 0.0, "score": 0.0}
+            )
 
         # Compute the softmax of all scores (we do it with numpy to stay independent from torch/tf in this file, using
         # the LogSumExp trick).
@@ -195,8 +240,14 @@ def postprocess_qa_predictions(
             best_non_null_pred = predictions[i]
 
             # Then we compare to the null prediction using the threshold.
-            score_diff = null_score - best_non_null_pred["start_logit"] - best_non_null_pred["end_logit"]
-            scores_diff_json[example["id"]] = float(score_diff)  # To be JSON-serializable.
+            score_diff = (
+                null_score
+                - best_non_null_pred["start_logit"]
+                - best_non_null_pred["end_logit"]
+            )
+            scores_diff_json[example["id"]] = float(
+                score_diff
+            )  # To be JSON-serializable.
             if score_diff > null_score_diff_threshold:
                 all_predictions[example["id"]] = ""
             else:
@@ -204,7 +255,14 @@ def postprocess_qa_predictions(
 
         # Make `predictions` JSON-serializable by casting np.float back to float.
         all_nbest_json[example["id"]] = [
-            {k: (float(v) if isinstance(v, (np.float16, np.float32, np.float64)) else v) for k, v in pred.items()}
+            {
+                k: (
+                    float(v)
+                    if isinstance(v, (np.float16, np.float32, np.float64))
+                    else v
+                )
+                for k, v in pred.items()
+            }
             for pred in predictions
         ]
 
@@ -213,14 +271,19 @@ def postprocess_qa_predictions(
         assert os.path.isdir(output_dir), f"{output_dir} is not a directory."
 
         prediction_file = os.path.join(
-            output_dir, "predictions.json" if prefix is None else f"predictions_{prefix}".json
+            output_dir,
+            "predictions.json" if prefix is None else f"predictions_{prefix}".json,
         )
         nbest_file = os.path.join(
-            output_dir, "nbest_predictions.json" if prefix is None else f"nbest_predictions_{prefix}".json
+            output_dir,
+            "nbest_predictions.json"
+            if prefix is None
+            else f"nbest_predictions_{prefix}".json,
         )
         if version_2_with_negative:
             null_odds_file = os.path.join(
-                output_dir, "null_odds.json" if prefix is None else f"null_odds_{prefix}".json
+                output_dir,
+                "null_odds.json" if prefix is None else f"null_odds_{prefix}".json,
             )
 
         logger.info(f"Saving predictions to {prediction_file}.")
@@ -281,7 +344,13 @@ def postprocess_qa_predictions_with_beam_search(
             Whether this process is the main process or not (used to determine if logging/saves should be done).
     """
     assert len(predictions) == 5, "`predictions` should be a tuple with five elements."
-    start_top_log_probs, start_top_index, end_top_log_probs, end_top_index, cls_logits = predictions
+    (
+        start_top_log_probs,
+        start_top_index,
+        end_top_log_probs,
+        end_top_index,
+        cls_logits,
+    ) = predictions
 
     assert len(predictions[0]) == len(
         features
@@ -300,7 +369,9 @@ def postprocess_qa_predictions_with_beam_search(
 
     # Logging.
     logger.setLevel(logging.INFO if is_world_process_zero else logging.WARN)
-    logger.info(f"Post-processing {len(examples)} example predictions split into {len(features)} features.")
+    logger.info(
+        f"Post-processing {len(examples)} example predictions split into {len(features)} features."
+    )
 
     # Let's loop over all the examples!
     for example_index, example in enumerate(tqdm(examples)):
@@ -323,7 +394,9 @@ def postprocess_qa_predictions_with_beam_search(
             offset_mapping = features[feature_index]["offset_mapping"]
             # Optional `token_is_max_context`, if provided we will remove answers that do not have the maximum context
             # available in the current feature.
-            token_is_max_context = features[feature_index].get("token_is_max_context", None)
+            token_is_max_context = features[feature_index].get(
+                "token_is_max_context", None
+            )
 
             # Update minimum null prediction
             if min_null_score is None or feature_null_score < min_null_score:
@@ -345,15 +418,24 @@ def postprocess_qa_predictions_with_beam_search(
                     ):
                         continue
                     # Don't consider answers with a length negative or > max_answer_length.
-                    if end_index < start_index or end_index - start_index + 1 > max_answer_length:
+                    if (
+                        end_index < start_index
+                        or end_index - start_index + 1 > max_answer_length
+                    ):
                         continue
                     # Don't consider answer that don't have the maximum context available (if such information is
                     # provided).
-                    if token_is_max_context is not None and not token_is_max_context.get(str(start_index), False):
+                    if (
+                        token_is_max_context is not None
+                        and not token_is_max_context.get(str(start_index), False)
+                    ):
                         continue
                     prelim_predictions.append(
                         {
-                            "offsets": (offset_mapping[start_index][0], offset_mapping[end_index][1]),
+                            "offsets": (
+                                offset_mapping[start_index][0],
+                                offset_mapping[end_index][1],
+                            ),
                             "score": start_log_prob[i] + end_log_prob[j_index],
                             "start_log_prob": start_log_prob[i],
                             "end_log_prob": end_log_prob[j_index],
@@ -361,7 +443,9 @@ def postprocess_qa_predictions_with_beam_search(
                     )
 
         # Only keep the best `n_best_size` predictions.
-        predictions = sorted(prelim_predictions, key=lambda x: x["score"], reverse=True)[:n_best_size]
+        predictions = sorted(
+            prelim_predictions, key=lambda x: x["score"], reverse=True
+        )[:n_best_size]
 
         # Use the offsets to gather the answer text in the original context.
         context = example["context"]
@@ -372,7 +456,10 @@ def postprocess_qa_predictions_with_beam_search(
         # In the very rare edge case we have not a single non-null prediction, we create a fake prediction to avoid
         # failure.
         if len(predictions) == 0:
-            predictions.insert(0, {"text": "", "start_logit": -1e-6, "end_logit": -1e-6, "score": -2e-6})
+            predictions.insert(
+                0,
+                {"text": "", "start_logit": -1e-6, "end_logit": -1e-6, "score": -2e-6},
+            )
 
         # Compute the softmax of all scores (we do it with numpy to stay independent from torch/tf in this file, using
         # the LogSumExp trick).
@@ -391,7 +478,14 @@ def postprocess_qa_predictions_with_beam_search(
 
         # Make `predictions` JSON-serializable by casting np.float back to float.
         all_nbest_json[example["id"]] = [
-            {k: (float(v) if isinstance(v, (np.float16, np.float32, np.float64)) else v) for k, v in pred.items()}
+            {
+                k: (
+                    float(v)
+                    if isinstance(v, (np.float16, np.float32, np.float64))
+                    else v
+                )
+                for k, v in pred.items()
+            }
             for pred in predictions
         ]
 
@@ -400,14 +494,19 @@ def postprocess_qa_predictions_with_beam_search(
         assert os.path.isdir(output_dir), f"{output_dir} is not a directory."
 
         prediction_file = os.path.join(
-            output_dir, "predictions.json" if prefix is None else f"predictions_{prefix}".json
+            output_dir,
+            "predictions.json" if prefix is None else f"predictions_{prefix}".json,
         )
         nbest_file = os.path.join(
-            output_dir, "nbest_predictions.json" if prefix is None else f"nbest_predictions_{prefix}".json
+            output_dir,
+            "nbest_predictions.json"
+            if prefix is None
+            else f"nbest_predictions_{prefix}".json,
         )
         if version_2_with_negative:
             null_odds_file = os.path.join(
-                output_dir, "null_odds.json" if prefix is None else f"null_odds_{prefix}".json
+                output_dir,
+                "null_odds.json" if prefix is None else f"null_odds_{prefix}".json,
             )
 
         print(f"Saving predictions to {prediction_file}.")

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ ensure_newline_before_comments = True
 force_grid_wrap = 0
 include_trailing_comma = True
 known_first_party = sparseml,sparsezoo,tests
-known_third_party = bs4,requests,packaging,yaml,tqdm,numpy,onnx,onnxruntime,pandas,PIL,psutil,scipy,toposort,pytest,torch,torchvision,keras,tensorflow,merge-args,cv2
+known_third_party = bs4,requests,packaging,yaml,tqdm,numpy,onnx,onnxruntime,pandas,PIL,psutil,pydantic,scipy,toposort,pytest,torch,torchvision,keras,tensorflow,merge-args,cv2
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 line_length = 88

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ if _NIGHTLY:
 _deps = [
     "jupyter>=1.0.0",
     "ipywidgets>=7.0.0",
+    "pydantic>=1.0.0",
     "pyyaml>=5.0.0",
     "progressbar2>=3.0.0",
     "numpy>=1.0.0",
@@ -80,10 +81,11 @@ _dev_deps = [
     "sphinx-copybutton>=0.3.0",
     "sphinx-markdown-tables>=0.0.15",
     "sphinx-multiversion==0.2.4",
+    "sphinx-pydantic>=0.1.0",
+    "sphinx-rtd-theme>=0.5.0",
     "wheel>=0.36.2",
     "pytest>=6.0.0",
     "flaky>=3.0.0",
-    "sphinx-rtd-theme",
 ]
 
 

--- a/src/sparseml/__init__.py
+++ b/src/sparseml/__init__.py
@@ -19,7 +19,10 @@ Tooling to help train, test, and optimize models for better performance
 # flake8: noqa
 # isort: skip_file
 
+# be sure to import all logging first and at the root
+# this keeps other loggers in nested files creating from the root logger setups
 from .log import *
+
 from .version import *
 
 from .base import (

--- a/src/sparseml/__init__.py
+++ b/src/sparseml/__init__.py
@@ -19,6 +19,7 @@ Tooling to help train, test, and optimize models for better performance
 # flake8: noqa
 # isort: skip_file
 
+from .log import *
 from .version import *
 
 from .base import (
@@ -27,7 +28,5 @@ from .base import (
     detect_framework,
     execute_in_sparseml_framework,
 )
-
-# be sure to import all logging first and at the root
-# this keeps other loggers in nested files creating from the root logger setups
-from .log import *
+from .framework import FrameworkInferenceProviderInfo, FrameworkInfo, framework_info
+from .sparsification import sparsification_info

--- a/src/sparseml/base.py
+++ b/src/sparseml/base.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import importlib
+import logging
+from enum import Enum
+from typing import Any, Optional
+
+import pkg_resources
+
+
+__all__ = [
+    "Framework",
+    "detect_framework",
+    "execute_in_sparseml_framework",
+    "get_version",
+    "check_version",
+]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Framework(Enum):
+    """
+    Framework types known of/supported within the sparseml/deepsparse ecosystem
+    """
+
+    unknown = "unknown"
+    deepsparse = "deepsparse"
+    onnx = "onnx"
+    keras = "keras"
+    pytorch = "pytorch"
+    tensorflow_v1 = "tensorflow_v1"
+
+
+def detect_framework(item: Any) -> Framework:
+    """
+    Detect the supported ML framework for a given item.
+    Supported input types are the following:
+
+    - A Framework enum
+    - A string of any case representing the name of the framework
+      (deepsparse, onnx, keras, pytorch, tensorflow_v1)
+    - A supported file type within the framework such as model files:
+      (onnx, pth, h5, pb)
+    - An object from a supported ML framework such as a model instance
+
+    If the framework cannot be determined, will return Framework.unknown
+
+    :param item: The item to detect the ML framework for
+    :type item: Any
+    :return: The detected framework from the given item
+    :rtype: Framework
+    """
+    _LOGGER.debug("detecting framework for %s", item)
+    framework = Framework.unknown
+
+    if isinstance(item, Framework):
+        _LOGGER.debug("framework detected from Framework instance")
+        framework = item
+    elif isinstance(item, str) and item.lower().strip() in Framework.__members__:
+        _LOGGER.debug("framework detected from Framework string instance")
+        framework = Framework[item.lower().strip()]
+    else:
+        _LOGGER.debug("detecting framework by calling into supported frameworks")
+
+        for test in Framework:
+            try:
+                framework = execute_in_sparseml_framework(
+                    test, "detect_framework", item
+                )
+            except Exception as err:
+                # errors are expected if the framework is not installed, log as debug
+                _LOGGER.debug(f"error while calling detect_framework for {test}: {err}")
+
+            if framework != Framework.unknown:
+                break
+
+    _LOGGER.info("detected framework of %s from %s", framework, item)
+
+    return framework
+
+
+def execute_in_sparseml_framework(
+    framework: Framework, function_name: str, *args, **kwargs
+) -> Any:
+    """
+    Execute a general function that is callable from the root of the frameworks
+    package under SparseML such as sparseml.pytorch.
+    Useful for benchmarking, analyzing, etc.
+    Will pass the args and kwargs to the callable function.
+
+    :param framework: The ML framework to run the function under in SparseML.
+    :type framework: Framework
+    :param function_name: The name of the function in SparseML that should be run
+        with the given args and kwargs.
+    :type function_name: str
+    :param args: Any positional args to be passed into the function.
+    :param kwargs: Any key word args to be passed into the function.
+    :return: The return value from the executed function.
+    :rtype: Any
+    """
+    _LOGGER.debug(
+        "executing function with name %s for framework %s, args %s, kwargs %s",
+        function_name,
+        framework,
+        args,
+        kwargs,
+    )
+
+    if not isinstance(framework, Framework):
+        framework = detect_framework(framework)
+
+    if framework == Framework.unknown:
+        raise ValueError(
+            f"unknown or unsupported framework {framework}, "
+            f"cannot call function {function_name}"
+        )
+
+    try:
+        module = importlib.import_module(f"sparseml.{framework.value}")
+        function = getattr(module, function_name)
+    except Exception as err:
+        raise ValueError(
+            f"could not find function_name {function_name} in framework {framework}: "
+            f"{err}"
+        )
+
+    return function(*args, **kwargs)
+
+
+def get_version(package_name: str, raise_on_error: bool) -> Optional[str]:
+    """
+    :param package_name: The name of the full package, as it would be imported,
+        to get the version for
+    :type package_name: str
+    :param raise_on_error: True to raise an error if package is not installed
+        or couldn't be imported, False to return None
+    :return: the version of the desired package if detected, otherwise raises an error
+    :rtype: str
+    """
+
+    try:
+        current_version: str = pkg_resources.get_distribution(package_name).version
+    except Exception as err:
+        if raise_on_error:
+            raise ImportError(
+                f"error while getting current version for {package_name}: {err}"
+            )
+
+        return None
+
+    return current_version
+
+
+def check_version(
+    package_name: str,
+    min_version: Optional[str] = None,
+    max_version: Optional[str] = None,
+    raise_on_error: bool = True,
+) -> bool:
+    """
+    :param package_name: the name of the package to check the version of
+    :type package_name: str
+    :param min_version: The minimum version for the package that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for the package that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    :param raise_on_error: True to raise any issues such as not installed,
+        minimum version, or maximum version as ImportError. False to return the result.
+    :type raise_on_error: bool
+    :return: If raise_on_error, will return False if the package is not installed
+        or the version is outside the accepted bounds and True if everything is correct.
+    :rtype: bool
+    """
+    current_version = get_version(package_name, raise_on_error)
+
+    if not current_version:
+        return False
+
+    if min_version and current_version < min_version:
+        if raise_on_error:
+            raise ImportError(
+                f"required min {package_name} version {min_version}, "
+                f"found {current_version}"
+            )
+        return False
+
+    if max_version and current_version > max_version:
+        if raise_on_error:
+            raise ImportError(
+                f"required min {package_name} version {min_version}, "
+                f"found {current_version}"
+            )
+        return False
+
+    return True

--- a/src/sparseml/deepsparse/__init__.py
+++ b/src/sparseml/deepsparse/__init__.py
@@ -12,22 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tooling to help train, test, and optimize models for better performance
-"""
-
 # flake8: noqa
-# isort: skip_file
 
-from .version import *
 
-from .base import (
-    Framework,
-    check_version,
-    detect_framework,
-    execute_in_sparseml_framework,
-)
-
-# be sure to import all logging first and at the root
-# this keeps other loggers in nested files creating from the root logger setups
-from .log import *
+from .framework import detect_framework, framework_info

--- a/src/sparseml/deepsparse/__init__.py
+++ b/src/sparseml/deepsparse/__init__.py
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Functionality for working with and sparsifying Models in the DeepSparse framework
+"""
+
 # flake8: noqa
 
-
-from .framework import detect_framework, framework_info
+from .base import (
+    check_deepsparse_install,
+    deepsparse,
+    deepsparse_err,
+    require_deepsparse,
+)
+from .framework import detect_framework, framework_info, is_supported
+from .sparsification import sparsification_info

--- a/src/sparseml/deepsparse/base.py
+++ b/src/sparseml/deepsparse/base.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import functools
+from typing import Optional
+
+from sparseml.base import check_version
+
+
+try:
+    import deepsparse
+
+    deepsparse_err = None
+except Exception as err:
+    deepsparse = object()  # TODO: populate with fake object for necessary imports
+    deepsparse_err = err
+
+
+__all__ = [
+    "deepsparse",
+    "deepsparse_err",
+    "check_deepsparse_install",
+    "require_deepsparse",
+]
+
+
+def check_deepsparse_install(
+    min_version: Optional[int] = None,
+    max_version: Optional[int] = None,
+    raise_on_error: bool = True,
+) -> bool:
+    """
+    Check that the deepsparse package is installed.
+    If raise_on_error, will raise an ImportError if it is not installed or
+    the required version range, if set, is not installed.
+    If not raise_on_error, will return True if installed with required version
+    and False otherwise.
+
+    :param min_version: The minimum version for deepsparse that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for deepsparse that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    :param raise_on_error: True to raise any issues such as not installed,
+        minimum version, or maximum version as ImportError. False to return the result.
+    :type raise_on_error: bool
+    :return: If raise_on_error, will return False if deepsparse is not installed
+        or the version is outside the accepted bounds and True if everything is correct.
+    :rtype: bool
+    """
+    if deepsparse_err is not None:
+        if raise_on_error:
+            raise deepsparse_err
+        return False
+
+    return check_version("deepsparse", min_version, max_version, raise_on_error)
+
+
+def require_deepsparse(
+    min_version: Optional[int] = None, max_version: Optional[int] = None
+):
+    """
+    Decorator function to require use of deepsparse.
+    Will check that deepsparse package is installed and within the bounding
+    ranges of min_version and max_version if they are set before calling
+    the wrapped function.
+    See :func:`check_deepsparse_install` for more info.
+
+    param min_version: The minimum version for deepsparse that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for deepsparse that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    """
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            check_deepsparse_install(min_version, max_version)
+
+            return func(*args, **kwargs)
+
+        return _wrapper
+
+    return _decorator

--- a/src/sparseml/deepsparse/base.py
+++ b/src/sparseml/deepsparse/base.py
@@ -37,8 +37,8 @@ __all__ = [
 
 
 def check_deepsparse_install(
-    min_version: Optional[int] = None,
-    max_version: Optional[int] = None,
+    min_version: Optional[str] = None,
+    max_version: Optional[str] = None,
     raise_on_error: bool = True,
 ) -> bool:
     """

--- a/src/sparseml/deepsparse/framework/__init__.py
+++ b/src/sparseml/deepsparse/framework/__init__.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Functionality related to integrating with, detecting, and getting information for
+support and sparsification in the DeepSparse framework.
+"""
+
 # flake8: noqa
 
 from .info import *

--- a/src/sparseml/deepsparse/framework/__init__.py
+++ b/src/sparseml/deepsparse/framework/__init__.py
@@ -12,22 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tooling to help train, test, and optimize models for better performance
-"""
-
 # flake8: noqa
-# isort: skip_file
 
-from .version import *
-
-from .base import (
-    Framework,
-    check_version,
-    detect_framework,
-    execute_in_sparseml_framework,
-)
-
-# be sure to import all logging first and at the root
-# this keeps other loggers in nested files creating from the root logger setups
-from .log import *
+from .info import *

--- a/src/sparseml/deepsparse/framework/info.py
+++ b/src/sparseml/deepsparse/framework/info.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any
+
+from sparseml.base import Framework, get_version
+from sparseml.deepsparse.base import check_deepsparse_install
+from sparseml.deepsparse.sparsification import sparsification_info
+from sparseml.framework import FrameworkInferenceProviderInfo, FrameworkInfo
+from sparseml.sparsification import SparsificationInfo
+from sparsezoo import File, Model
+
+
+__all__ = ["is_supported", "detect_framework", "framework_info"]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def is_supported(item: Any) -> bool:
+    """
+
+    :param item: The item to detect the support for
+    :type item: Any
+    :return: True if the item is supported by deepsparse, False otherwise
+    :rtype: bool
+    """
+    framework = detect_framework(item)
+
+    return framework == Framework.deepsparse
+
+
+def detect_framework(item: Any) -> Framework:
+    """
+    Detect the supported ML framework for a given item specifically for the
+    deepsparse package.
+    Supported input types are the following:
+
+    - A Framework enum
+    - A string of any case representing the name of the framework
+      (deepsparse, onnx, keras, pytorch, tensorflow_v1)
+    - A supported file type within the framework such as model files:
+      (onnx, pth, h5, pb)
+    - An object from a supported ML framework such as a model instance
+
+    If the framework cannot be determined, will return Framework.unknown
+
+    :param item: The item to detect the ML framework for
+    :type item: Any
+    :return: The detected framework from the given item
+    :rtype: Framework
+    """
+    framework = Framework.unknown
+
+    if isinstance(item, Framework):
+        _LOGGER.debug("framework detected from Framework instance")
+        framework = item
+    elif isinstance(item, str) and item.lower().strip() in Framework.__members__:
+        _LOGGER.debug("framework detected from Framework string instance")
+        framework = Framework[item.lower().strip()]
+    elif (
+        isinstance(item, str)
+        and "deepsparse" in item.lower().strip()
+        or "deep sparse" in item.lower().strip()
+    ):
+        _LOGGER.debug("framework detected from deepsparse text")
+        # string, check if it's a string saying deepsparse first
+        framework = Framework.deepsparse
+    elif isinstance(item, str) and ".onnx" in item.lower().strip():
+        _LOGGER.debug("framework detected from .onnx")
+        # string, check if it's a file url or path that ends with onnx extension
+        framework = Framework.deepsparse
+    elif isinstance(item, Model) or isinstance(item, File):
+        _LOGGER.debug("framework detected from SparseZoo instance")
+        # sparsezoo model/file, deepsparse supports these natively
+        framework = Framework.deepsparse
+
+    return framework
+
+
+def framework_info() -> FrameworkInfo:
+    """
+    Detect the information for the deepsparse framework such as package versions,
+    availability for core actions such as training and inference,
+    sparsification support, and inference provider support.
+
+    :return: The framework info for deepsparse
+    :rtype: FrameworkInfo
+    """
+    cpu_provider = FrameworkInferenceProviderInfo(
+        name="cpu",
+        description=(
+            "Performant CPU provider within DeepSparse specializing in speedup of "
+            "sparsified models using AVX and VNNI instruction sets"
+        ),
+        device="cpu",
+        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        available=check_deepsparse_install(raise_on_error=False),
+        properties={},
+        warnings=[],
+    )
+
+    return FrameworkInfo(
+        framework=Framework.deepsparse,
+        pacakge_version={
+            "deepsparse": get_version(package_name="deepsparse", raise_on_error=False),
+            "sparsezoo": get_version(package_name="sparsezoo", raise_on_error=False),
+            "sparseml": get_version(package_name="sparseml", raise_on_error=False),
+        },
+        sparsification=sparsification_info(),
+        inference_providers=[cpu_provider],
+        training_available=False,
+        sparsification_available=False,
+        exporting_onnx_available=False,
+        inference_available=True,
+    )

--- a/src/sparseml/deepsparse/sparsification/__init__.py
+++ b/src/sparseml/deepsparse/sparsification/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 # Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,22 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tooling to help train, test, and optimize models for better performance
-"""
-
-# flake8: noqa
-# isort: skip_file
-
-from .version import *
-
-from .base import (
-    Framework,
-    check_version,
-    detect_framework,
-    execute_in_sparseml_framework,
-)
-
-# be sure to import all logging first and at the root
-# this keeps other loggers in nested files creating from the root logger setups
-from .log import *
+from .info import *

--- a/src/sparseml/deepsparse/sparsification/__init__.py
+++ b/src/sparseml/deepsparse/sparsification/__init__.py
@@ -14,4 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Functionality related to applying, describing, and supporting sparsification
+algorithms to models within in the DeepSparse framework.
+"""
+
+# flake8: noqa
+
 from .info import *

--- a/src/sparseml/deepsparse/sparsification/info.py
+++ b/src/sparseml/deepsparse/sparsification/info.py
@@ -12,22 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tooling to help train, test, and optimize models for better performance
-"""
+import logging
 
-# flake8: noqa
-# isort: skip_file
+from sparseml.sparsification import SparsificationInfo
 
-from .version import *
 
-from .base import (
-    Framework,
-    check_version,
-    detect_framework,
-    execute_in_sparseml_framework,
-)
+__all__ = ["sparsification_info"]
 
-# be sure to import all logging first and at the root
-# this keeps other loggers in nested files creating from the root logger setups
-from .log import *
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def sparsification_info() -> SparsificationInfo:
+    """
+    Load the available setup for sparsifying model within deepsparse.
+
+    :return: The sparsification info for the deepsparse framework
+    :rtype: SparsificationInfo
+    """
+    _LOGGER.debug("getting sparsification info for deepsparse")
+    info = SparsificationInfo(modifiers=[])
+    _LOGGER.info("retrieved sparsification info for deepsparse: %s", info)
+
+    return info

--- a/src/sparseml/framework/__init__.py
+++ b/src/sparseml/framework/__init__.py
@@ -12,22 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tooling to help train, test, and optimize models for better performance
-"""
-
 # flake8: noqa
-# isort: skip_file
 
-from .version import *
-
-from .base import (
-    Framework,
-    check_version,
-    detect_framework,
-    execute_in_sparseml_framework,
-)
-
-# be sure to import all logging first and at the root
-# this keeps other loggers in nested files creating from the root logger setups
-from .log import *
+from .info import *

--- a/src/sparseml/framework/info.py
+++ b/src/sparseml/framework/info.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Functions and classes for detecting and working with functionality
+for models within ML frameworks.
+"""
+
+import logging
+from collections import OrderedDict
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+from sparseml.base import Framework, detect_framework, execute_in_sparseml_framework
+from sparseml.sparsification.info import SparsificationInfo
+
+
+__all__ = [
+    "FrameworkInferenceProviderInfo",
+    "FrameworkInfo",
+    "framework_info",
+]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FrameworkInferenceProviderInfo(BaseModel):
+    """
+    Class for storing information for an inference provider within a frameworks engine.
+    For example, the gpu provider within PyTorch.
+
+    Extends pydantics BaseModel class for serialization to and from json
+    in addition to proper type checking on construction.
+    """
+
+    name: str = Field(title="name", description="The name/id of the provider.")
+    description: str = Field(
+        title="description",
+        description="A description for the provider to offer more detail.",
+    )
+    device: str = Field(
+        title="device", description="The device the provider is for such as cpu or gpu."
+    )
+    supported_sparsification: SparsificationInfo = Field(
+        title="supported_sparsification",
+        description=(
+            "The supported sparsification information for support "
+            "for inference speedup in the provider."
+        ),
+    )
+
+    available: bool = Field(
+        default=False,
+        title="available",
+        description="True if the provider is available on the system, False otherwise.",
+    )
+    properties: Dict[str, Any] = Field(
+        default=OrderedDict(),
+        title="properties",
+        description="Any properties for the given provider.",
+    )
+    warnings: List[str] = Field(
+        default=[],
+        title="warnings",
+        description="Any warnings/restrictions for the provider on the given system.",
+    )
+
+
+class FrameworkInfo(BaseModel):
+    """
+    Class for storing the information for an ML frameworks info and availability
+    on the current system.
+
+    Extends pydantics BaseModel class for serialization to and from json
+    in addition to proper type checking on construction.
+    """
+
+    framework: Framework = Field(
+        title="framework", description="The framework the system info is for."
+    )
+    package_versions: Dict[str, str] = Field(
+        title="package_versions",
+        description=(
+            "A mapping of the package and supporting packages for a given framework "
+            "to the detected versions on the system currently. "
+            "If the package is not detected, will be set to 'not detected'."
+        ),
+    )
+    sparsification: SparsificationInfo = Field(
+        title="sparsification",
+        description=(
+            "True if inference for a model is available on the system "
+            "for the given framework, False otherwise."
+        ),
+    )
+    inference_providers: List[FrameworkInferenceProviderInfo] = Field(
+        title="inference_providers",
+        description=(
+            "True if inference for a model is available on the system "
+            "for the given framework, False otherwise."
+        ),
+    )
+
+    training_available: bool = Field(
+        default=False,
+        title="training_available",
+        description=(
+            "True if training/editing a model is available on the system "
+            "for the given framework, False otherwise."
+        ),
+    )
+    sparsification_available: bool = Field(
+        default=False,
+        title="sparsification_available",
+        description=(
+            "True if sparsifying a model is available on the system "
+            "for the given framework, False otherwise."
+        ),
+    )
+    exporting_onnx_available: bool = Field(
+        default=False,
+        title="exporting_onnx_available",
+        description=(
+            "True if exporting a model in the ONNX format is available on the system "
+            "for the given framework, False otherwise."
+        ),
+    )
+    inference_available: bool = Field(
+        default=False,
+        title="inference_available",
+        description=(
+            "True if inference for a model is available on the system "
+            "for the given framework, False otherwise."
+        ),
+    )
+
+
+def framework_info(framework: Any) -> FrameworkInfo:
+    """
+    Detect the information for the given ML framework such as package versions,
+    availability for core actions such as training and inference,
+    sparsification support, and inference provider support.
+
+    :param framework: The item to detect the ML framework for.
+        See :func:`detect_framework` for more information.
+    :type framework: Any
+    :return: The framework info for the given framework
+    :rtype: FrameworkInfo
+    """
+    _LOGGER.debug("getting system info for framework %s", framework)
+    info: FrameworkInfo = execute_in_sparseml_framework(framework, "framework_info")
+    _LOGGER.info("retrieved system info for framework %s: %s", framework, info)
+
+    return info

--- a/src/sparseml/framework/info.py
+++ b/src/sparseml/framework/info.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 """
-Functions and classes for detecting and working with functionality
-for models within ML frameworks.
+Functionality related to integrating with, detecting, and getting information for
+support and sparsification in ML frameworks.
 """
 
 import logging
 from collections import OrderedDict
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -91,12 +91,12 @@ class FrameworkInfo(BaseModel):
     framework: Framework = Field(
         title="framework", description="The framework the system info is for."
     )
-    package_versions: Dict[str, str] = Field(
+    package_versions: Dict[str, Optional[str]] = Field(
         title="package_versions",
         description=(
             "A mapping of the package and supporting packages for a given framework "
             "to the detected versions on the system currently. "
-            "If the package is not detected, will be set to 'not detected'."
+            "If the package is not detected, will be set to None."
         ),
     )
     sparsification: SparsificationInfo = Field(
@@ -114,6 +114,11 @@ class FrameworkInfo(BaseModel):
         ),
     )
 
+    properties: Dict[str, Any] = Field(
+        default={},
+        title="properties",
+        description="Any additional properties for the framework.",
+    )
     training_available: bool = Field(
         default=False,
         title="training_available",

--- a/src/sparseml/keras/__init__.py
+++ b/src/sparseml/keras/__init__.py
@@ -13,33 +13,24 @@
 # limitations under the License.
 
 """
-Code for working with the keras framework for creating /
-editing models for performance in the Neural Magic System
+Functionality for working with and sparsifying Models in the Keras framework
 """
 
 # flake8: noqa
 
-try:
-    import tensorflow
+from .base import (
+    check_keras_install,
+    is_native_keras,
+    keras,
+    keras_err,
+    require_keras,
+    tensorflow,
+    tensorflow_err,
+)
 
-    if tensorflow.__version__ < "2.1.0":
-        raise RuntimeError("TensorFlow >= 2.1.0 is required, found {}".format(version))
-except:
-    raise RuntimeError(
-        "Unable to import tensorflow. TensorFlow>=2.1.0 is required"
-        " to use sparseml.keras."
-    )
+
+check_keras_install()  # TODO: remove once files within package load without installs
 
 
-try:
-    import keras
-
-    v = keras.__version__
-    if v < "2.4.3":
-        raise RuntimeError(
-            "Native keras is found and will be used, but required >= 2.4.3, found {}".format(
-                v
-            )
-        )
-except:
-    pass
+from .framework import detect_framework, framework_info, is_supported
+from .sparsification import sparsification_info

--- a/src/sparseml/keras/base.py
+++ b/src/sparseml/keras/base.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import functools
+from typing import Optional
+
+from sparseml.base import check_version
+
+
+try:
+    import keras
+
+    keras_err = None
+    is_native_keras = True
+except Exception as err:
+    keras = object()
+    keras_err = err
+    is_native_keras = False
+
+try:
+    import tensorflow
+
+    tensorflow_err = None
+
+    if keras_err:
+        from tensorflow import keras
+
+        keras_err = None
+except Exception as err:
+    tensorflow = object()  # TODO: populate with fake object for necessary improvements
+    tensorflow_err = err
+
+
+try:
+    import keras2onnx
+
+    keras2onnx_err = None
+except Exception as err:
+    keras2onnx = object()  # TODO: populate with fake object for necessary imports
+    keras2onnx_err = err
+
+
+__all__ = [
+    "keras",
+    "keras_err",
+    "tensorflow",
+    "tensorflow_err",
+    "keras2onnx",
+    "keras2onnx_err",
+    "is_native_keras",
+    "check_keras_install",
+    "check_keras2onnx_install",
+    "require_keras",
+    "require_keras2onnx",
+]
+
+_DEF_TF_MIN_VERSION = "2.1.0"
+_DEF_KERAS_MIN_VERSION = "2.4.3"
+_KERAS2ONNX_MIN_VERSION = "1.0.0"
+
+
+def check_keras_install(
+    min_tf_version: Optional[str] = _DEF_TF_MIN_VERSION,
+    max_tf_version: Optional[str] = None,
+    min_native_version: Optional[str] = _DEF_KERAS_MIN_VERSION,
+    require_tensorflow_backend: bool = True,
+    raise_on_error: bool = True,
+) -> bool:
+    """
+    Check that the keras package is installed.
+    If raise_on_error, will raise an ImportError if it is not installed or
+    the required version range, if set, is not installed.
+    If not raise_on_error, will return True if installed with required version
+    and False otherwise.
+
+    :param min_tf_version: The minimum version for keras that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_tf_version: str
+    :param max_tf_version: The maximum version for keras that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_tf_version: str
+    :param min_native_version: The minimum version for native keras that it must be
+        greater than or equal to if installed
+    :type min_native_version: str
+    :param require_tensorflow_backend: True to require keras to use the tensorflow
+        backend, False otherwise.
+    :type require_tensorflow_backend: bool
+    :param raise_on_error: True to raise any issues such as not installed,
+        minimum version, or maximum version as ImportError. False to return the result.
+    :type raise_on_error: bool
+    :return: If raise_on_error, will return False if keras is not installed
+        or the version is outside the accepted bounds and True if everything is correct.
+    :rtype: bool
+    """
+    if keras_err is not None:
+        if raise_on_error:
+            raise keras_err
+        return False
+
+    if tensorflow_err is not None and require_tensorflow_backend:
+        if raise_on_error:
+            raise tensorflow_err
+        return False
+
+    if require_tensorflow_backend and not check_version(
+        "tensorflow", min_tf_version, max_tf_version, raise_on_error
+    ):
+        return False
+
+    if is_native_keras and not check_version(
+        "keras", min_native_version, None, raise_on_error
+    ):
+        return False
+
+    return True
+
+
+def check_keras2onnx_install(
+    min_version: Optional[str] = _KERAS2ONNX_MIN_VERSION,
+    max_version: Optional[str] = None,
+    raise_on_error: bool = True,
+) -> bool:
+    """
+    Check that the keras2onnx package is installed.
+    If raise_on_error, will raise an ImportError if it is not installed or
+    the required version range, if set, is not installed.
+    If not raise_on_error, will return True if installed with required version
+    and False otherwise.
+
+    :param min_version: The minimum version for keras2onnx that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for keras2onnx that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    :param raise_on_error: True to raise any issues such as not installed,
+        minimum version, or maximum version as ImportError. False to return the result.
+    :type raise_on_error: bool
+    :return: If raise_on_error, will return False if keras2onnx is not installed
+        or the version is outside the accepted bounds and True if everything is correct.
+    :rtype: bool
+    """
+    if keras2onnx_err is not None:
+        if raise_on_error:
+            raise keras2onnx_err
+        return False
+
+    return check_version("keras2onnx", min_version, max_version, raise_on_error)
+
+
+def require_keras(
+    min_tf_version: Optional[str] = _DEF_TF_MIN_VERSION,
+    max_tf_version: Optional[str] = None,
+    min_native_version: Optional[str] = _DEF_KERAS_MIN_VERSION,
+    require_tensorflow_backend: bool = True,
+):
+    """
+    Decorator function to require use of keras.
+    Will check that keras package is installed and within the bounding
+    ranges of min_version and max_version if they are set before calling
+    the wrapped function.
+    See :func:`check_keras_install` for more info.
+
+    :param min_tf_version: The minimum version for keras that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_tf_version: str
+    :param max_tf_version: The maximum version for keras that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_tf_version: str
+    :param min_native_version: The minimum version for native keras that it must be
+        greater than or equal to if installed
+    :type min_native_version: str
+    :param require_tensorflow_backend: True to require keras to use the tensorflow
+        backend, False otherwise.
+    :type require_tensorflow_backend: bool
+    :param require_tensorflow_backend: True to require keras to use the tensorflow
+        backend, False otherwise.
+    :type require_tensorflow_backend: bool
+    """
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            check_keras_install(
+                min_tf_version,
+                max_tf_version,
+                min_native_version,
+                require_tensorflow_backend,
+            )
+
+            return func(*args, **kwargs)
+
+        return _wrapper
+
+    return _decorator
+
+
+def require_keras2onnx(
+    min_version: Optional[int] = _KERAS2ONNX_MIN_VERSION,
+    max_version: Optional[int] = None,
+):
+    """
+    Decorator function to require use of keras2onnx.
+    Will check that keras2onnx package is installed and within the bounding
+    ranges of min_version and max_version if they are set before calling
+    the wrapped function.
+    See :func:`check_keras2onnx_install` for more info.
+
+    param min_version: The minimum version for keras2onnx that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for keras2onnx that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    """
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            check_keras2onnx_install(min_version, max_version)
+
+            return func(*args, **kwargs)
+
+        return _wrapper
+
+    return _decorator

--- a/src/sparseml/keras/framework/__init__.py
+++ b/src/sparseml/keras/framework/__init__.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa
+
 """
-Functionality related to integrating with, detecting, and getting information for
-support and sparsification in ML frameworks.
+Functionality related to detecting and getting information for
+support and sparsification in the Keras framework.
 """
 
 # flake8: noqa

--- a/src/sparseml/keras/sparsification/__init__.py
+++ b/src/sparseml/keras/sparsification/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 # Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +15,8 @@
 # limitations under the License.
 
 """
-Functionality related to integrating with, detecting, and getting information for
-support and sparsification in ML frameworks.
+Functionality related to applying, describing, and supporting sparsification
+algorithms to models within in the Keras framework.
 """
 
 # flake8: noqa

--- a/src/sparseml/keras/sparsification/info.py
+++ b/src/sparseml/keras/sparsification/info.py
@@ -14,7 +14,7 @@
 
 """
 Functionality related to describing availability and information of sparsification
-algorithms to models within in the DeepSparse framework.
+algorithms to models within in the Keras framework.
 """
 
 import logging
@@ -30,13 +30,13 @@ _LOGGER = logging.getLogger(__name__)
 
 def sparsification_info() -> SparsificationInfo:
     """
-    Load the available setup for sparsifying model within deepsparse.
+    Load the available setup for sparsifying model within keras.
 
-    :return: The sparsification info for the deepsparse framework
+    :return: The sparsification info for the keras framework
     :rtype: SparsificationInfo
     """
-    _LOGGER.debug("getting sparsification info for deepsparse")
-    info = SparsificationInfo(modifiers=[])
-    _LOGGER.info("retrieved sparsification info for deepsparse: %s", info)
+    _LOGGER.debug("getting sparsification info for keras")
+    info = SparsificationInfo(modifiers=[])  # TODO: fill in once available
+    _LOGGER.info("retrieved sparsification info for keras: %s", info)
 
     return info

--- a/src/sparseml/onnx/__init__.py
+++ b/src/sparseml/onnx/__init__.py
@@ -13,8 +13,20 @@
 # limitations under the License.
 
 """
-Code for working with the ONNX framework for creating /
-editing models for performance in the Neural Magic System
+Functionality for working with and sparsifying Models in the ONNX/ONNXRuntime framework
 """
 
 # flake8: noqa
+
+from .base import (
+    check_onnx_install,
+    check_onnxruntime_install,
+    onnx,
+    onnx_err,
+    onnxruntime,
+    onnxruntime_err,
+    require_onnx,
+    require_onnxruntime,
+)
+from .framework import detect_framework, framework_info, is_supported
+from .sparsification import sparsification_info

--- a/src/sparseml/onnx/base.py
+++ b/src/sparseml/onnx/base.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import functools
+from typing import Optional
+
+from sparseml.base import check_version
+
+
+try:
+    import onnx
+
+    onnx_err = None
+except Exception as err:
+    onnx = object()  # TODO: populate with fake object for necessary imports
+    onnx_err = err
+
+try:
+    import onnxruntime
+
+    onnxruntime_err = None
+except Exception as err:
+    onnxruntime = object()  # TODO: populate with fake object for necessary imports
+    onnxruntime_err = err
+
+
+__all__ = [
+    "onnx",
+    "onnx_err",
+    "onnxruntime",
+    "onnxruntime_err",
+    "check_onnx_install",
+    "check_onnxruntime_install",
+    "require_onnx",
+    "require_onnxruntime",
+]
+
+
+_ONNX_MIN_VERSION = "1.5.0"
+_ORT_MIN_VERSION = "1.0.0"
+
+
+def check_onnx_install(
+    min_version: Optional[str] = _ONNX_MIN_VERSION,
+    max_version: Optional[str] = None,
+    raise_on_error: bool = True,
+) -> bool:
+    """
+    Check that the onnx package is installed.
+    If raise_on_error, will raise an ImportError if it is not installed or
+    the required version range, if set, is not installed.
+    If not raise_on_error, will return True if installed with required version
+    and False otherwise.
+
+    :param min_version: The minimum version for onnx that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for onnx that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    :param raise_on_error: True to raise any issues such as not installed,
+        minimum version, or maximum version as ImportError. False to return the result.
+    :type raise_on_error: bool
+    :return: If raise_on_error, will return False if onnx is not installed
+        or the version is outside the accepted bounds and True if everything is correct.
+    :rtype: bool
+    """
+    if onnx_err is not None:
+        if raise_on_error:
+            raise onnx_err
+        return False
+
+    return check_version("onnx", min_version, max_version, raise_on_error)
+
+
+def check_onnxruntime_install(
+    min_version: Optional[str] = _ORT_MIN_VERSION,
+    max_version: Optional[str] = None,
+    raise_on_error: bool = True,
+) -> bool:
+    """
+    Check that the onnxruntime package is installed.
+    If raise_on_error, will raise an ImportError if it is not installed or
+    the required version range, if set, is not installed.
+    If not raise_on_error, will return True if installed with required version
+    and False otherwise.
+
+    :param min_version: The minimum version for onnxruntime that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for onnxruntime that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    :param raise_on_error: True to raise any issues such as not installed,
+        minimum version, or maximum version as ImportError. False to return the result.
+    :type raise_on_error: bool
+    :return: If raise_on_error, will return False if onnxruntime is not installed
+        or the version is outside the accepted bounds and True if everything is correct.
+    :rtype: bool
+    """
+    if onnxruntime_err is not None:
+        if raise_on_error:
+            raise onnxruntime_err
+        return False
+
+    return check_version("onnxruntime", min_version, max_version, raise_on_error)
+
+
+def require_onnx(
+    min_version: Optional[int] = _ONNX_MIN_VERSION, max_version: Optional[int] = None
+):
+    """
+    Decorator function to require use of onnx.
+    Will check that onnx package is installed and within the bounding
+    ranges of min_version and max_version if they are set before calling
+    the wrapped function.
+    See :func:`check_onnx_install` for more info.
+
+    param min_version: The minimum version for onnx that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for onnx that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    """
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            check_onnx_install(min_version, max_version)
+
+            return func(*args, **kwargs)
+
+        return _wrapper
+
+    return _decorator
+
+
+def require_onnxruntime(
+    min_version: Optional[int] = _ORT_MIN_VERSION, max_version: Optional[int] = None
+):
+    """
+    Decorator function to require use of onnxruntime.
+    Will check that onnxruntime package is installed and within the bounding
+    ranges of min_version and max_version if they are set before calling
+    the wrapped function.
+    See :func:`check_onnxruntime_install` for more info.
+
+    param min_version: The minimum version for onnxruntime that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for onnxruntime that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    """
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            check_onnxruntime_install(min_version, max_version)
+
+            return func(*args, **kwargs)
+
+        return _wrapper
+
+    return _decorator

--- a/src/sparseml/onnx/framework/__init__.py
+++ b/src/sparseml/onnx/framework/__init__.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa
+
 """
 Functionality related to integrating with, detecting, and getting information for
-support and sparsification in ML frameworks.
+support and sparsification in the ONNX/ONNXRuntime framework.
 """
 
 # flake8: noqa

--- a/src/sparseml/onnx/sparsification/__init__.py
+++ b/src/sparseml/onnx/sparsification/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 # Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +15,8 @@
 # limitations under the License.
 
 """
-Functionality related to integrating with, detecting, and getting information for
-support and sparsification in ML frameworks.
+Functionality related to applying, describing, and supporting sparsification
+algorithms to models within in the ONNX/ONNXRuntime framework.
 """
 
 # flake8: noqa

--- a/src/sparseml/onnx/sparsification/info.py
+++ b/src/sparseml/onnx/sparsification/info.py
@@ -14,7 +14,7 @@
 
 """
 Functionality related to describing availability and information of sparsification
-algorithms to models within in the DeepSparse framework.
+algorithms to models within in the ONNX/ONNXRuntime framework.
 """
 
 import logging
@@ -30,13 +30,13 @@ _LOGGER = logging.getLogger(__name__)
 
 def sparsification_info() -> SparsificationInfo:
     """
-    Load the available setup for sparsifying model within deepsparse.
+    Load the available setup for sparsifying model within keras.
 
-    :return: The sparsification info for the deepsparse framework
+    :return: The sparsification info for the keras framework
     :rtype: SparsificationInfo
     """
-    _LOGGER.debug("getting sparsification info for deepsparse")
-    info = SparsificationInfo(modifiers=[])
-    _LOGGER.info("retrieved sparsification info for deepsparse: %s", info)
+    _LOGGER.debug("getting sparsification info for keras")
+    info = SparsificationInfo(modifiers=[])  # TODO: fill in once available
+    _LOGGER.info("retrieved sparsification info for keras: %s", info)
 
     return info

--- a/src/sparseml/pytorch/__init__.py
+++ b/src/sparseml/pytorch/__init__.py
@@ -13,18 +13,25 @@
 # limitations under the License.
 
 """
-Code for working with the pytorch framework for creating /
-editing models for performance in the Neural Magic System
+Functionality for working with and sparsifying Models in the PyTorch framework
 """
 
 # flake8: noqa
 
-try:
-    import torch
+from .base import (
+    check_torch_install,
+    check_torchvision_install,
+    require_torch,
+    require_torchvision,
+    torch,
+    torch_err,
+    torchvision,
+    torchvision_err,
+)
 
-    if torch.__version__[0] != "1":
-        raise Exception
-except:
-    raise RuntimeError(
-        "Unable to import torch. torch>=1.0.0 is required to use sparseml.pytorch"
-    )
+
+check_torch_install()  # TODO: remove once files within package load without installs
+
+
+from .framework import detect_framework, framework_info, is_supported
+from .sparsification import sparsification_info

--- a/src/sparseml/pytorch/base.py
+++ b/src/sparseml/pytorch/base.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import functools
+from typing import Optional
+
+from sparseml.base import check_version
+
+
+try:
+    import torch
+
+    torch_err = None
+except Exception as err:
+    torch = object()  # TODO: populate with fake object for necessary imports
+    torch_err = err
+
+try:
+    import torchvision
+
+    torchvision_err = None
+except Exception as err:
+    torchvision = object()  # TODO: populate with fake object for necessary imports
+    torchvision_err = err
+
+
+__all__ = [
+    "torch",
+    "torch_err",
+    "torchvision",
+    "torchvision_err",
+    "check_torch_install",
+    "check_torchvision_install",
+    "require_torch",
+    "require_torchvision",
+]
+
+
+_TORCH_MIN_VERSION = "1.0.0"
+_TORCH_MAX_VERSION = "1.7.0"
+
+
+def check_torch_install(
+    min_version: Optional[str] = _TORCH_MIN_VERSION,
+    max_version: Optional[str] = _TORCH_MAX_VERSION,
+    raise_on_error: bool = True,
+) -> bool:
+    """
+    Check that the torch package is installed.
+    If raise_on_error, will raise an ImportError if it is not installed or
+    the required version range, if set, is not installed.
+    If not raise_on_error, will return True if installed with required version
+    and False otherwise.
+
+    :param min_version: The minimum version for torch that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for torch that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    :param raise_on_error: True to raise any issues such as not installed,
+        minimum version, or maximum version as ImportError. False to return the result.
+    :type raise_on_error: bool
+    :return: If raise_on_error, will return False if torch is not installed
+        or the version is outside the accepted bounds and True if everything is correct.
+    :rtype: bool
+    """
+    if torch_err is not None:
+        if raise_on_error:
+            raise torch_err
+        return False
+
+    return check_version("torch", min_version, max_version, raise_on_error)
+
+
+def check_torchvision_install(
+    min_version: Optional[str] = None,
+    max_version: Optional[str] = None,
+    raise_on_error: bool = True,
+) -> bool:
+    """
+    Check that the torchvision package is installed.
+    If raise_on_error, will raise an ImportError if it is not installed or
+    the required version range, if set, is not installed.
+    If not raise_on_error, will return True if installed with required version
+    and False otherwise.
+
+    :param min_version: The minimum version for torchvision that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for torchvision that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    :param raise_on_error: True to raise any issues such as not installed,
+        minimum version, or maximum version as ImportError. False to return the result.
+    :type raise_on_error: bool
+    :return: If raise_on_error, will return False if torchvision is not installed
+        or the version is outside the accepted bounds and True if everything is correct.
+    :rtype: bool
+    """
+    if torchvision_err is not None:
+        if raise_on_error:
+            raise torchvision_err
+        return False
+
+    return check_version("torchvision", min_version, max_version, raise_on_error)
+
+
+def require_torch(
+    min_version: Optional[int] = _TORCH_MIN_VERSION,
+    max_version: Optional[int] = _TORCH_MAX_VERSION,
+):
+    """
+    Decorator function to require use of torch.
+    Will check that torch package is installed and within the bounding
+    ranges of min_version and max_version if they are set before calling
+    the wrapped function.
+    See :func:`check_torch_install` for more info.
+
+    param min_version: The minimum version for torch that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for torch that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    """
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            check_torch_install(min_version, max_version)
+
+            return func(*args, **kwargs)
+
+        return _wrapper
+
+    return _decorator
+
+
+def require_torchvision(
+    min_version: Optional[int] = None, max_version: Optional[int] = None
+):
+    """
+    Decorator function to require use of torchvision.
+    Will check that torchvision package is installed and within the bounding
+    ranges of min_version and max_version if they are set before calling
+    the wrapped function.
+    See :func:`check_torchvision_install` for more info.
+
+    param min_version: The minimum version for torchvision that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for torchvision that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    """
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            check_torchvision_install(min_version, max_version)
+
+            return func(*args, **kwargs)
+
+        return _wrapper
+
+    return _decorator

--- a/src/sparseml/pytorch/framework/__init__.py
+++ b/src/sparseml/pytorch/framework/__init__.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa
+
 """
 Functionality related to integrating with, detecting, and getting information for
-support and sparsification in ML frameworks.
+support and sparsification in the PyTorch framework.
 """
 
 # flake8: noqa

--- a/src/sparseml/pytorch/sparsification/__init__.py
+++ b/src/sparseml/pytorch/sparsification/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 # Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +15,8 @@
 # limitations under the License.
 
 """
-Functionality related to integrating with, detecting, and getting information for
-support and sparsification in ML frameworks.
+Functionality related to applying, describing, and supporting sparsification
+algorithms to models within in the PyTorch framework.
 """
 
 # flake8: noqa

--- a/src/sparseml/pytorch/sparsification/info.py
+++ b/src/sparseml/pytorch/sparsification/info.py
@@ -14,7 +14,7 @@
 
 """
 Functionality related to describing availability and information of sparsification
-algorithms to models within in the DeepSparse framework.
+algorithms to models within in the PyTorch framework.
 """
 
 import logging
@@ -30,13 +30,13 @@ _LOGGER = logging.getLogger(__name__)
 
 def sparsification_info() -> SparsificationInfo:
     """
-    Load the available setup for sparsifying model within deepsparse.
+    Load the available setup for sparsifying model within pytorch.
 
-    :return: The sparsification info for the deepsparse framework
+    :return: The sparsification info for the pytorch framework
     :rtype: SparsificationInfo
     """
-    _LOGGER.debug("getting sparsification info for deepsparse")
-    info = SparsificationInfo(modifiers=[])
-    _LOGGER.info("retrieved sparsification info for deepsparse: %s", info)
+    _LOGGER.debug("getting sparsification info for pytorch")
+    info = SparsificationInfo(modifiers=[])  # TODO: fill in once available
+    _LOGGER.info("retrieved sparsification info for pytorch: %s", info)
 
     return info

--- a/src/sparseml/sparsification/__init__.py
+++ b/src/sparseml/sparsification/__init__.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Functionality related to applying, describing, and supporting sparsification
+algorithms to models within in ML frameworks.
+"""
+
 # flake8: noqa
 
 from .info import *

--- a/src/sparseml/sparsification/__init__.py
+++ b/src/sparseml/sparsification/__init__.py
@@ -12,22 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Tooling to help train, test, and optimize models for better performance
-"""
-
 # flake8: noqa
-# isort: skip_file
 
-from .version import *
-
-from .base import (
-    Framework,
-    check_version,
-    detect_framework,
-    execute_in_sparseml_framework,
-)
-
-# be sure to import all logging first and at the root
-# this keeps other loggers in nested files creating from the root logger setups
-from .log import *
+from .info import *

--- a/src/sparseml/sparsification/info.py
+++ b/src/sparseml/sparsification/info.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from enum import Enum
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, Field
+
+from sparseml.base import detect_framework, execute_in_sparseml_framework
+
+
+__all__ = [
+    "ModifierType",
+    "ModifierPropInfo",
+    "ModifierInfo",
+    "SparsificationInfo",
+    "sparsification_info",
+]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ModifierType(Enum):
+    """
+    Types of modifiers for grouping what functionality a Modifier falls under.
+    """
+
+    general = "general"
+    training = "training"
+    pruning = "pruning"
+    quantization = "quantization"
+    act_sparsity = "act_sparsity"
+    misc = "misc"
+
+
+class ModifierPropInfo(BaseModel):
+    """
+    Class for storing information and associated metadata for a
+    property on a given Modifier.
+
+    Extends pydantics BaseModel class for serialization to and from json
+    in addition to proper type checking on construction.
+    """
+
+    name: str = Field(
+        title="name",
+        description=(
+            "Name of the property for a Modifier. "
+            "It can be accessed by this name on the modifier instance."
+        ),
+    )
+    description: str = Field(
+        title="description",
+        description="Description and information for the property for a Modifier.",
+    )
+    type_: str = Field(
+        title="type_",
+        description=(
+            "The format type for the property for a Modifier such as "
+            "int, float, str, etc."
+        ),
+    )
+    restrictions: Optional[List[Any]] = Field(
+        default=None,
+        title="restrictions",
+        description=(
+            "Value restrictions for the property for a Modifier. "
+            "If set, restrict the set value to one of the contained restrictions."
+        ),
+    )
+
+
+class ModifierInfo(BaseModel):
+    """
+    Class for storing information and associated metadata for a given Modifier.
+
+    Extends pydantics BaseModel class for serialization to and from json
+    in addition to proper type checking on construction.
+    """
+
+    name: str = Field(
+        title="name",
+        description=(
+            "Name/class of the Modifier to be used for construction and identification."
+        ),
+    )
+    description: str = Field(
+        title="description",
+        description="Description and info for the Modifier and what its used for.",
+    )
+    type_: ModifierType = Field(
+        default=ModifierType.misc,
+        title="type_",
+        description=(
+            "The type the given Modifier is for grouping by similar functionality."
+        ),
+    )
+    props: List[ModifierPropInfo] = Field(
+        default=[],
+        title="props",
+        description="The properties for the Modifier that can be set and controlled.",
+    )
+    warnings: Optional[List[str]] = Field(
+        default=None,
+        title="warnings",
+        description=(
+            "Any warnings that apply for the Modifier and using it within a system"
+        ),
+    )
+
+
+class SparsificationInfo(BaseModel):
+    """
+    Class for storing the information for sparsifying in a given framework.
+
+    Extends pydantics BaseModel class for serialization to and from json
+    in addition to proper type checking on construction.
+    """
+
+    modifiers: List[ModifierInfo] = Field(
+        default=[],
+        title="modifiers",
+        description="A list of the information for the available modifiers",
+    )
+
+    def type_modifiers(self, type_: ModifierType) -> List[ModifierInfo]:
+        """
+        Get the contained Modifiers for a specific ModifierType.
+
+        :param type_: The ModifierType to filter the returned list of Modifiers by.
+        :type type_: ModifierType
+        :return: The filtered list of Modifiers that match the given type_.
+        :rtype: List[ModifierInfo]
+        """
+        modifiers = []
+
+        for mod in self.modifiers:
+            if mod.type_ == type_:
+                modifiers.append(mod)
+
+        return modifiers
+
+
+def sparsification_info(framework: Any) -> SparsificationInfo:
+    """
+    Load the available setup for sparsifying model in the given framework.
+
+    :param framework: The item to detect the ML framework for.
+        See :func:`detect_framework` for more information.
+    :type framework: Any
+    :return: The sparsification info for the given framework
+    :rtype: SparsificationInfo
+    """
+    _LOGGER.debug("getting sparsification info for framework %s", framework)
+    info: SparsificationInfo = execute_in_sparseml_framework(
+        framework, "sparsification_info"
+    )
+    _LOGGER.info("retrieved sparsification info for framework %s: %s", framework, info)
+
+    return info

--- a/src/sparseml/sparsification/info.py
+++ b/src/sparseml/sparsification/info.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Functionality related to describing availability and information of sparsification
+algorithms to models within in the ML frameworks.
+"""
+
 import logging
 from enum import Enum
 from typing import Any, List, Optional

--- a/src/sparseml/tensorflow_v1/__init__.py
+++ b/src/sparseml/tensorflow_v1/__init__.py
@@ -13,26 +13,30 @@
 # limitations under the License.
 
 """
-Code for working with the tensorflow_v1 framework for creating /
-editing models for performance in the Neural Magic System
+Functionality for working with and sparsifying Models in the TensorFlow 1.x framework
 """
 
 # flake8: noqa
 
 import os as _os
 
+from .base import (
+    check_tensorflow_install,
+    check_tf2onnx_install,
+    require_tensorflow,
+    require_tf2onnx,
+    tensorflow,
+    tensorflow_err,
+    tf2onnx,
+    tf2onnx_err,
+    tf_compat,
+)
 
-try:
-    import tensorflow
 
-    if not _os.getenv("SPARSEML_IGNORE_TFV1", False):
-        # special use case so docs can be generated without having
-        # conflicting TF versions for V1 and Keras
-        version = [int(v) for v in tensorflow.__version__.split(".")]
-        if version[0] != 1 or version[1] < 8:
-            raise Exception
-except:
-    raise RuntimeError(
-        "Unable to import tensorflow. tensorflow>=1.8,<2.0 is required"
-        " to use sparseml.tensorflow_v1."
-    )
+if not _os.getenv("SPARSEML_IGNORE_TFV1", False):
+    # TODO: remove once files within package load without installs
+    check_tensorflow_install()
+
+
+from .framework import detect_framework, framework_info, is_supported
+from .sparsification import sparsification_info

--- a/src/sparseml/tensorflow_v1/base.py
+++ b/src/sparseml/tensorflow_v1/base.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import functools
+from typing import Optional
+
+from sparseml.base import check_version
+
+
+try:
+    import tensorflow
+
+    tf_compat = (
+        tensorflow
+        if not hasattr(tensorflow, "compat")
+        or not hasattr(getattr(tensorflow, "compat"), "v1")
+        else tensorflow.compat.v1
+    )
+    tensorflow_err = None
+except Exception as err:
+    tensorflow = object()  # TODO: populate with fake object for necessary imports
+    tf_compat = object()  # TODO: populate with fake object for necessary imports
+    tensorflow_err = err
+
+
+try:
+    import tf2onnx
+
+    tf2onnx_err = None
+except Exception as err:
+    tf2onnx = object()  # TODO: populate with fake object for necessary imports
+    tf2onnx_err = err
+
+
+__all__ = [
+    "tensorflow",
+    "tf_compat",
+    "tensorflow_err",
+    "tf2onnx",
+    "tf2onnx_err",
+    "check_tensorflow_install",
+    "check_tf2onnx_install",
+    "require_tensorflow",
+    "require_tf2onnx",
+]
+
+
+_TENSORFLOW_MIN_VERSION = "1.8.0"
+_TENSORFLOW_MAX_VERSION = "1.16.0"
+
+_TF2ONNX_MIN_VERSION = "1.0.0"
+
+
+def check_tensorflow_install(
+    min_version: Optional[str] = _TENSORFLOW_MIN_VERSION,
+    max_version: Optional[str] = _TENSORFLOW_MAX_VERSION,
+    raise_on_error: bool = True,
+) -> bool:
+    """
+    Check that the tensorflow package is installed.
+    If raise_on_error, will raise an ImportError if it is not installed or
+    the required version range, if set, is not installed.
+    If not raise_on_error, will return True if installed with required version
+    and False otherwise.
+
+    :param min_version: The minimum version for tensorflow that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for tensorflow that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    :param raise_on_error: True to raise any issues such as not installed,
+        minimum version, or maximum version as ImportError. False to return the result.
+    :type raise_on_error: bool
+    :return: If raise_on_error, will return False if tensorflow is not installed
+        or the version is outside the accepted bounds and True if everything is correct.
+    :rtype: bool
+    """
+    if tensorflow_err is not None:
+        if raise_on_error:
+            raise tensorflow_err
+        return False
+
+    return check_version("tensorflow", min_version, max_version, raise_on_error)
+
+
+def check_tf2onnx_install(
+    min_version: Optional[str] = _TF2ONNX_MIN_VERSION,
+    max_version: Optional[str] = None,
+    raise_on_error: bool = True,
+) -> bool:
+    """
+    Check that the tf2onnx package is installed.
+    If raise_on_error, will raise an ImportError if it is not installed or
+    the required version range, if set, is not installed.
+    If not raise_on_error, will return True if installed with required version
+    and False otherwise.
+
+    :param min_version: The minimum version for tf2onnx that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for tf2onnx that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    :param raise_on_error: True to raise any issues such as not installed,
+        minimum version, or maximum version as ImportError. False to return the result.
+    :type raise_on_error: bool
+    :return: If raise_on_error, will return False if tf2onnx is not installed
+        or the version is outside the accepted bounds and True if everything is correct.
+    :rtype: bool
+    """
+    if tf2onnx_err is not None:
+        if raise_on_error:
+            raise tf2onnx_err
+        return False
+
+    return check_version("tf2onnx", min_version, max_version, raise_on_error)
+
+
+def require_tensorflow(
+    min_version: Optional[int] = _TENSORFLOW_MIN_VERSION,
+    max_version: Optional[int] = _TENSORFLOW_MAX_VERSION,
+):
+    """
+    Decorator function to require use of tensorflow.
+    Will check that tensorflow package is installed and within the bounding
+    ranges of min_version and max_version if they are set before calling
+    the wrapped function.
+    See :func:`check_tensorflow_install` for more info.
+
+    param min_version: The minimum version for tensorflow that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for tensorflow that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    """
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            check_tensorflow_install(min_version, max_version)
+
+            return func(*args, **kwargs)
+
+        return _wrapper
+
+    return _decorator
+
+
+def require_tf2onnx(
+    min_version: Optional[int] = _TF2ONNX_MIN_VERSION,
+    max_version: Optional[int] = None,
+):
+    """
+    Decorator function to require use of tf2onnx.
+    Will check that tf2onnx package is installed and within the bounding
+    ranges of min_version and max_version if they are set before calling
+    the wrapped function.
+    See :func:`check_tf2onnx_install` for more info.
+
+    param min_version: The minimum version for tf2onnx that it must be greater than
+        or equal to, if unset will require no minimum version
+    :type min_version: str
+    :param max_version: The maximum version for tf2onnx that it must be less than
+        or equal to, if unset will require no maximum version.
+    :type max_version: str
+    """
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            check_tf2onnx_install(min_version, max_version)
+
+            return func(*args, **kwargs)
+
+        return _wrapper
+
+    return _decorator

--- a/src/sparseml/tensorflow_v1/framework/__init__.py
+++ b/src/sparseml/tensorflow_v1/framework/__init__.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa
+
 """
 Functionality related to integrating with, detecting, and getting information for
-support and sparsification in ML frameworks.
+support and sparsification in the TensorFLow 1.x framework.
 """
 
 # flake8: noqa

--- a/src/sparseml/tensorflow_v1/framework/info.py
+++ b/src/sparseml/tensorflow_v1/framework/info.py
@@ -14,18 +14,17 @@
 
 """
 Functionality related to detecting and getting information for
-support and sparsification in the DeepSparse framework.
+support and sparsification in the TensorFlow 1.x framework.
 """
 
 import logging
 from typing import Any
 
 from sparseml.base import Framework, get_version
-from sparseml.deepsparse.base import check_deepsparse_install
-from sparseml.deepsparse.sparsification import sparsification_info
 from sparseml.framework import FrameworkInferenceProviderInfo, FrameworkInfo
 from sparseml.sparsification import SparsificationInfo
-from sparsezoo import File, Model
+from sparseml.tensorflow_v1.base import check_tensorflow_install, tf_compat
+from sparseml.tensorflow_v1.sparsification import sparsification_info
 
 
 __all__ = ["is_supported", "detect_framework", "framework_info"]
@@ -39,23 +38,23 @@ def is_supported(item: Any) -> bool:
 
     :param item: The item to detect the support for
     :type item: Any
-    :return: True if the item is supported by deepsparse, False otherwise
+    :return: True if the item is supported by tensorflow, False otherwise
     :rtype: bool
     """
     framework = detect_framework(item)
 
-    return framework == Framework.deepsparse
+    return framework == Framework.tensorflow_v1
 
 
 def detect_framework(item: Any) -> Framework:
     """
     Detect the supported ML framework for a given item specifically for the
-    deepsparse package.
+    tensorflow package.
     Supported input types are the following:
 
     - A Framework enum
     - A string of any case representing the name of the framework
-      (deepsparse, onnx, keras, pytorch, tensorflow_v1)
+      (deepsparse, onnx, keras, tensorflow, tensorflow_v1)
     - A supported file type within the framework such as model files:
       (onnx, pth, h5, pb)
     - An object from a supported ML framework such as a model instance
@@ -75,84 +74,74 @@ def detect_framework(item: Any) -> Framework:
     elif isinstance(item, str) and item.lower().strip() in Framework.__members__:
         _LOGGER.debug("framework detected from Framework string instance")
         framework = Framework[item.lower().strip()]
-    elif (
-        isinstance(item, str)
-        and "deepsparse" in item.lower().strip()
-        or "deep sparse" in item.lower().strip()
+    elif isinstance(item, str) and (
+        "tensorflow" in item.lower().strip() or "tf" in item.lower().strip()
     ):
-        _LOGGER.debug("framework detected from deepsparse text")
-        # string, check if it's a string saying deepsparse first
-        framework = Framework.deepsparse
-    elif isinstance(item, str) and ".onnx" in item.lower().strip():
-        _LOGGER.debug("framework detected from .onnx")
+        _LOGGER.debug("framework detected from tensorflow text")
+        # string, check if it's a string saying onnx first
+        framework = Framework.tensorflow_v1
+    elif isinstance(item, str) and ".pb" in item.lower().strip():
+        _LOGGER.debug("framework detected from .pb")
         # string, check if it's a file url or path that ends with onnx extension
-        framework = Framework.deepsparse
-    elif isinstance(item, Model) or isinstance(item, File):
-        _LOGGER.debug("framework detected from SparseZoo instance")
-        # sparsezoo model/file, deepsparse supports these natively
-        framework = Framework.deepsparse
+        framework = Framework.tensorflow_v1
+    elif check_tensorflow_install(raise_on_error=False):
+        if isinstance(item, tf_compat.Graph) or isinstance(item, tf_compat.Session):
+            _LOGGER.debug("framework detected from tensorflow instance")
+            # tensorflow native support
+            framework = Framework.tensorflow_v1
 
     return framework
 
 
 def framework_info() -> FrameworkInfo:
     """
-    Detect the information for the deepsparse framework such as package versions,
+    Detect the information for the tensorflow framework such as package versions,
     availability for core actions such as training and inference,
     sparsification support, and inference provider support.
 
-    :return: The framework info for deepsparse
+    :return: The framework info for tensorflow
     :rtype: FrameworkInfo
     """
-    arch = {}
-
-    if check_deepsparse_install(raise_on_error=False):
-        from deepsparse.cpu import cpu_architecture
-
-        arch = cpu_architecture()
-
-    cpu_warnings = []
-    if arch and arch.isa != "avx512":
-        cpu_warnings.append(
-            "AVX512 instruction set not detected, inference performance will be limited"
-        )
-    if arch and arch.isa != "avx512" and arch.isa != "avx2":
-        cpu_warnings.append(
-            "AVX2 and AVX512 instruction sets not detected, "
-            "inference performance will be severely limited"
-        )
-    if arch and not arch.vni:
-        cpu_warnings.append(
-            "VNNI instruction set not detected, "
-            "quantized inference performance will be limited"
-        )
-
     cpu_provider = FrameworkInferenceProviderInfo(
         name="cpu",
-        description=(
-            "Performant CPU provider within DeepSparse specializing in speedup of "
-            "sparsified models using AVX and VNNI instruction sets"
-        ),
+        description="Base CPU provider within TensorFlow",
         device="cpu",
         supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
-        available=check_deepsparse_install(raise_on_error=False),
-        properties={
-            "cpu_architecture": arch,
-        },
-        warnings=cpu_warnings,
+        available=check_tensorflow_install(raise_on_error=False),
+        properties={},
+        warnings=[],
+    )
+    gpu_provider = FrameworkInferenceProviderInfo(
+        name="cuda",
+        description="Base GPU CUDA provider within TensorFlow",
+        device="gpu",
+        supported_sparsification=SparsificationInfo(),  # TODO: fill in when available
+        available=(
+            check_tensorflow_install(raise_on_error=False)
+            and get_version("tensorflow_gpu", raise_on_error=False)
+            and tf_compat.test.is_gpu_available()
+        ),
+        properties={},
+        warnings=[],
     )
 
     return FrameworkInfo(
-        framework=Framework.deepsparse,
+        framework=Framework.tensorflow,
         package_versions={
-            "deepsparse": get_version(package_name="deepsparse", raise_on_error=False),
+            "tensorflow": (
+                get_version(package_name="tensorflow", raise_on_error=False)
+                or get_version(package_name="tensorflow_gpu", raise_on_error=False)
+            ),
+            "onnx": get_version(package_name="onnx", raise_on_error=False),
+            "tf2onnx": get_version(package_name="tf2onnx", raise_on_error=False),
             "sparsezoo": get_version(package_name="sparsezoo", raise_on_error=False),
             "sparseml": get_version(package_name="sparseml", raise_on_error=False),
         },
         sparsification=sparsification_info(),
-        inference_providers=[cpu_provider],
-        training_available=False,
-        sparsification_available=False,
-        exporting_onnx_available=False,
+        inference_providers=[cpu_provider, gpu_provider],
+        properties={},
+        training_available=True,
+        sparsification_available=True,
+        exporting_onnx_available=True,
         inference_available=True,
     )

--- a/src/sparseml/tensorflow_v1/sparsification/__init__.py
+++ b/src/sparseml/tensorflow_v1/sparsification/__init__.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 # Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +15,8 @@
 # limitations under the License.
 
 """
-Functionality related to integrating with, detecting, and getting information for
-support and sparsification in ML frameworks.
+Functionality related to applying, describing, and supporting sparsification
+algorithms to models within in the TensorFlow 1.x framework.
 """
 
 # flake8: noqa

--- a/src/sparseml/tensorflow_v1/sparsification/info.py
+++ b/src/sparseml/tensorflow_v1/sparsification/info.py
@@ -14,7 +14,7 @@
 
 """
 Functionality related to describing availability and information of sparsification
-algorithms to models within in the DeepSparse framework.
+algorithms to models within in the TensorFlow 1.x framework.
 """
 
 import logging
@@ -30,13 +30,13 @@ _LOGGER = logging.getLogger(__name__)
 
 def sparsification_info() -> SparsificationInfo:
     """
-    Load the available setup for sparsifying model within deepsparse.
+    Load the available setup for sparsifying model within tensorflow.
 
-    :return: The sparsification info for the deepsparse framework
+    :return: The sparsification info for the tensorflow framework
     :rtype: SparsificationInfo
     """
-    _LOGGER.debug("getting sparsification info for deepsparse")
-    info = SparsificationInfo(modifiers=[])
-    _LOGGER.info("retrieved sparsification info for deepsparse: %s", info)
+    _LOGGER.debug("getting sparsification info for tensorflow")
+    info = SparsificationInfo(modifiers=[])  # TODO: fill in once available
+    _LOGGER.info("retrieved sparsification info for tensorflow: %s", info)
 
     return info


### PR DESCRIPTION
Framework and base implementations for phase two of SparseML:
- imports, check installs and versions, and require installs decorators for frameworks
- framework info implementations for getting availability of functionality within frameworks
- sparsification info in prep for getting availability of sparsification algorithms within frameworks
- generic ability to call into core functionality with an item and detect proper framework to run