### PR TITLE
Fix incorrect epoch in the checkpoint

### DIFF
--- a/scripts/pytorch_vision.py
+++ b/scripts/pytorch_vision.py
@@ -1193,7 +1193,7 @@ def train(args, model, train_loader, val_loader, input_shape, save_dir, loggers)
             # only convert qat -> quantized ONNX graph for finalized model
             # TODO: change this to all checkpoints when conversion times improve
             _save_model_training(
-                model, optim, input_shape, "model", save_dir, epoch, val_res, True
+                model, optim, input_shape, "model", save_dir, epoch - 1, val_res, True
             )
 
             LOGGER.info("layer sparsities:")


### PR DESCRIPTION
The checkpoint created at the end of training is saved with the wrong epoch number because of the `epoch += 1` in the training loop.