### PR TITLE
topologically sort ONNX nodes

### DIFF
--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -22,6 +22,7 @@ from typing import Iterable, List, Optional, Union
 import numpy
 import onnx
 from onnx import ModelProto, NodeProto, TensorProto, numpy_helper
+from toposort import toposort_flatten
 
 from sparseml.onnx.utils.helpers import get_node_params
 
@@ -194,6 +195,35 @@ class ONNXGraph(object):
                 if not self._input_id_to_nodes[init.name]
             ]
         )  # delete inits that have no edge
+
+    def sort_nodes_topologically(self):
+        """
+        Sorts the order of the graph Node repeated field in place in topological
+        order as per the ONNX Model proto specifications
+        """
+        # build toposort DAG input and sort
+        model_dag = defaultdict(set)  # node_id -> dependencies
+        for parent_node_id, child_nodes in self._input_id_to_nodes.items():
+            if parent_node_id not in self._output_id_to_node:
+                continue  # parent is an initializer, not node
+            for child_node in child_nodes:
+                model_dag[child_node.output[0]].add(parent_node_id)
+        sorted_node_ids = toposort_flatten(model_dag)
+
+        # deduplicate any nodes from the sorted list
+        updated_node_list = []
+        seen_ids = set()
+        for node_id in sorted_node_ids:
+            if node_id in seen_ids:
+                continue  # a node could have multiple ids, all ids will be updated
+            node = self._output_id_to_node[node_id]
+            updated_node_list.append(node)
+            seen_ids.update(node.output)
+
+        # update model node list with topo sorted list
+        assert len(updated_node_list) == len(self._model.graph.node)
+        self._model.graph.ClearField("node")
+        self._model.graph.node.extend(updated_node_list)
 
     def _store_node_edges(self, node: NodeProto):
         for output_id in node.output:

--- a/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
@@ -598,6 +598,7 @@ def quantize_torch_qat_export(
     quantize_resnet_identity_add_inputs(model)
     quantized_residual_add_optim(model)
     _remove_duplicate_quantize__ops(model)
+    ONNXGraph(model).sort_nodes_topologically()
 
     if output_file_path:
         onnx.save(model, output_file_path)


### PR DESCRIPTION
@mgoin correctly noted that our quantized ONNX graph exports do not have topologically sorted nodes which violates the ONNX model proto spec and will cause an ONNX checker error. This PR adds a helper function to correct models after optimizations are made.