### PR TITLE
Fix memory leak when using debug-steps

### DIFF
--- a/src/sparseml/pytorch/utils/module.py
+++ b/src/sparseml/pytorch/utils/module.py
@@ -685,7 +685,7 @@ class ModuleRunner(ABC):
         data_iter = (
             enumerate(data_loader)
             if not show_progress
-            else auto.tqdm(enumerate(data_loader), desc=desc, total=progress_steps)
+            else enumerate(auto.tqdm(data_loader, desc=desc, total=progress_steps))
         )
         results = ModuleRunResults() if track_results else None
         previous_steps = (counter if counter > -1 else 0) * counter_len


### PR DESCRIPTION
Memory leak seems to be related to the way how tqdm is wrapping data_loader.
More info at: https://github.com/tqdm/tqdm/issues/746
This PR fixes https://github.com/neuralmagic/sparseml/issues/152
