### PR TITLE
PyTorch refactor pruning algorithms with pruning scorer object

### DIFF
--- a/src/sparseml/pytorch/optim/__init__.py
+++ b/src/sparseml/pytorch/optim/__init__.py
@@ -26,6 +26,7 @@ from .analyzer_pruning import *
 from .manager import *
 from .mask_creator_pruning import *
 from .mask_pruning import *
+from .mask_pruning_scorer import *
 from .modifier import *
 from .modifier_as import *
 from .modifier_epoch import *

--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -17,7 +17,6 @@ Code related to applying a mask onto a parameter to impose kernel sparsity,
 aka model pruning
 """
 
-from enum import Enum
 from functools import partial
 from typing import List, Optional, Tuple, Union
 
@@ -29,30 +28,13 @@ from sparseml.pytorch.optim.mask_creator_pruning import (
     PruningMaskCreator,
     UnstructuredPruningMaskCreator,
 )
-from sparseml.pytorch.utils import MFACOptions, compute_hessian_inv, mask_difference
+from sparseml.pytorch.optim.mask_pruning_scorer import create_pruning_param_scorer
+from sparseml.pytorch.utils import MFACOptions, mask_difference
 
 
 __all__ = [
-    "PruningScoreTypes",
     "ModuleParamPruningMask",
 ]
-
-
-class PruningScoreTypes(str, Enum):
-    """
-    Methods for scoring parameters for pruning
-    """
-
-    MAGNITUDE = "magnitude"  # https://neuralmagic.com/blog/pruning-gmp/
-    MOVEMENT = "movement"  # https://arxiv.org/abs/2005.07683
-    MFAC = "M-FAC"
-
-    @staticmethod
-    def values() -> List[str]:
-        """
-        :return: List of string values this Enum can take
-        """
-        return [score_type.value for score_type in PruningScoreTypes]
 
 
 class ModuleParamPruningMask(object):
@@ -93,7 +75,7 @@ class ModuleParamPruningMask(object):
         mask_creator: PruningMaskCreator = UnstructuredPruningMaskCreator(),
         layer_names: Optional[List[str]] = None,
         global_sparsity: bool = False,
-        score_type: Union[PruningScoreTypes, MFACOptions] = PruningScoreTypes.MAGNITUDE,
+        score_type: Union[str, MFACOptions] = "magnitude",
     ):
         self._layers = layers
         self._param_names = (
@@ -103,9 +85,7 @@ class ModuleParamPruningMask(object):
         )
         self._layer_names = layer_names
         self._store_init = store_init
-        self._store_unmasked = (
-            store_unmasked or score_type == PruningScoreTypes.MOVEMENT
-        )
+        self._store_unmasked = store_unmasked
         self._track_grad_mom = track_grad_mom
         self._mask_creator = mask_creator
         self._global_sparsity = global_sparsity
@@ -131,37 +111,17 @@ class ModuleParamPruningMask(object):
         self._params_unmasked = [None] * len(self._layers)  # type: List[Tensor]
         self._params_grad = [None] * len(self._layers)  # type: List[Tensor]
         self._params_movement = [None] * len(self._layers)  # type: List[Tensor]
-        self._mfac_unpruned_idxs = [None] * len(self._layers)  # type: List[Tensor]
-        self._mfac_grad_buffer = None  # type: Tensor
-        self._mfac_buffer_idx = 0  # type: int
-        self._mfac_latest_h_inv_diag = None  # type: tuple
-        self._mfac_last_applied_sparsity = 0.0  # type: float
 
-        # validate score type
-        if isinstance(score_type, MFACOptions):
-            self._mfac_options = score_type
-            score_type = PruningScoreTypes.MFAC
-        else:
-            self._mfac_options = (
-                MFACOptions() if score_type == PruningScoreTypes.MFAC else None
-            )
-        if score_type not in PruningScoreTypes.values():
-            raise ValueError(
-                f"Invalid score_type: {score_type}. "
-                f"Valid values: {PruningScoreTypes.values()}"
-            )
-        self._score_type = score_type
+        # create scorer
+        self._scorer = create_pruning_param_scorer(self._params, score_type)
         # movement pruning requires weight reintroduction
-        self._allow_reintroduction = self._score_type == PruningScoreTypes.MOVEMENT
+        self._allow_reintroduction = self._score_type == "movement"
+        self._store_unmasked |= self._allow_reintroduction  # to support reintroduction
 
         self._setup_params_init()
         self._setup_params_unmasked()
         self._setup_params_grad()
         self._setup_param_movement()
-        self._setup_mfac_grad_buffer()
-
-        if score_type == PruningScoreTypes.MOVEMENT:
-            self.enabled = True
 
     def __len__(self):
         return len(self._layers)
@@ -241,13 +201,6 @@ class ModuleParamPruningMask(object):
         return self._global_sparsity
 
     @property
-    def params_movement(self) -> Union[None, List[Tensor]]:
-        """
-        :return: The current movement scores for each parameter
-        """
-        return self._params_movement
-
-    @property
     def enabled(self) -> bool:
         """
         :return: True if the parameter is currently being masked, False otherwise
