### PR TITLE
PyTorch Global Magnitude Pruning

### DIFF
--- a/src/sparseml/pytorch/optim/mask_creator_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_creator_pruning.py
@@ -110,7 +110,8 @@ class UnstructuredPruningMaskCreator(PruningMaskCreator):
         global_sparsity: bool = False,
     ) -> List[Tensor]:
         """
-        :param tensors: list of tensors to calculate a mask from based on their contained values
+        :param tensors: list of tensors to calculate a mask from based on their
+            contained values
         :param sparsity: the desired sparsity to reach within the mask
             (decimal fraction of zeros)
         :param global_sparsity: if True, sparsity masks will be created such that the
@@ -401,14 +402,15 @@ class DimensionSparsityMaskCreator(GroupedPruningMaskCreator):
             values
         :param sparsity: the desired sparsity to reach within the mask
             (decimal fraction of zeros)
-        :param global_sparsity: do not set True, unsupported for DimensionSparsityMaskCreator
+        :param global_sparsity: do not set True, unsupported for
+            DimensionSparsityMaskCreator
         :return: list of masks (0.0 for values that are masked, 1.0 for values that are
             unmasked) calculated from the tensors such that the desired number of zeros
             matches the sparsity and all values mapped to the same group have the same
             value
         """
         if global_sparsity:
-            # global sparsity unsupported because channel dimensions may vary across layers
+            # global sparsity unsupported because channel dims may vary across layers
             raise ValueError(
                 "global_sparsity not supported for DimensionSparsityMaskCreator"
             )

--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -384,7 +384,7 @@ class ModuleParamPruningMask(object):
 
     def _check_regen_value(self, val: Tensor, param_idx: int) -> Tensor:
         if self._params[param_idx].data.device != val.device:
