### PR TITLE
[cherry-pick] fix propagation of mask creator objects in PT pruning modifier (#220)

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_pruning.py
+++ b/src/sparseml/pytorch/optim/modifier_pruning.py
@@ -608,6 +608,7 @@ class GMPruningModifier(ScheduledUpdateModifier):
             layers,
             param_names,
             layer_names=layer_names,
+            mask_creator=self._mask_creator,
             global_sparsity=self._global_sparsity,
         )
 

--- a/src/sparseml/version.py
+++ b/src/sparseml/version.py
@@ -19,7 +19,7 @@ Functionality for storing and setting the version info for SparseML
 from datetime import date
 
 
-version_base = "0.3.0"
+version_base = "0.3.1"
 is_release = False  # change to True to set the generated version as a release version
 
 

--- a/tests/sparseml/pytorch/optim/test_modifier_pruning.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_pruning.py
@@ -22,6 +22,7 @@ from sparseml.pytorch.optim import (
     GlobalMagnitudePruningModifier,
     GMPruningModifier,
     MagnitudePruningModifier,
+    load_mask_creator,
 )
 from tests.sparseml.pytorch.helpers import LinearNet
 from tests.sparseml.pytorch.optim.test_modifier import (
@@ -260,6 +261,10 @@ class TestGMPruningModifier(ScheduledUpdateModifierTest):
         optimizer = optim_lambda(model)
         self.initialize_helper(modifier, model, optimizer)
         assert modifier.applied_sparsity is None
+        assert type(load_mask_creator(modifier._mask_type)) == type(  # noqa: E721
+            modifier._mask_creator
+        )
+        assert modifier._mask_creator == modifier._module_masks._mask_creator
 
         # check sparsity is not set before
         for epoch in range(int(modifier.start_epoch)):


### PR DESCRIPTION
fixes bug that defaults pytorch mask creators to be 'unstructured' in certain training flows

updates release version to 0.3.1 for this hotfix