### PR TITLE
fix warning in MFAC torch.nonzero usage

### DIFF
--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -710,7 +710,9 @@ class ModuleParamPruningMask(object):
         if self._score_type == PruningScoreTypes.MFAC:
             total_nonzero = 0
             for idx, mask in enumerate(self._param_masks):
-                self._mfac_unpruned_idxs[idx] = mask.view(-1).nonzero().reshape(-1)
+                self._mfac_unpruned_idxs[idx] = (
+                    mask.view(-1).nonzero(astuple=False).reshape(-1)
+                )
                 total_nonzero += self._mfac_unpruned_idxs[idx].numel()
             # only track nonzero grads
             num_grads = self._mfac_options.get_num_grads_for_sparsity(

--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -711,7 +711,7 @@ class ModuleParamPruningMask(object):
             total_nonzero = 0
             for idx, mask in enumerate(self._param_masks):
                 self._mfac_unpruned_idxs[idx] = (
-                    mask.view(-1).nonzero(astuple=False).reshape(-1)
+                    mask.view(-1).nonzero(as_tuple=False).reshape(-1)
                 )
                 total_nonzero += self._mfac_unpruned_idxs[idx].numel()
             # only track nonzero grads


### PR DESCRIPTION
fixing this warning
```
INFO     note, the lr for the optimizer may not reflect the manager yet until the recipe config is created and run
/mnt/sda1/neuralmagic/sparseml/src/sparseml/pytorch/optim/mask_pruning.py:699: UserWarning: This overload of nonzero is deprecated:
        nonzero()
Consider using one of the following signatures instead:
        nonzero(*, bool as_tuple) (Triggered internally at  /pytorch/torch/csrc/utils/python_arg_parser.cpp:882.)
  self._mfac_unpruned_idxs[idx] = mask.view(-1).nonzero().reshape(-1)
```