-            val = _detach_tens(
+            val = ModuleParamPruningMask._detach_tens(
                 torch.empty_like(self._params[param_idx].data).copy_(val)
             )
 

--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -17,7 +17,7 @@ Code related to applying a mask onto a parameter to impose kernel sparsity,
 aka model pruning
 """
 
-from typing import Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -40,18 +40,19 @@ class ModuleParamPruningMask(object):
 
     def __init__(
         self,
-        layer: Module,
-        param_name: str = "weight",
+        layers: List[Module],
+        param_names: Union[str, List[str]] = "weight",
         store_init: bool = False,
         store_unmasked: bool = False,
         track_grad_mom: float = -1.0,
         mask_creator: PruningMaskCreator = UnstructuredPruningMaskCreator(),
-        layer_name: str = None,
+        layer_names: Optional[List[str]] = None,
     ):
         """
-        :param layer: the layer containing the parameter to mask
-        :param param_name: the name of the parameter to mask in the layer,
-            default is weight
+        :param layers: the layers containing the parameters to mask
+        :param param_names: the names of the parameter to mask in each layer. If only
+            one name is given, that name will be applied to all layers that this object
+            masks. default is weight
         :param store_init: store the init weights in a separate variable that can be
             used and referenced later
         :param store_unmasked: store the unmasked weights in a separate variable that
@@ -61,69 +62,81 @@ class ModuleParamPruningMask(object):
             only keep most recent
         :param mask_creator: object to define sparisty mask creation,
             default is unstructured mask
-        :param layer_name: the name of the layer the parameter to mask is located in
+        :param layer_names: the name of the layers the parameters to mask are located in
         """
-        self._layer = layer
-        self._param_name = param_name
-        self._layer_name = layer_name
+        self._layers = layers
+        self._param_names = (
+            param_names
+            if isinstance(param_names, List)
+            else [param_names] * len(self._layers)
+        )
+        self._layer_names = layer_names
         self._store_init = store_init
         self._store_unmasked = store_unmasked
         self._track_grad_mom = track_grad_mom
         self._mask_creator = mask_creator
 
         self._enabled = False
-        self._forward_hook = None
-        self._gradient_hook = None
+        self._forward_hooks = [None] * len(self._layers)
+        self._gradient_hooks = [None] * len(self._layers)
 
-        try:
-            self._param = self._layer.__getattr__(self._param_name)  # type: Parameter
-        except Exception as err:
-            raise RuntimeError(
-                "Error occurred while trying to get param {} in layer {}: {}".format(
-                    self._param_name, self._layer, err
+        self._params = []  # type: List[Parameter]
+        for layer, param_name in zip(self._layers, self._param_names):
+            try:
+                self._params.append(layer.__getattr__(param_name))
+            except Exception as err:
+                raise RuntimeError(
+                    f"Error occurred while trying to get param {param_name} "
+                    f"in layer {layer}: {err}"
                 )
-            )
 
-        self._param_mask = torch.ones(self._param.shape)  # initialize to all ones
-        self._param_init = None  # type: Tensor
-        self._param_unmasked = None  # type: Tensor
-        self._param_grad = None  # type: Tensor
+        # initialize masks to all ones
+        self._param_masks = [torch.ones(param.shape) for param in self._params]
+        self._params_init = [None] * len(self._layers)  # type: List[Tensor]
+        self._params_unmasked = [None] * len(self._layers)  # type: List[Tensor]
+        self._params_grad = [None] * len(self._layers)  # type: List[Tensor]
 
-        self._setup_param_init()
-        self._setup_param_unmasked()
-        self._setup_param_grad()
+        self._setup_params_init()
+        self._setup_params_unmasked()
+        self._setup_params_grad()
+
+    def __len__(self):
+        return len(self._layers)
 
     def __del__(self):
         self._delete_hooks()
 
     @property
-    def layer(self) -> Module:
+    def layers(self) -> List[Module]:
         """
-        :return: the layer containing the parameter to mask
+        :return: the layers containing the parameters to mask
         """
-        return self._layer
+        return self._layers
 
     @property
-    def param_name(self) -> str:
+    def param_names(self) -> List[str]:
         """
-        :return: the name of the parameter to mask in the layer, default is weight
+        :return: the names of the parameters to mask in the layers
         """
-        return self._param_name
+        return self._param_names
 
     @property
-    def layer_name(self) -> str:
+    def layer_names(self) -> Optional[List[str]]:
         """
-        :return: the name of the layer the parameter to mask is located in
+        :return: the names of the layers the parameter to mask is located in
         """
-        return self._layer_name
+        return self._layer_names
 
     @property
-    def name(self) -> str:
+    def names(self) -> List[str]:
         """
-        :return: the full name of this sparsity mask in the following format:
+        :return: the full names of the sparsity masks in the following format:
             <LAYER>.<PARAM>.sparsity_mask
         """
-        return "{}.{}.sparsity_mask".format(self._layer_name, self._param_name)
+        return [
+            f"{layer_name}.{param_name}.sparsity_mask"
+            for layer_name, param_name in zip(self._layer_names, self._param_names)
+        ]
 
     @property
     def store_init(self) -> bool:
@@ -171,258 +184,305 @@ class ModuleParamPruningMask(object):
         """
         if value and not self._enabled:
             self._create_hooks()
-            self._param_grad = None
-            self._setup_param_grad()
+            self._params_grad = [None] * len(self._params)
+            self._setup_params_grad()
         elif not value and self._enabled:
             self._delete_hooks()
 
         self._enabled = value
 
     @property
-    def param_data(self) -> Tensor:
+    def params_data(self) -> List[Tensor]:
         """
-        :return: the current tensor in the parameter
+        :return: the current tensors in each of the parameters
         """
-        return self._param.data
+        return [param.data for param in self._params]
 
     @property
-    def param_mask(self) -> Tensor:
+    def param_masks(self) -> List[Tensor]:
         """
-        :return: the current mask applied to the parameter
+        :return: the current masks applied to each of the parameters
         """
-        return self._param_mask
+        return self._param_masks
 
     @property
-    def param_init(self) -> Union[None, Tensor]:
+    def params_init(self) -> List[Optional[Tensor]]:
         """
-        :return: the initial value of the parameter before being masked
+        :return: the initial values of the parameters before being masked
         """
-        return self._param_init
+        return self._params_init
 
     @property
-    def param_unmasked(self) -> Union[None, Tensor]:
+    def params_unmasked(self) -> List[Optional[Tensor]]:
         """
-        :return: the unmasked value of the parameter
+        :return: the unmasked values of the parameters
             (stores the last unmasked value before masking)
         """
-        if self._param_unmasked is None:
-            return None
-
-        return (
-            self._param.data
-            + (self._param_mask == 0.0).type(self._param.data.type())
-            * self._param_unmasked
-        )
+        params_unmasked = []
+        for idx in range(len(self._params)):
+            if self._params_unmasked[idx] is None:
+                params_unmasked.append(None)
+            else:
+                params_unmasked.append(
+                    self._params[idx].data
+                    + (self._param_masks == 0.0).type(self._params[idx].data.type())
+                    * self._params_unmasked[idx]
+                )
+        return params_unmasked
 
     @property
-    def param_grad(self) -> Union[None, Tensor]:
+    def params_grad(self) -> List[Optional[Tensor]]:
         """
-        :return: the current gradient values for the parameter
+        :return: the current gradient values for each parameter
         """
-        return self._param_grad
+        return self._params_grad
 
-    def set_param_data(self, value: Tensor):
+    def set_param_data(self, value: Tensor, param_idx: int):
         """
         :param value: the value to set as the current tensor for the parameter,
             if enabled the mask will be applied
+        :param param_idx: index of the parameter in this object to set the data of
         """
         if value is None:
-            raise ValueError("param_data cannot be set to None")
+            raise ValueError("param data cannot be set to None")
 
-        if value.shape != self._param.data.shape:
+        if value.shape != self._params[param_idx].data.shape:
             raise ValueError(
-                f"param_tensor shape of {value.shape} does not match layer.param "
-                f"shape of {self._param.shape}"
+                f"param_tensor shape of {value.shape} does not match parameter "
+                f"shape of {self._param[param_idx].shape}"
             )
 
-        value = self._check_regen_value(value)
-        self._check_regen_param_vals()
-        self._param.data.copy_(value)
-        self._param_unmasked = None
-        self._setup_param_unmasked()
-        self.apply()
+        value = self._check_regen_value(value, param_idx)
+        self._check_regen_param_vals(param_idx)
+        self._params[param_idx].data.copy_(value)
+        self._params_unmasked[param_idx] = None
+        self._setup_params_unmasked(param_idx)
+        self.apply(param_idx)
 
-    def set_param_mask(self, value: Tensor):
+    def set_param_masks(self, masks: List[Tensor]):
         """
-        :param value: the mask to set and apply as the current tensor,
+        :param masks: the masks to set and apply as the current param tensors,
             if enabled mask is applied immediately
         """
-        if value is None:
-            raise ValueError("mask cannot be set to None")
+        mask_diffs = []
+        for idx, value in enumerate(masks):
+            if value is None:
+                raise ValueError("mask cannot be set to None")
 
-        if value.shape != self._param.shape:
-            raise ValueError(
-                "mask shape of {} does not match layer.param shape of {}".format(
-                    value.shape, self._param.shape
+            if value.shape != self._params[idx].shape:
+                raise ValueError(
+                    "mask shape of {} does not match layer.param shape of {}".format(
+                        value.shape, self._params[idx].shape
+                    )
                 )
-            )
 
-        value = self._check_regen_value(value)
-        self._check_regen_param_vals()
-        mask_diff = mask_difference(self._param_mask, value)
+            value = self._check_regen_value(value, idx)
+            self._check_regen_param_vals(idx)
+            mask_diff = mask_difference(self._param_masks[idx], value)
 
-        if self._param_unmasked is not None:
-            # store our unmasked values if they should be tracked
-            # we only want to update our param_masked tensor with the ones
-            # that are newly masked
-            self._param_unmasked = (mask_diff == -1.0).type(
-                self._param.data.type()
-            ) * self._param.data + (mask_diff != -1.0).type(
-                self._param.data.type()
-            ) * self._param_unmasked
-        self._param_mask = value
-        self.apply()
+            if self._params_unmasked[idx] is not None:
+                # store our unmasked values if they should be tracked
+                # we only want to update our param_masked tensor with the ones
+                # that are newly masked
+                self._params_unmasked[idx] = (mask_diff == -1.0).type(
+                    self._params[idx].data.type()
+                ) * self._params[idx].data + (mask_diff != -1.0).type(
+                    self._params[idx].data.type()
+                ) * self._params_unmasked[
+                    idx
+                ]
+            self._param_masks[idx] = value
+            self.apply(idx)
 
-        return mask_diff
+            mask_diffs.append(mask_diff)
 
-    def set_param_mask_from_weights(self) -> Tensor:
+        return mask_diffs
+
+    def set_param_masks_from_weights(self) -> Tensor:
         """
-        Convenience function to set the parameter mask such that the
-        mask is 1 if the parameter value is non zero and 0 otherwise,
+        Convenience function to set the parameter masks such that the
+        mask is 1 if a parameter value is non zero and 0 otherwise,
         unless otherwise defined by this object's mask_creator.
 
         """
-        value = self._mask_creator.create_sparsity_mask_from_tensor(self._param.data)
+        masks = self._mask_creator.create_sparsity_masks_from_tensor(
+            [param.data for param in self._params]
+        )
 
-        return self.set_param_mask(value)
+        return self.set_param_masks(masks)
 
-    def set_param_mask_from_abs_threshold(
+    def set_param_masks_from_abs_threshold(
         self, threshold: Union[float, Tensor]
     ) -> Tensor:
         """
-        Convenience function to set the parameter mask such that if
-        abs(value) <= threshold the it is masked to 0
+        Convenience function to set the parameter masks such that if
+        abs(value) <= threshold the it a value is masked to 0
 
         :param threshold: the threshold at which all values will be masked to 0
         """
-        value = self._mask_creator.create_sparsity_mask_from_abs_threshold(
-            self._param.data, threshold
+        masks = self._mask_creator.create_sparsity_masks_from_abs_threshold(
+            [param.data for param in self._params], threshold
         )
 
-        return self.set_param_mask(value)
+        return self.set_param_masks(masks)
 
-    def set_param_mask_from_sparsity(self, sparsity: float) -> Tensor:
+    def set_param_masks_from_sparsity(self, sparsity: float) -> Tensor:
         """
-        Convenience function to set the parameter mask such that it has a specific
+        Convenience function to set the parameter masks such that each masks have an
         amount of masked values such that the percentage equals the sparsity amount
         given. Masks the absolute smallest values up until sparsity is reached.
 
         :param sparsity: the decimal sparsity to set the param mask to
         """
-        value = self._mask_creator.create_sparsity_mask(self._param.data, sparsity)
+        masks = self._mask_creator.create_sparsity_masks(
+            [param.data for param in self._params], sparsity
+        )
 
-        return self.set_param_mask(value)
+        return self.set_param_masks(masks)
 
-    def apply(self):
+    def apply(self, param_idx: Optional[int] = None):
         """
         apply the current mask to the params tensor (zero out the desired values)
+
+        :param param_idx: index of parameter to apply mask to. if not set, then masks
+            will be applied to all parameters with available masks
         """
         if not self._enabled:
             return
 
-        self._check_regen_param_vals()
+        indices = range(len(self._params)) if param_idx is None else [param_idx]
 
-        with torch.no_grad():
-            self._param.data.mul_(self._param_mask)
+        for idx in indices:
+            self._check_regen_param_vals(idx)
+
+            with torch.no_grad():
+                self._params[idx].data.mul_(self._param_masks[idx])
 
     def reset(self):
         """
         resets the current stored tensors such that they will be on the same device
-        and have the proper data
+        and have the initial data
         """
         self._check_regen_param_vals()
-        self._param.data.copy_(self._param_init)
+        for idx, param in enumerate(self._params):
+            param.data.copy_(self._params_init[idx])
 
-    def _check_regen_value(self, val: Tensor) -> Tensor:
-        if self._param.data.device != val.device:
-            val = ModuleParamPruningMask._detach_tens(
-                torch.empty_like(self._param.data).copy_(val)
+    def _check_regen_value(self, val: Tensor, param_idx: int) -> Tensor:
+        if self._params[param_idx].data.device != val.device:
+            val = _detach_tens(
+                torch.empty_like(self._params[param_idx].data).copy_(val)
             )
 
         return val
 
-    def _check_regen_param_vals(self):
-        if self._param.data.device != self._param_mask.device:
-            self._param_mask = ModuleParamPruningMask._detach_tens(
-                torch.empty_like(self._param.data).copy_(self._param_mask)
-            )
+    def _check_regen_param_vals(self, param_idx: int = None):
+        indices = range(len(self._params)) if param_idx is None else [param_idx]
 
-        if (
-            self._param_init is not None
-            and self._param.data.device != self._param_init.device
-        ):
-            self._param_init = ModuleParamPruningMask._detach_tens(
-                torch.empty_like(self._param.data).copy_(self._param_init)
-            )
+        for idx in indices:
+            if self._params[idx].data.device != self._param_masks[idx].device:
+                self._param_masks[idx] = ModuleParamPruningMask._detach_tens(
+                    torch.empty_like(self._params[idx].data).copy_(
+                        self._param_masks[idx]
+                    )
+                )
 
-        if (
-            self._param_unmasked is not None
-            and self._param.data.device != self._param_unmasked.device
-        ):
-            self._param_unmasked = ModuleParamPruningMask._detach_tens(
-                torch.empty_like(self._param.data).copy_(self._param_unmasked)
-            )
+            if (
+                self._params_init[idx] is not None
+                and self._params[idx].data.device != self._params_init[idx].device
+            ):
+                self._params_init[idx] = ModuleParamPruningMask._detach_tens(
+                    torch.empty_like(self._params[idx].data).copy_(
+                        self._params_init[idx]
+                    )
+                )
 
-        if (
-            self._param_grad is not None
-            and self._param.data.device != self._param_grad.device
-        ):
-            self._param_grad = ModuleParamPruningMask._detach_tens(
-                torch.empty_like(self._param.data).copy_(self._param_grad)
-            )
+            if (
+                self._params_unmasked[idx] is not None
+                and self._params[idx].data.device != self._params_unmasked[idx].device
+            ):
+                self._params_unmasked[idx] = ModuleParamPruningMask._detach_tens(
+                    torch.empty_like(self._params[idx].data).copy_(
+                        self._params_unmasked[idx]
+                    )
+                )
+
+            if (
+                self._params_grad[idx] is not None
+                and self._params[idx].data.device != self._params_grad[idx].device
+            ):
+                self._param_grad[idx] = ModuleParamPruningMask._detach_tens(
+                    torch.empty_like(self._params[idx].data).copy_(
+                        self._params_grad[idx]
+                    )
+                )
 
     def _create_hooks(self):
-        if self._forward_hook is None:
-            self._forward_hook = self._layer.register_forward_pre_hook(
-                self._hook_mask_forward
-            )
+        for idx, (param, layer) in enumerate(zip(self._params, self._layers)):
+            if self._forward_hooks[idx] is None:
+                self._forward_hooks[idx] = layer.register_forward_pre_hook(
+                    self._get_param_mask_forward_hook(idx)
+                )
 
-        if self._gradient_hook is None:
-            self._gradient_hook = self._param.register_hook(self._hook_mask_gradient)
+            if self._gradient_hooks[idx] is None:
+                self._gradient_hooks[idx] = param.register_hook(
+                    self._get_param_mask_gradient_hook(idx)
+                )
 
     def _delete_hooks(self):
-        if self._forward_hook is not None:
-            self._forward_hook.remove()
-            self._forward_hook = None
+        for idx in range(len(self._params)):
+            if self._forward_hooks[idx] is not None:
+                self._forward_hooks[idx].remove()
+                self._forward_hooks[idx] = None
 
-        if self._gradient_hook is not None:
-            self._gradient_hook.remove()
-            self._gradient_hook = None
+            if self._gradient_hooks[idx] is not None:
+                self._gradient_hooks[idx].remove()
+                self._gradient_hooks[idx] = None
 
-    def _hook_mask_forward(self, mod: Module, inp: Union[Tensor, Tuple[Tensor]]):
-        self.apply()
+    def _get_param_mask_forward_hook(self, param_idx):
+        def hook_mask_forward(mod: Module, inp: Union[Tensor, Tuple[Tensor]]):
+            self.apply(param_idx)
 
-    def _hook_mask_gradient(self, grad):
-        if 0.0 <= self._track_grad_mom < 1.0:
-            self._param_grad.mul_(self._track_grad_mom).add_(
-                (1.0 - self._track_grad_mom) * grad
-            )
+        return hook_mask_forward
 
-        return grad.mul_(self._param_mask)
+    def _get_param_mask_gradient_hook(self, param_idx):
+        def hook_mask_gradient(grad):
+            if 0.0 <= self._track_grad_mom < 1.0:
+                self._params_grad[param_idx].mul_(self._track_grad_mom).add_(
+                    (1.0 - self._track_grad_mom) * grad
+                )
 
-    def _setup_param_init(self):
-        if self._store_init and self._param_init is None:
-            self._param_init = ModuleParamPruningMask._detach_tens(
-                self._param.data.clone()
-            )
-        elif not self._store_init and self._param_init is not None:
-            self._param_init = None
+            return grad.mul_(self._param_masks[param_idx])
 
-    def _setup_param_unmasked(self):
-        if self._store_unmasked and self._param_unmasked is None:
-            self._param_unmasked = ModuleParamPruningMask._detach_tens(
-                self._param.data.clone()
-            )
-        elif not self._store_unmasked and self._param_unmasked is not None:
-            self._param_unmasked = None
+        return hook_mask_gradient
 
-    def _setup_param_grad(self):
-        if self._track_grad_mom >= 0.0 and self._param_grad is None:
-            self._param_grad = ModuleParamPruningMask._detach_tens(
-                self._param.data.new_zeros(self._param.data.shape)
-            )
-        elif self._track_grad_mom < 0.0 and self._param_grad is not None:
-            self._param_grad = None
+    def _setup_params_init(self):
+        for idx, param in enumerate(self._params):
+            if self._store_init and self._params_init[idx] is None:
+                self._params_init[idx] = ModuleParamPruningMask._detach_tens(
+                    param.data.clone()
+                )
+            elif not self._store_init and self._params_init[idx] is not None:
+                self._params_init[idx] = None
+
+    def _setup_params_unmasked(self, param_idx: int = None):
+        indices = range(len(self._params)) if param_idx is None else [param_idx]
+
+        for idx in indices:
+            if self._store_unmasked and self._params_unmasked[idx] is None:
+                self._params_unmasked[idx] = ModuleParamPruningMask._detach_tens(
+                    self._params[idx].data.clone()
+                )
+            elif not self._store_unmasked and self._params_unmasked[idx] is not None:
+                self._params_unmasked[idx] = None
+
+    def _setup_params_grad(self):
+        for idx, param in enumerate(self._params):
+            if self._track_grad_mom >= 0.0 and self._params_grad[idx] is None:
+                self._params_grad[idx] = ModuleParamPruningMask._detach_tens(
+                    param.data.new_zeros(param.data.shape)
+                )
+            elif self._track_grad_mom < 0.0 and self._params_grad[idx] is not None:
+                self._params_grad[idx] = None
 
     @staticmethod
     def _detach_tens(tens) -> Tensor:

--- a/src/sparseml/pytorch/optim/sensitivity_pruning.py
+++ b/src/sparseml/pytorch/optim/sensitivity_pruning.py
@@ -153,7 +153,7 @@ def _sensitivity_callback(
             prunable_layers
         ):
             # increment sparsity level for current layer
-            current_mask.set_param_mask_from_sparsity(sparsity_levels[sparsity_index])
+            current_mask.set_param_masks_from_sparsity(sparsity_levels[sparsity_index])
         else:
             # go to next layer
             sparsity_index = 0
@@ -167,14 +167,14 @@ def _sensitivity_callback(
 
             if layer_index < len(prunable_layers):
                 current_mask = ModuleParamPruningMask(
-                    prunable_layers[layer_index][1],
+                    [prunable_layers[layer_index][1]],
                     store_init=True,
                     mask_creator=UnstructuredPruningMaskCreator(),
                 )
                 current_mask.enabled = True
 
                 if sparsity_levels[sparsity_index] > 0.0:
-                    current_mask.set_param_mask_from_sparsity(
+                    current_mask.set_param_masks_from_sparsity(
                         sparsity_levels[sparsity_index]
                     )
 

--- a/tests/sparseml/pytorch/optim/test_mask_pruning.py
+++ b/tests/sparseml/pytorch/optim/test_mask_pruning.py
@@ -36,6 +36,7 @@ def _test_constructor(layer, param_name, mask_creator):
     assert not mask.store_init
     assert not mask.store_unmasked
     assert mask.track_grad_mom == -1.0
+    assert not mask.global_sparsity
     assert not mask.enabled
     assert mask_creator == mask.mask_creator
 

--- a/tests/sparseml/pytorch/optim/test_mask_pruning.py
+++ b/tests/sparseml/pytorch/optim/test_mask_pruning.py
@@ -30,9 +30,9 @@ from sparseml.pytorch.utils import tensor_sparsity
 
 
 def _test_constructor(layer, param_name, mask_creator):
-    mask = ModuleParamPruningMask(layer, param_name, mask_creator=mask_creator)
-    assert mask.layer == layer
-    assert mask.param_name == param_name
+    mask = ModuleParamPruningMask([layer], [param_name], mask_creator=mask_creator)
+    assert mask.layers[0] == layer
+    assert mask.param_names[0] == param_name
     assert not mask.store_init
     assert not mask.store_unmasked
     assert mask.track_grad_mom == -1.0
@@ -123,9 +123,9 @@ def test_constructor_cuda(layer, param_name, mask_creator):
     reason="Skipping pytorch tests",
 )
 def _test_set_param_data(layer, param_name, data):
-    mask = ModuleParamPruningMask(layer, param_name)
-    mask.set_param_data(data)
-    assert torch.sum((mask.param_data - data).abs()) < sys.float_info.epsilon
+    mask = ModuleParamPruningMask([layer], param_name)
+    mask.set_param_data(data, 0)
+    assert torch.sum((mask.params_data[0] - data).abs()) < sys.float_info.epsilon
 
 
 @pytest.mark.skipif(
@@ -186,8 +186,8 @@ def random_mask(*size, threshold):
     reason="Skipping pytorch tests",
 )
 def _test_set_param_mask(layer, param_name, param_mask):
-    mask = ModuleParamPruningMask(layer, param_name)
-    result = mask.set_param_mask(param_mask)
+    mask = ModuleParamPruningMask([layer], [param_name])
+    result = mask.set_param_masks([param_mask])[0]
     res_unmasked = (result == 1.0).type(torch.float32)
     res_masked = (result == -1.0).type(torch.float32)
     res_no_change = (result == 0.0).type(torch.float32)
@@ -200,7 +200,7 @@ def _test_set_param_mask(layer, param_name, param_mask):
 
     mask.enabled = True
     mask.apply()
-    param_data_zeros = (mask.param_data == 0.0).type("float32")
+    param_data_zeros = (mask.params_data[0] == 0.0).type("float32")
 
     assert torch.sum((param_data_zeros - mask_zeros).abs()) < sys.float_info.epsilon
 
@@ -296,13 +296,13 @@ def _test_set_param_mask_from_abs_threshold(
     expected_sparsity,
     mask_creator,
 ):
-    mask = ModuleParamPruningMask(layer, param_name, mask_creator=mask_creator)
-    mask.set_param_data(param)
-    mask.set_param_mask_from_abs_threshold(threshold)
-    sparsity = tensor_sparsity(mask.param_mask)
+    mask = ModuleParamPruningMask([layer], [param_name], mask_creator=mask_creator)
+    mask.set_param_data(param, 0)
+    mask.set_param_masks_from_abs_threshold(threshold)
+    sparsity = tensor_sparsity(mask.param_masks[0])
     assert (sparsity - expected_sparsity).abs() < 0.01
     if isinstance(mask_creator, GroupedPruningMaskCreator):
-        _test_grouped_sparsity_mask_output(mask_creator, mask.param_mask)
+        _test_grouped_sparsity_mask_output(mask_creator, mask.param_masks[0])
 
 
 @pytest.mark.skipif(
@@ -510,13 +510,13 @@ def test_set_param_mask_from_abs_threshold_cuda(
 def _test_set_param_mask_from_sparsity(
     layer, param_name, param, sparsity, mask_creator
 ):
-    mask = ModuleParamPruningMask(layer, param_name, mask_creator=mask_creator)
-    mask.set_param_data(param)
-    mask.set_param_mask_from_sparsity(sparsity)
-    measured = tensor_sparsity(mask.param_mask)
+    mask = ModuleParamPruningMask([layer], [param_name], mask_creator=mask_creator)
+    mask.set_param_data(param, 0)
+    mask.set_param_masks_from_sparsity(sparsity)
+    measured = tensor_sparsity(mask.param_masks[0])
     assert (measured - sparsity).abs() < 0.01
     if isinstance(mask_creator, GroupedPruningMaskCreator):
-        _test_grouped_sparsity_mask_output(mask_creator, mask.param_mask)
+        _test_grouped_sparsity_mask_output(mask_creator, mask.param_masks[0])
 
 
 @pytest.mark.skipif(

--- a/tests/sparseml/pytorch/optim/test_modifier_pruning.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_pruning.py
@@ -17,7 +17,12 @@ import os
 import pytest
 import torch
 
-from sparseml.pytorch.optim import ConstantPruningModifier, GMPruningModifier
+from sparseml.pytorch.optim import (
+    ConstantPruningModifier,
+    GlobalMagnitudePruningModifier,
+    GMPruningModifier,
+    MagnitudePruningModifier,
+)
 from tests.sparseml.pytorch.helpers import LinearNet
 from tests.sparseml.pytorch.optim.test_modifier import (
     ScheduledModifierTest,
@@ -214,6 +219,15 @@ def test_constant_pruning_yaml():
             inter_func="cubic",
             global_sparsity=True,
         ),
+        lambda: GlobalMagnitudePruningModifier(
+            params="__ALL_PRUNABLE__",
+            init_sparsity=0.05,
+            final_sparsity=0.95,
+            start_epoch=10.0,
+            end_epoch=25.0,
+            update_frequency=1.0,
+            inter_func="cubic",
+        ),
         lambda: GMPruningModifier(
             params=["seq.fc1.weight", "seq.fc2.weight"],
             init_sparsity=0.05,
@@ -374,4 +388,162 @@ def test_gm_pruning_yaml():
         str(yaml_modifier.global_sparsity)
         == str(serialized_modifier.global_sparsity)
         == str(obj_modifier.global_sparsity)
+    )
+
+
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
+    reason="Skipping pytorch tests",
+)
+def test_magnitude_pruning_yaml():
+    init_sparsity = 0.05
+    final_sparsity = 0.8
+    start_epoch = 5.0
+    end_epoch = 15.0
+    update_frequency = 1.0
+    params = "__ALL_PRUNABLE__"
+    inter_func = "cubic"
+    mask_type = "filter"
+    yaml_str = f"""
+    !MagnitudePruningModifier
+        init_sparsity: {init_sparsity}
+        final_sparsity: {final_sparsity}
+        start_epoch: {start_epoch}
+        end_epoch: {end_epoch}
+        update_frequency: {update_frequency}
+        params: {params}
+        inter_func: {inter_func}
+        mask_type: {mask_type}
+    """
+    yaml_modifier = MagnitudePruningModifier.load_obj(
+        yaml_str
+    )  # type: MagnitudePruningModifier
+    serialized_modifier = GMPruningModifier.load_obj(
+        str(yaml_modifier)
+    )  # type: MagnitudePruningModifier
+    obj_modifier = GMPruningModifier(
+        init_sparsity=init_sparsity,
+        final_sparsity=final_sparsity,
+        start_epoch=start_epoch,
+        end_epoch=end_epoch,
+        update_frequency=update_frequency,
+        params=params,
+        inter_func=inter_func,
+        mask_type=mask_type,
+    )
+
+    assert isinstance(yaml_modifier, MagnitudePruningModifier)
+    assert (
+        yaml_modifier.init_sparsity
+        == serialized_modifier.init_sparsity
+        == obj_modifier.init_sparsity
+    )
+    assert (
+        yaml_modifier.final_sparsity
+        == serialized_modifier.final_sparsity
+        == obj_modifier.final_sparsity
+    )
+    assert (
+        yaml_modifier.start_epoch
+        == serialized_modifier.start_epoch
+        == obj_modifier.start_epoch
+    )
+    assert (
+        yaml_modifier.end_epoch
+        == serialized_modifier.end_epoch
+        == obj_modifier.end_epoch
+    )
+    assert (
+        yaml_modifier.update_frequency
+        == serialized_modifier.update_frequency
+        == obj_modifier.update_frequency
+    )
+    assert yaml_modifier.params == serialized_modifier.params == obj_modifier.params
+    assert (
+        yaml_modifier.inter_func
+        == serialized_modifier.inter_func
+        == obj_modifier.inter_func
+    )
+    assert (
+        str(yaml_modifier.mask_type)
+        == str(serialized_modifier.mask_type)
+        == str(obj_modifier.mask_type)
+    )
+
+
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
+    reason="Skipping pytorch tests",
+)
+def test_global_magnitude_pruning_yaml():
+    init_sparsity = 0.05
+    final_sparsity = 0.8
+    start_epoch = 5.0
+    end_epoch = 15.0
+    update_frequency = 1.0
+    params = "__ALL_PRUNABLE__"
+    inter_func = "cubic"
+    mask_type = "filter"
+    yaml_str = f"""
+    !GlobalMagnitudePruningModifier
+        init_sparsity: {init_sparsity}
+        final_sparsity: {final_sparsity}
+        start_epoch: {start_epoch}
+        end_epoch: {end_epoch}
+        update_frequency: {update_frequency}
+        params: {params}
+        inter_func: {inter_func}
+        mask_type: {mask_type}
+    """
+    yaml_modifier = GlobalMagnitudePruningModifier.load_obj(yaml_str)
+    serialized_modifier = GMPruningModifier.load_obj(
+        str(yaml_modifier)
+    )  # type: GlobalMagnitudePruningModifier
+    obj_modifier = GlobalMagnitudePruningModifier(
+        init_sparsity=init_sparsity,
+        final_sparsity=final_sparsity,
+        start_epoch=start_epoch,
+        end_epoch=end_epoch,
+        update_frequency=update_frequency,
+        params=params,
+        inter_func=inter_func,
+        mask_type=mask_type,
+    )
+
+    assert isinstance(yaml_modifier, GlobalMagnitudePruningModifier)
+    assert (
+        yaml_modifier.init_sparsity
+        == serialized_modifier.init_sparsity
+        == obj_modifier.init_sparsity
+    )
+    assert (
+        yaml_modifier.final_sparsity
+        == serialized_modifier.final_sparsity
+        == obj_modifier.final_sparsity
+    )
+    assert (
+        yaml_modifier.start_epoch
+        == serialized_modifier.start_epoch
+        == obj_modifier.start_epoch
+    )
+    assert (
+        yaml_modifier.end_epoch
+        == serialized_modifier.end_epoch
+        == obj_modifier.end_epoch
+    )
+    assert (
+        yaml_modifier.update_frequency
+        == serialized_modifier.update_frequency
+        == obj_modifier.update_frequency
+    )
+    assert yaml_modifier.params == serialized_modifier.params == obj_modifier.params
+    assert (
+        yaml_modifier.inter_func
+        == serialized_modifier.inter_func
+        == obj_modifier.inter_func
+    )
+    assert (
+        str(yaml_modifier.mask_type)
+        == str(serialized_modifier.mask_type)
+        == str(obj_modifier.mask_type)
     )

--- a/tests/sparseml/pytorch/optim/test_modifier_pruning.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_pruning.py
@@ -158,14 +158,12 @@ def test_constant_pruning_yaml():
     start_epoch = 5.0
     end_epoch = 15.0
     params = ["re:.*weight"]
-    yaml_str = """
+    yaml_str = f"""
     !ConstantPruningModifier
         start_epoch: {start_epoch}
         end_epoch: {end_epoch}
         params: {params}
-    """.format(
-        start_epoch=start_epoch, end_epoch=end_epoch, params=params
-    )
+    """
     yaml_modifier = ConstantPruningModifier.load_obj(
         yaml_str
     )  # type: ConstantPruningModifier
@@ -214,6 +212,7 @@ def test_constant_pruning_yaml():
             end_epoch=25.0,
             update_frequency=1.0,
             inter_func="cubic",
+            global_sparsity=True,
         ),
         lambda: GMPruningModifier(
             params=["seq.fc1.weight", "seq.fc2.weight"],
@@ -305,7 +304,8 @@ def test_gm_pruning_yaml():
     params = ["re:.*weight"]
     inter_func = "cubic"
     mask_type = "filter"
-    yaml_str = """
+    global_sparsity = False
+    yaml_str = f"""
     !GMPruningModifier
         init_sparsity: {init_sparsity}
         final_sparsity: {final_sparsity}
@@ -315,16 +315,8 @@ def test_gm_pruning_yaml():
         params: {params}
         inter_func: {inter_func}
         mask_type: {mask_type}
-    """.format(
-        init_sparsity=init_sparsity,
-        final_sparsity=final_sparsity,
-        start_epoch=start_epoch,
-        end_epoch=end_epoch,
-        update_frequency=update_frequency,
-        params=params,
-        inter_func=inter_func,
-        mask_type=mask_type,
-    )
+        global_sparsity: {global_sparsity}
+    """
     yaml_modifier = GMPruningModifier.load_obj(yaml_str)  # type: GMPruningModifier
     serialized_modifier = GMPruningModifier.load_obj(
         str(yaml_modifier)
@@ -338,6 +330,7 @@ def test_gm_pruning_yaml():
         params=params,
         inter_func=inter_func,
         mask_type=mask_type,
+        global_sparsity=global_sparsity,
     )
 
     assert isinstance(yaml_modifier, GMPruningModifier)
@@ -376,4 +369,9 @@ def test_gm_pruning_yaml():
         str(yaml_modifier.mask_type)
         == str(serialized_modifier.mask_type)
         == str(obj_modifier.mask_type)
+    )
+    assert (
+        str(yaml_modifier.global_sparsity)
+        == str(serialized_modifier.global_sparsity)
+        == str(obj_modifier.global_sparsity)
     )

--- a/tests/sparseml/pytorch/optim/test_modifier_pruning.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_pruning.py
@@ -391,10 +391,6 @@ def test_gm_pruning_yaml():
     )
 
 
-@pytest.mark.skipif(
-    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
-    reason="Skipping pytorch tests",
-)
 def test_magnitude_pruning_yaml():
     init_sparsity = 0.05
     final_sparsity = 0.8
@@ -471,10 +467,6 @@ def test_magnitude_pruning_yaml():
     )
 
 
-@pytest.mark.skipif(
-    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
-    reason="Skipping pytorch tests",
-)
 def test_global_magnitude_pruning_yaml():
     init_sparsity = 0.05
     final_sparsity = 0.8


### PR DESCRIPTION
enable global magnitude pruning by adding `global_sparsity: True` to GMPruningModifier configs

* [x] refactor mask creators and masking objects to process lists of tensors instead of single tensors
* [x] add option for global masking in mask creators and pruning modifier
* [x] testing