@@ -322,7 +275,7 @@ class ModuleParamPruningMask(object):
         return self._params_grad
 
     @property
-    def score_type(self) -> PruningScoreTypes:
+    def score_type(self) -> Union[str, MFACOptions]:
         """
         :return: the scoring method used to create masks (i.e. magnitude, movement)
         """
@@ -380,19 +333,14 @@ class ModuleParamPruningMask(object):
 
             mask_diffs.append(mask_diff)
 
-        if self._score_type == PruningScoreTypes.MFAC:
-            if self._mfac_latest_h_inv_diag:
-                # perform OBS weight update
-                self._update_weights_mfac_obs_perturb(mask_diffs)
-            self._mfac_latest_h_inv_diag = None  # clear h_inv
-            self._setup_mfac_grad_buffer()  # reset grad buffer
-            torch.cuda.empty_cache()
-        if self._score_type != PruningScoreTypes.MOVEMENT:
+        self._scorer.mask_update(masks, mask_diffs)
+
+        if not self._allow_reintroduction:
             self.apply()
 
         return mask_diffs
 
-    def set_param_masks_from_weights(self) -> Tensor:
+    def set_param_masks_from_weights(self) -> List[Tensor]:
         """
         Convenience function to set the parameter masks such that the
         mask is 1 if a parameter value is non zero and 0 otherwise,
@@ -407,21 +355,21 @@ class ModuleParamPruningMask(object):
 
     def set_param_masks_from_abs_threshold(
         self, threshold: Union[float, Tensor]
-    ) -> Tensor:
+    ) -> List[Tensor]:
         """
         Convenience function to set the parameter masks such that if
         abs(value) <= threshold the it a value is masked to 0
 
         :param threshold: the threshold at which all values will be masked to 0
         """
-        score_tensors = self._score_parameters()
+        param_scores = self._scorer.score_parameters()
         masks = self._mask_creator.create_sparsity_masks_from_threshold(
-            score_tensors, threshold
+            param_scores, threshold
         )
 
         return self.set_param_masks(masks)
 
-    def set_param_masks_from_sparsity(self, sparsity: float) -> Tensor:
+    def set_param_masks_from_sparsity(self, sparsity: float) -> List[Tensor]:
         """
         Convenience function to set the parameter masks such that each masks have an
         amount of masked values such that the percentage equals the sparsity amount
@@ -429,11 +377,11 @@ class ModuleParamPruningMask(object):
 
         :param sparsity: the decimal sparsity to set the param mask to
         """
-        score_tensors = self._score_parameters()
+        param_scores = self._scorer.score_parameters()
         masks = self._mask_creator.create_sparsity_masks(
-            score_tensors, sparsity, global_sparsity=self._global_sparsity
+            param_scores, sparsity, global_sparsity=self._global_sparsity
         )
-        self._mfac_last_applied_sparsity = sparsity
+        self._scorer.update_last_applied_sparsity(sparsity)
 
         return self.set_param_masks(masks)
 
@@ -473,31 +421,7 @@ class ModuleParamPruningMask(object):
         updates scores and buffers that depend on gradients. Should be called
         before Optimizer.step() to grab the latest gradients
         """
-        if self._score_type == PruningScoreTypes.MOVEMENT:
-            # update movement scores
-            for idx, param in enumerate(self._params):
-                if param.grad is not None:
-                    self._params_movement[idx].add_(-0.01 * param.grad * param.data)
-        elif self._score_type == PruningScoreTypes.MFAC:
-            # update M-FAC gradient buffer
-            if any(param.grad is None for param in self._params):
-                return
-
-            # get non-pruned grads
-            non_pruned_grads = [
-                param.grad.view(-1)[self._mfac_unpruned_idxs[idx]].to(
-                    self._mfac_grad_buffer.device
-                )
-                for idx, param in enumerate(self._params)
-            ]
-            # update buffer
-            torch.cat(
-                non_pruned_grads,
-                out=self._mfac_grad_buffer[self._mfac_buffer_idx, :],  # write to buffer
-            )
-            # update buffer idx
-            self._mfac_buffer_idx += 1
-            self._mfac_buffer_idx %= self._mfac_grad_buffer.size(0)
+        self._scorer.pre_optim_step_update()
 
     def disable_reintroduction(self):
         """
@@ -505,56 +429,6 @@ class ModuleParamPruningMask(object):
         disables further weight reintroduction
         """
         self._allow_reintroduction = False
