### PR TITLE
fix pickling in torch pruning hooks

### DIFF
--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -436,12 +436,12 @@ class ModuleParamPruningMask(object):
         for idx, (param, layer) in enumerate(zip(self._params, self._layers)):
             if self._forward_hooks[idx] is None:
                 self._forward_hooks[idx] = layer.register_forward_pre_hook(
-                    partial(self._hook_mask_forward, param_idx=idx)
+                    partial(self._hook_mask_forward, idx)
                 )
 
             if self._gradient_hooks[idx] is None:
                 self._gradient_hooks[idx] = param.register_hook(
-                    partial(self._hook_mask_gradient, param_idx=idx)
+                    partial(self._hook_mask_gradient, idx)
                 )
 
     def _delete_hooks(self):

--- a/tests/sparseml/pytorch/optim/test_modifier_pruning.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_pruning.py
@@ -272,6 +272,11 @@ class TestGMPruningModifier(ScheduledUpdateModifierTest):
         assert modifier.applied_sparsity == modifier.init_sparsity
         last_sparsity = modifier.init_sparsity
 
+        # check forward pass
+        input_shape = model_lambda.layer_descs()[0].input_size
+        test_batch = torch.randn(10, *input_shape)
+        _ = model(test_batch)
+
         while epoch < modifier.end_epoch - modifier.update_frequency:
             epoch += modifier.update_frequency
             assert modifier.update_ready(epoch, test_steps_per_epoch)
@@ -279,6 +284,7 @@ class TestGMPruningModifier(ScheduledUpdateModifierTest):
             assert modifier.applied_sparsity > last_sparsity
             last_sparsity = modifier.applied_sparsity
 
+        _ = model(test_batch)  # check forward pass
         epoch = int(modifier.end_epoch)
         assert modifier.update_ready(epoch, test_steps_per_epoch)
         modifier.scheduled_update(model, optimizer, epoch, test_steps_per_epoch)


### PR DESCRIPTION
Pruning hook functions were recently moved to be nested functions that would be returned for a given parameter idx to support global pruning.  This causes issues with python pickling because nested functions cannot be pickled.  This causes issues when `torch.save` is directly called on a pruned model.

Note that best practice is not to pickle entire pytorch models, but to just serialize their state dicts.

PyTorch tests passing. Some sample code to directly test pickling (fails without this change):

```python
from torchvision.models import resnet50
import torch
from sparseml.pytorch.optim import GMPruningModifier

model = resnet50(False)
mod = GMPruningModifier(0.5, 0.9, 0.0, 10.0, 0.1, "__ALL_PRUNABLE__", leave_enabled=True)
mod.initialize(model, None)
mod.scheduled_update(model, None, 1, 1)
torch.save(model, "tmp.pt")  # fails without this PR
```