### PR TITLE
renaming torchvision script for import compatibility

### DIFF
--- a/integrations/pytorch/README.md
+++ b/integrations/pytorch/README.md
@@ -78,14 +78,14 @@ print(recipe)
 
 The following table lays out the root-level files and folders along with a description for each.
 
-| Folder/File Name     | Description                                                                                                           |
-|----------------------|-----------------------------------------------------------------------------------------------------------------------|
-| notebooks            | Jupyter notebooks to walk through sparsifiation within standard PyTorch training flows                                |
-| recipes              | Typical recipes for sparsifying PyTorch models along with any downloaded recipes from the SparseZoo.                  |
-| tutorials            | Tutorial walkthroughs for how to sparsify PyTorch models using recipes.                                               |
-| README.md            | Readme file.                                                                                                          |
-| torchvision.py       | Example training script for sparsifying PyTorch torchvision classification models.                                    |
-| vision.py            | Utility training script for sparsifying classification and detection models in PyTorch (loads SparseML models).       |
+| Folder/File Name              | Description                                                                                                           |
+|-------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| notebooks                     | Jupyter notebooks to walk through sparsifiation within standard PyTorch training flows                                |
+| recipes                       | Typical recipes for sparsifying PyTorch models along with any downloaded recipes from the SparseZoo.                  |
+| tutorials                     | Tutorial walkthroughs for how to sparsify PyTorch models using recipes.                                               |
+| README.md                     | Readme file.                                                                                                          |
+| torchvision_sparsification.py | Example training script for sparsifying PyTorch torchvision classification models.                                    |
+| vision.py                     | Utility training script for sparsifying classification and detection models in PyTorch (loads SparseML models).       |
 
 ### Exporting for Inference
 

--- a/integrations/pytorch/torchvision_sparsification.py
+++ b/integrations/pytorch/torchvision_sparsification.py
@@ -76,7 +76,7 @@ optional arguments:
 
 ##########
 Example command for pruning resnet50 on an imagefolder dataset:
-python integrations/pytorch-torchvision/main.py \
+python integrations/pytorch/torchvision_sparsification.py \
     --recipe-path ~/sparseml_recipes/pruning_resnet50.yaml \
     --model resnet50 \
     --imagefolder-path ~/datasets/ILSVRC2012 \


### PR DESCRIPTION
`integrations/pytorch/vision.py` is currently failing with
```
  File "/mnt/sda1/neuralmagic/sparseml/integrations/pytorch/torchvision.py", line 95, in <module>
    from torchvision import models
ImportError: cannot import name 'models'
```