-
-    def _score_parameters(self):
-        if self._score_type == PruningScoreTypes.MAGNITUDE:
-            # S = |W|
-            return [torch.abs(param.data) for param in self._params]
-        if self._score_type == PruningScoreTypes.MOVEMENT:
-            # S = -dL/dW * W
-            return self._params_movement
-        if self._score_type == PruningScoreTypes.MFAC:
-            if torch.any(torch.all(self._mfac_grad_buffer == 0.0, dim=1)):
-                return [torch.abs(param.data) for param in self._params]
-            # S = W^2 / (2 * diag(H^-1))
-
-            # gather non-pruned weights
-            non_pruned_weights = torch.empty(self._mfac_grad_buffer.size(1)).to(
-                self._mfac_grad_buffer.device
-            )
-            weights_idx = 0
-            for idx, param in enumerate(self._params):
-                indices = self._mfac_unpruned_idxs[idx]
-                next_idx = weights_idx + indices.numel()
-                non_pruned_weights[weights_idx:next_idx] = param.data.view(-1)[indices]
-                weights_idx = next_idx
-
-            # inverse hessian approximation
-            h_inv = compute_hessian_inv(self._mfac_grad_buffer, self._mfac_options)
-            diag = h_inv.diag().to(non_pruned_weights.device)
-
-            global_scores = (non_pruned_weights ** 2) / (2.0 * diag)
-            parameter_scores = []
-            # set pruned weights smaller than unpruned
-            minimum_score = global_scores.min().item() - 1
-            weights_idx = 0
-            for idx, param in enumerate(self._params):
-                indices = self._mfac_unpruned_idxs[idx]
-                next_idx = weights_idx + indices.numel()
-                param_score = ModuleParamPruningMask._detach_tens(
-                    torch.ones_like(param.data) * minimum_score
-                )
-                param_score.view(-1)[self._mfac_unpruned_idxs[idx]] = global_scores[
-                    weights_idx:next_idx
-                ].to(param_score.device)
-                weights_idx = next_idx
-
-                parameter_scores.append(param_score)
-
-            # save h_inv and diag for weight update later
-            self._mfac_latest_h_inv_diag = (h_inv, diag)
-            torch.cuda.empty_cache()
-            return parameter_scores
 
     def _check_regen_value(self, val: Tensor, param_idx: int) -> Tensor:
         if self._params[param_idx].data.device != val.device:
@@ -605,15 +479,7 @@ class ModuleParamPruningMask(object):
                     )
                 )
 
-            if (
-                self._params_movement[idx] is not None
-                and self._params[idx].data.device != self._params_movement[idx].device
-            ):
-                self._params_movement[idx] = ModuleParamPruningMask._detach_tens(
-                    torch.empty_like(self._params[idx].data).copy_(
-                        self._params_movement[idx]
-                    )
-                )
+            self._scorer.check_regen_param_vals()
 
     def _create_hooks(self):
         for idx, (param, layer) in enumerate(zip(self._params, self._layers)):
@@ -622,10 +488,7 @@ class ModuleParamPruningMask(object):
                     partial(self._hook_mask_forward, idx)
                 )
 
-            if (
-                self._score_type == PruningScoreTypes.MOVEMENT
-                and self._undo_mask_hooks[idx] is None
-            ):
+            if not self._allow_reintroduction and self._undo_mask_hooks[idx] is None:
                 self._undo_mask_hooks[idx] = layer.register_forward_hook(
                     partial(self._hook_undo_mask, idx)
                 )
@@ -698,62 +561,6 @@ class ModuleParamPruningMask(object):
                 )
             elif self._track_grad_mom < 0.0 and self._params_grad[idx] is not None:
                 self._params_grad[idx] = None
-
-    def _setup_param_movement(self):
-        if self._score_type == PruningScoreTypes.MOVEMENT:
-            for idx, param in enumerate(self._params):
-                self._params_movement[idx] = ModuleParamPruningMask._detach_tens(
-                    param.data.new_zeros(param.data.shape)
-                )
-
-    def _setup_mfac_grad_buffer(self):
-        if self._score_type == PruningScoreTypes.MFAC:
-            total_nonzero = 0
-            for idx, mask in enumerate(self._param_masks):
-                self._mfac_unpruned_idxs[idx] = (
-                    mask.view(-1).nonzero(as_tuple=False).reshape(-1)
-                )
-                total_nonzero += self._mfac_unpruned_idxs[idx].numel()
-            # only track nonzero grads
-            num_grads = self._mfac_options.get_num_grads_for_sparsity(
-                self._mfac_last_applied_sparsity
-            )
-            self._mfac_grad_buffer = torch.zeros(
-                (num_grads, total_nonzero),
-                device=self._mfac_options.grads_device,
-            )
-            self._mfac_buffer_idx = 0
-
-    @torch.no_grad()
-    def _update_weights_mfac_obs_perturb(self, mask_diffs):
-        # select weights that are about to be masked with 0s for unmasked weights
-        weights_to_prune = torch.zeros(
-            self._mfac_grad_buffer.size(1),
-            device=self._mfac_grad_buffer.device,
-        )
-        weights_idx = 0
-        for idx, mask_diff in enumerate(mask_diffs):
-            indices = self._mfac_unpruned_idxs[idx]
-            next_idx = weights_idx + indices.numel()
-            weights_to_prune[weights_idx:next_idx] = (
-                self._params[idx].data.view(-1)[indices]
-                * (mask_diff.view(-1)[indices] == -1.0)  # newly pruned weights
-            ).to(weights_to_prune.device)
-            weights_idx = next_idx
-
-        # calculate optimal perturbation = -w_i * H^-1 / H_{i,i}
-        h_inv, diag = self._mfac_latest_h_inv_diag
-        perturb = h_inv.mul(-1.0 * weights_to_prune / diag)
-        weights_idx = 0
-
-        # update weights by mapping to perturbation
-        for idx, param in enumerate(self._params):
-            indices = self._mfac_unpruned_idxs[idx]
-            next_idx = weights_idx + indices.numel()
-            param.view(-1)[self._mfac_unpruned_idxs[idx]] += perturb[
-                weights_idx:next_idx
-            ].to(param.device)
-            weights_idx = next_idx
 
     @staticmethod
     def _detach_tens(tens) -> Tensor:

