### PR TITLE
Fix incorrect loss scaling in DDP setup

### DIFF
--- a/src/sparseml/pytorch/utils/module.py
+++ b/src/sparseml/pytorch/utils/module.py
@@ -1105,8 +1105,7 @@ class ModuleTester(ModuleRunner):
 
                 # loss steps
                 losses = self._loss(data, pred)
-                # scale loss by world size
-                losses[DEFAULT_LOSS_KEY] *= self.device_context.world_size
+
                 self._run_hooks.invoke_batch_loss(
                     counter, batch, batch_size, data, pred, losses
                 )


### PR DESCRIPTION
This is a forgotten fix for `ModuleTester` class. The description is the same as for #135 .