### PR TITLE
Typo in wandb error var

### DIFF
--- a/src/sparseml/pytorch/utils/logger.py
+++ b/src/sparseml/pytorch/utils/logger.py
@@ -38,7 +38,7 @@ except Exception as tensorboard_err:
 try:
     import wandb
 
-    wandb_error = None
+    wandb_err = None
 except Exception as err:
     wandb = None
     wandb_err = err


### PR DESCRIPTION
Fix a wrong var name for wandb logger