--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -114,14 +114,14 @@ class ModuleParamPruningMask(object):
 
         # create scorer
         self._scorer = create_pruning_param_scorer(self._params, score_type)
+
         # movement pruning requires weight reintroduction
-        self._allow_reintroduction = self._score_type == "movement"
+        self._allow_reintroduction = self._scorer.get_name() == "movement"
         self._store_unmasked |= self._allow_reintroduction  # to support reintroduction
 
         self._setup_params_init()
         self._setup_params_unmasked()
         self._setup_params_grad()
-        self._setup_param_movement()
 
     def __len__(self):
         return len(self._layers)
@@ -279,7 +279,7 @@ class ModuleParamPruningMask(object):
         """
         :return: the scoring method used to create masks (i.e. magnitude, movement)
         """
-        return self._score_type
+        return self._scorer.get_name()
 
     def set_param_data(self, value: Tensor, param_idx: int):
         """

--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -488,7 +488,7 @@ class ModuleParamPruningMask(object):
                     partial(self._hook_mask_forward, idx)
                 )
 
-            if not self._allow_reintroduction and self._undo_mask_hooks[idx] is None:
+            if self._allow_reintroduction and self._undo_mask_hooks[idx] is None:
                 self._undo_mask_hooks[idx] = layer.register_forward_hook(
                     partial(self._hook_undo_mask, idx)
                 )
@@ -519,7 +519,8 @@ class ModuleParamPruningMask(object):
 
     def _hook_undo_mask(self, param_idx, module, inp, out):
         if self._allow_reintroduction:
-            self._params[param_idx].data.add_(self._params_unmasked[param_idx])
+            with torch.no_grad():
+                self._params[param_idx].data.add_(self._params_unmasked[param_idx])
 
     def _hook_mask_gradient(self, param_idx, grad):
         if 0.0 <= self._track_grad_mom < 1.0:

--- a/src/sparseml/pytorch/optim/mask_pruning_scorer.py
+++ b/src/sparseml/pytorch/optim/mask_pruning_scorer.py
@@ -32,6 +32,7 @@ __all__ = [
     "PruningParamsScorer",
     "MagnitudePruningParamsScorer",
     "MovementPruningParamsScorer",
+    "MFACPruningParamsScorer",
     "MFACOptions",
     "create_pruning_param_scorer",
 ]
@@ -197,7 +198,7 @@ class MFACPruningParamsScorer(PruningParamsScorer):
     def __init__(self, params: List[Parameter], mfac_options: MFACOptions = None):
         super().__init__(params)
 
-        self._mfac_options = MFACOptions() or mfac_options
+        self._mfac_options = mfac_options or MFACOptions()
         self._unpruned_idxs = [None] * len(self._params)  # type: List[Tensor]
         self._grad_buffer = None  # type: Tensor
         self._buffer_idx = 0

--- a/src/sparseml/pytorch/optim/mask_pruning_scorer.py
+++ b/src/sparseml/pytorch/optim/mask_pruning_scorer.py
@@ -1,0 +1,353 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Classes for tracking and scoring model parameters to generate pruning scores
+"""
+
+
+from abc import ABC, abstractmethod
+from typing import List, Union
+
+import torch
+from torch import Tensor
+from torch.nn import Parameter
+
+from sparseml.pytorch.utils import MFACOptions, compute_hessian_inv
+
+
+__all__ = [
+    "PruningParamsScorer",
+    "MagnitudePruningParamsScorer",
+    "MovementPruningParamsScorer",
+    "MFACOptions",
+    "create_pruning_param_scorer",
+]
+
+
+class PruningParamsScorer(ABC):
+    """
+    Base abstract class for scoring model parameters for pruning
+
+    :param params: list of model Parameters to track and score
+    """
+
+    def __init__(self, params: List[Parameter]):
+        self._params = params
+        self._last_applied_sparsity = 0.0
+
+    @abstractmethod
+    def score_parameters(self) -> List[Tensor]:
+        """
+        :return: List of Tensors the same shapes as the given Parameters that
+            correspond to their scores to be pruned by
+        """
+        raise NotImplementedError()
+
+    def pre_optim_step_update(self):
+        """
+        Perform any required logic for tracking Parameter data and gradients before
+            an Optimizer step is applied to the model.
+        """
+        pass
+
+    def mask_update(self, masks: List[Tensor], mask_diffs: List[Tensor]):
+        """
+        Perform any updates based on the latest mask to be applied to the weights
+        immediately after this function completes
+
+        :param masks: latest masks to be applied to these parameters
+        :param mask_diffs: mask diff values returned by mask_difference for these
+            masks that describe how these masks changed since the last update
+        """
+        pass
+
+    def update_last_applied_sparsity(self, sparsity: float):
+        """
+        :param sparsity: sparsity level between 0.0 and 1.0 that was the last value
+            set for the given parameters
+        """
+        self._last_applied_sparsity = sparsity
+
+    def check_regen_param_vals(self):
+        """
+        Check that all variables based on the params are on the correct device
+        and regenerate if not
+        """
+        pass
+
+
+class MagnitudePruningParamsScorer(PruningParamsScorer):
+    """
+    Scores parameters based on their magnitude
+
+    :param params: list of model Parameters to track and score
+    """
+
+    def score_parameters(self) -> List[Tensor]:
+        """
+        :return: List of Tensors the same shapes as the given Parameters where
+            each Parameter's elements are scored by their magnitude (absolute value)
+        """
+        return [torch.abs(param.data) for param in self._params]
+
+
+class MovementPruningParamsScorer(PruningParamsScorer):
+    """
+    Scores parameters based on their movement which is defined as
+    movement_score = sum(-1.0 * W * dL/dW)
+
+    Movement pruning introduced here: https://arxiv.org/abs/2005.07683
+
+    :param params: list of model Parameters to track and score
+    """
+
+    def __init__(self, params: List[Parameter]):
+        super().__init__(params)
+
+        self._movement_scores = [
+            param.data.new_zeros(param.data.shape).detach().requires_grad_(False)
+            for param in self._params
+        ]
+
+    def score_parameters(self) -> List[Tensor]:
+        """
+        :return: List of Tensors the same shapes as the given Parameters where
+            each Parameter's elements are scored by their weight times the direction
+            of their gradient.
+        """
+        return self._movement_scores
+
+    def pre_optim_step_update(self):
+        """
+        Update movement scores based on the current Parameter weights and gradients
+        """
+        for idx, param in enumerate(self._params):
+            if param.grad is not None:
+                self._movement_scores[idx].add_(-0.01 * param.grad * param.data)
+
+    def check_regen_param_vals(self):
+        """
+        Check that movement scores are on the correct device and regenerate if not
+        """
+        for idx, param in enumerate(self._params):
+            if self._params[idx].data.device != self._movement_scores[idx].device:
+                self._movement_scores[idx] = (
+                    torch.empty_like(self._params[idx].data)
+                    .copy_(self._movement_scores[idx])
+                    .detach()
+                    .requires_grad_(False)
+                )
+
+
+class MFACPruningParamsScorer(PruningParamsScorer):
+    """
+    Scores parameters using the Matrix-Free Approximate Curvature (M-FAC)
+    algorithm to solve for the optimal update in the Optimal Brain Surgeon (OBS)
+    framework.  Given an estimate of the inverse Hessian matrix H^-1,
+    scores are determined by W^2 / (2 * diag(H^-1)).
+
+    Additionally, when masking, weights should also be updated by the optimal
+    perturbation: -w_i * H^-1 / H_{i,i} for every newly masked weight w_i.
+
+    :param params: list of model Parameters to track and score
+    :param mfac_options: Dictionary of key words specifying arguments for the M-FAC
+        pruning run. num_grads controls the number of gradient samples that are kept,
+        fisher_block_size if given enables block approximations of the Fisher matrix
+        (if not specified, the full matrix is used), available_gpus specifies a list
+        of device ids that can be used for computation. For a full list of options,
+        see the MFACOptions dataclass documentation. Default configuration uses
+        CPU for computation without blocked computation
+    """
+
+    def __init__(self, params: List[Parameter], mfac_options: MFACOptions = None):
+        super().__init__(params)
+
+        self._mfac_options = MFACOptions() or mfac_options
+        self._unpruned_idxs = [None] * len(self._params)  # type: List[Tensor]
+        self._grad_buffer = None  # type: Tensor
+        self._buffer_idx = 0
+        self._latest_h_inv_diag = None  # type: tuple
+
+        self._setup_grad_buffer()
+
+    def score_parameters(self) -> List[Tensor]:
+        """
+        :return: List of Tensors the same shapes as the given Parameters where
+            each Parameter's elements are scored based on the optimal value
+            given by the OBS method. For the approximated Hessian inverse matrix
+            H^-1, scores will be W^2 / (2 * diag(H^-1))
+        """
+        if torch.any(torch.all(self._grad_buffer == 0.0, dim=1)):
+            # if not all grads are captured, return magnitudes as scores
+            return [torch.abs(param.data) for param in self._params]
+
+        # gather non-pruned weights
+        non_pruned_weights = torch.empty(self._grad_buffer.size(1)).to(
+            self._grad_buffer.device
+        )
+        weights_idx = 0
+        for idx, param in enumerate(self._params):
+            indices = self._unpruned_idxs[idx]
+            next_idx = weights_idx + indices.numel()
+            non_pruned_weights[weights_idx:next_idx] = param.data.view(-1)[indices]
+            weights_idx = next_idx
+
+        # inverse hessian approximation
+        h_inv = compute_hessian_inv(self._grad_buffer, self._mfac_options)
+        diag = h_inv.diag().to(non_pruned_weights.device)
+
+        # compute global scores for non-pruned weights
+        global_scores = (non_pruned_weights ** 2) / (2.0 * diag)
+        parameter_scores = []
+        minimum_score = global_scores.min().item() - 1
+
+        # map global scores to parameter weight shapes
+        weights_idx = 0
+        for idx, param in enumerate(self._params):
+            indices = self._unpruned_idxs[idx]
+            next_idx = weights_idx + indices.numel()
+            param_score = torch.ones_like(param.data).detach().requires_grad_(False)
+            param_score *= minimum_score  # set values to the minimal score by default
+
+            param_score.view(-1)[self._unpruned_idxs[idx]] = global_scores[
+                weights_idx:next_idx
+            ].to(param_score.device)
+            weights_idx = next_idx
+
+            parameter_scores.append(param_score)
+
+        # save h_inv and diag for weight update later
+        self._latest_h_inv_diag = (h_inv, diag)
+        torch.cuda.empty_cache()  # release GPU memory
+
+        return parameter_scores
+
+    def pre_optim_step_update(self):
+        """
+        Update the gradient buffer based on the current gradients
+        """
+        if any(param.grad is None for param in self._params):
+            # only update buffer if all gradients are computed
+            return
+
+        # get non-pruned grads
+        non_pruned_grads = [
+            param.grad.view(-1)[self._unpruned_idxs[idx]].to(self._grad_buffer.device)
+            for idx, param in enumerate(self._params)
+        ]
+
+        # update buffer
+        torch.cat(
+            non_pruned_grads,
+            out=self._grad_buffer[self._buffer_idx, :],  # write to buffer
+        )
+        del non_pruned_grads
+
+        # update buffer idx
+        self._buffer_idx += 1
+        self._buffer_idx %= self._grad_buffer.size(0)
+
+    @torch.no_grad()
+    def mask_update(self, masks: List[Tensor], mask_diffs: List[Tensor]):
+        """
+        Update parameters for a new mask based on the OBS optimal perturbation:
+        -w_i * H^-1 / H_{i,i} for every newly masked weight w_i
+
+        :param masks: latest masks to be applied to these parameters
+        :param mask_diffs: mask diff values returned by mask_difference for these
+            masks that describe how these masks changed since the last update
+        """
+        # select weights that are about to be masked with 0s for unmasked weights
+        weights_to_prune = torch.zeros(
+            self._grad_buffer.size(1),
+            device=self._grad_buffer.device,
+        )
+        weights_idx = 0
+        for idx, mask_diff in enumerate(mask_diffs):
+            indices = self._unpruned_idxs[idx]
+            next_idx = weights_idx + indices.numel()
+            weights_to_prune[weights_idx:next_idx] = (
+                self._params[idx].data.view(-1)[indices]
+                * (mask_diff.view(-1)[indices] == -1.0)  # newly pruned weights
+            ).to(weights_to_prune.device)
+            weights_idx = next_idx
+
+        # calculate optimal perturbation = -w_i * H^-1 / H_{i,i}
+        h_inv, diag = self._latest_h_inv_diag
+        perturb = h_inv.mul(-1.0 * weights_to_prune / diag)
+        weights_idx = 0
+
+        # update weights by mapping to perturbation
+        for idx, param in enumerate(self._params):
+            indices = self._unpruned_idxs[idx]
+            next_idx = weights_idx + indices.numel()
+            param.view(-1)[self._unpruned_idxs[idx]] += perturb[
+                weights_idx:next_idx
+            ].to(param.device)
+            weights_idx = next_idx
+
+        self._latest_h_inv_diag = None  # clear h_inv
+        self._setup_grad_buffer()  # reset grad buffer
+        torch.cuda.empty_cache()  # release GPU memory
+
+    def _setup_grad_buffer(self):
+        total_nonzero = 0
+        for idx, param in enumerate(self._params):
+            self._unpruned_idxs[idx] = (
+                param.view(-1).nonzero(as_tuple=False).reshape(-1)
+            )
+            total_nonzero += self._unpruned_idxs[idx].numel()
+        # only track nonzero grads
+        num_grads = self._mfac_options.get_num_grads_for_sparsity(
+            self._last_applied_sparsity
+        )
+        self._grad_buffer = torch.zeros(
+            (num_grads, total_nonzero),
+            device=self._mfac_options.grads_device,
+        )
+        self._buffer_idx = 0
+
+
+_SCORE_TYPE_TO_CONSTRUCTOR = {
+    "magnitude": MagnitudePruningParamsScorer,
+    "movement": MovementPruningParamsScorer,
+    "MFAC": MFACPruningParamsScorer,
+}
+
+
+def create_pruning_param_scorer(
+    params: List[Parameter],
+    score_type: Union[str, MFACOptions],
+) -> PruningParamsScorer:
+    """
+    :param params: List of Parameters for the created PruningParamsScorer to track
+    :param score_type: String name of scoring type to use. Valid options are
+        'magnitude', 'movement', or 'MFAC'. For MFAC pruning, passing in an MFACOptions
+        object valid and is preferred.
+    """
+    if isinstance(score_type, str):
+        if score_type not in _SCORE_TYPE_TO_CONSTRUCTOR:
+            raise ValueError(
+                f"Invalid score_type {score_type}. Valid score types include "
+                f"{list(_SCORE_TYPE_TO_CONSTRUCTOR.keys())}"
+            )
+        return _SCORE_TYPE_TO_CONSTRUCTOR[score_type](params)
+    if isinstance(score_type, MFACOptions):
+        return MFACPruningParamsScorer(params, mfac_options=score_type)
+
+    raise ValueError(
+        f"Recieved unsupported type for score_type: {type(score_type)} "
+        "expected string or MFACOptions object"
+    )

