### PR TITLE
torch ScheduledOptimizer del - check manager

### DIFF
--- a/src/sparseml/pytorch/optim/optimizer.py
+++ b/src/sparseml/pytorch/optim/optimizer.py
@@ -92,7 +92,10 @@ class ScheduledOptimizer(Optimizer):
         self._manager.initialize_loggers(loggers)
 
     def __del__(self):
-        del self._manager
+        try:
+            del self._manager
+        except Exception:
+            pass
 
     def __getstate__(self):
         return self._optimizer.__getstate__()


### PR DESCRIPTION
currently python 3.8 tests of this function fail because del is called twice
* `hasattr` wasn't used because it currently causes an infinite recursion