--- a/src/sparseml/pytorch/optim/mask_pruning_scorer.py
+++ b/src/sparseml/pytorch/optim/mask_pruning_scorer.py
@@ -151,7 +151,7 @@ class MovementPruningParamsScorer(PruningParamsScorer):
         Update movement scores based on the current Parameter weights and gradients
         """
         for idx, param in enumerate(self._params):
-            if param.grad is not None:
+            if param.grad is not None and not torch.any(param.grad.isnan()):
                 self._movement_scores[idx].add_(-0.01 * param.grad * param.data)
 
     def check_regen_param_vals(self):

--- a/src/sparseml/pytorch/utils/mfac_helpers.py
+++ b/src/sparseml/pytorch/utils/mfac_helpers.py
@@ -484,7 +484,7 @@ class FisherInverseFastPageSwap(FisherInverse):
             grad_sample = self._hinv_g[page_sample_idx + page_offset, :].to(self._gpu0)
             mul = fisher_inv_buf_gpu[:page_sample_idx, :].matmul(
                 grad_sample
-            ) / self._denom[page_sample_idx : (page_sample_idx + page_offset)].to(
+            ) / self._denom[page_offset : (page_sample_idx + page_offset)].to(
                 self._gpu0
             )
             fisher_inv_buf_gpu[page_sample_idx, :] -= mul.matmul(

--- a/tests/sparseml/pytorch/optim/test_mask_pruning_scorer.py
+++ b/tests/sparseml/pytorch/optim/test_mask_pruning_scorer.py
@@ -43,7 +43,7 @@ def _fake_params_random_update(params):
         ("movement", 5),
         (MFACOptions(num_grads=10), 12),
         (MFACOptions(num_grads=10, fisher_block_size=24), 10),
-        (MFACOptions(num_grads=8, num_pages=4), 8),
+        (MFACOptions(num_grads=8, num_pages=4 if torch.cuda.is_available() else 1), 8),
     ],
 )
 def test_pruning_scorer(score_type, n_updates):

--- a/tests/sparseml/pytorch/optim/test_mask_pruning_scorer.py
+++ b/tests/sparseml/pytorch/optim/test_mask_pruning_scorer.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from sparseml.pytorch.optim import (
+    MagnitudePruningParamsScorer,
+    MFACOptions,
+    MFACPruningParamsScorer,
+    MovementPruningParamsScorer,
+    create_pruning_param_scorer,
+)
+
+
+def _make_fake_params(n, shape):
+    return [torch.nn.Parameter(torch.randn(*shape)) for _ in range(n)]
+
+
+def _fake_params_random_update(params):
+    for param in params:
+        shape = param.data.shape
+        param.data = torch.randn(*shape)
+        param.grad = torch.randn(*shape)
+
+
+@pytest.mark.parametrize(
+    "score_type,n_updates",
+    [
+        ("magnitude", 0),
+        ("magnitude", 1),
+        ("movement", 5),
+        (MFACOptions(num_grads=10), 12),
+        (MFACOptions(num_grads=10, fisher_block_size=24), 10),
+        (MFACOptions(num_grads=8, num_pages=4), 8),
+    ],
+)
+def test_pruning_scorer(score_type, n_updates):
+    params = _make_fake_params(8, (24, 24))
+    scorer = create_pruning_param_scorer(params, score_type)
+
+    for i in range(n_updates):
+        _fake_params_random_update(params)
+        scorer.pre_optim_step_update()
+    scores = scorer.score_parameters()
+    assert len(scores) == len(params)
+
+    # simulate mask update
+    fake_masks = [torch.ones_like(p) for p in params]
+    fake_mask_diffs = [-1.0 * torch.ones_like(p) for p in params]
+    scorer.mask_update(fake_masks, fake_mask_diffs)
+
+    for param, score in zip(params, scores):
+        assert param is not None
+        assert score is not None
+
+        assert param.dtype == score.dtype
+        assert param.data.shape == score.shape
+
+
+@pytest.mark.parametrize(
+    "expected_class,score_type",
+    [
+        (MagnitudePruningParamsScorer, "magnitude"),
+        (MovementPruningParamsScorer, "movement"),
+        (MFACPruningParamsScorer, "MFAC"),
+        (MFACPruningParamsScorer, MFACOptions()),
+    ],
+)
+def test_create_pruning_param_scorer(expected_class, score_type):
+    fake_params = _make_fake_params(5, (25, 25))
+    scorer = create_pruning_param_scorer(fake_params, score_type)
+    assert isinstance(scorer, expected_class)

--- a/tests/sparseml/pytorch/optim/test_modifier_pruning.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_pruning.py
@@ -25,6 +25,7 @@ from sparseml.pytorch.optim import (
     GMPruningModifier,
     LayerPruningModifier,
     MagnitudePruningModifier,
+    MFACPruningModifier,
     MovementPruningModifier,
     load_mask_creator,
 )
@@ -723,4 +724,86 @@ def test_global_magnitude_pruning_yaml():
         str(yaml_modifier.mask_type)
         == str(serialized_modifier.mask_type)
         == str(obj_modifier.mask_type)
+    )
+
+
+def test_mfac_pruning_yaml():
+    init_sparsity = 0.05
+    final_sparsity = 0.8
+    start_epoch = 5.0
+    end_epoch = 15.0
+    update_frequency = 1.0
+    params = "__ALL_PRUNABLE__"
+    inter_func = "cubic"
+    mask_type = "unstructured"
+    mfac_options = {"num_grads": 64, "available_gpus": ["cuda:0", "cuda:1"]}
+    yaml_str = f"""
+    !MFACPruningModifier
+        init_sparsity: {init_sparsity}
+        final_sparsity: {final_sparsity}
+        start_epoch: {start_epoch}
+        end_epoch: {end_epoch}
+        update_frequency: {update_frequency}
+        params: {params}
+        inter_func: {inter_func}
+        mask_type: {mask_type}
+        mfac_options: {mfac_options}
+    """
+    yaml_modifier = MFACPruningModifier.load_obj(yaml_str)  # type: MFACPruningModifier
+    serialized_modifier = MFACPruningModifier.load_obj(
+        str(yaml_modifier)
+    )  # type: MFACPruningModifier
+    obj_modifier = MFACPruningModifier(
+        init_sparsity=init_sparsity,
+        final_sparsity=final_sparsity,
+        start_epoch=start_epoch,
+        end_epoch=end_epoch,
+        update_frequency=update_frequency,
+        params=params,
+        inter_func=inter_func,
+        mask_type=mask_type,
+        mfac_options=mfac_options,
+    )
+
+    assert isinstance(yaml_modifier, MFACPruningModifier)
+    assert (
+        yaml_modifier.init_sparsity
+        == serialized_modifier.init_sparsity
+        == obj_modifier.init_sparsity
+    )
+    assert (
+        yaml_modifier.final_sparsity
+        == serialized_modifier.final_sparsity
+        == obj_modifier.final_sparsity
+    )
+    assert (
+        yaml_modifier.start_epoch
+        == serialized_modifier.start_epoch
+        == obj_modifier.start_epoch
+    )
+    assert (
+        yaml_modifier.end_epoch
+        == serialized_modifier.end_epoch
+        == obj_modifier.end_epoch
+    )
+    assert (
+        yaml_modifier.update_frequency
+        == serialized_modifier.update_frequency
+        == obj_modifier.update_frequency
+    )
+    assert yaml_modifier.params == serialized_modifier.params == obj_modifier.params
+    assert (
+        yaml_modifier.inter_func
+        == serialized_modifier.inter_func
+        == obj_modifier.inter_func
+    )
+    assert (
+        str(yaml_modifier.mask_type)
+        == str(serialized_modifier.mask_type)
+        == str(obj_modifier.mask_type)
+    )
+    assert (
+        yaml_modifier.mfac_options
+        == serialized_modifier.mfac_options
+        == obj_modifier.mfac_options
     )


### PR DESCRIPTION
Introduces the `PruningParamsScorer` class to handle logic specific to the ranking of parameters to prune.  With this change, the `ModuleParamPruningMask` now makes calls into the scorer to determine which scores should be passed into the mask creator.  This change will make future implementations of new pruning algorithms more modular and simple to implement.  Scorers are implemented for magnitude, movement, and M-FAC pruning.