### PR TITLE
Set MFAC default block size to 2000

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_pruning.py
+++ b/src/sparseml/pytorch/optim/modifier_pruning.py
@@ -1117,8 +1117,8 @@ class MFACPruningModifier(GMPruningModifier):
         channels, or a SparsityMaskCreator object. default is 'unstructured'
     :param mfac_options: Dictionary of key words specifying arguments for the M-FAC
         pruning run. num_grads controls the number of gradient samples that are kept,
-        fisher_block_size if given enables block approximations of the Fisher matrix
-        (if not specified, the full matrix is used), available_gpus specifies a list
+        fisher_block_size specifies the block size to break the M-FAC computation into
+        (default is 2000, use None for no blocks), available_gpus specifies a list
         of device ids that can be used for computation. For a full list of options,
         see the MFACOptions dataclass documentation. Default configuration uses
         CPU for computation without blocked computation
@@ -1173,8 +1173,8 @@ class MFACPruningModifier(GMPruningModifier):
         """
         :return: Dictionary of key words specifying arguments for the M-FAC
             pruning run. num_grads controls the number of gradient samples,
-            fisher_block_size if given enables block approximations of the Fisher matrix
-            (if not specified, the full matrix is used), available_gpus specifies a list
+            fisher_block_size is the block size to break the M-FAC computation into
+            (default is 2000, None means no blocks), available_gpus specifies a list
             of device ids that can be used for computation. For a full list of options,
             see the MFACOptions dataclass documentation.
         """

--- a/src/sparseml/pytorch/utils/mfac_helpers.py
+++ b/src/sparseml/pytorch/utils/mfac_helpers.py
@@ -48,12 +48,12 @@ class MFACOptions:
         dictionary of float sparsity values to the number of gradients that should be
         stored when that sparsity level (between 0.0 and 1.0) is reached. If a
         dictionary, then 0.0 must be included as a key for the base number of gradients
-        to store (i.e. {0: 64, 0.5: 128, 0.75: 256}). Default is 64.
+        to store (i.e. {0: 64, 0.5: 128, 0.75: 256}). Default is 64
     :param damp: dampening factor, default is 1e-5
     :param grads_device: device to store the gradient buffer on. Default is "cpu"
     :param fisher_block_size: optional value to enable blocked computation of the
         Fisher matrix. Blocks will be formed consecutively along the diagonal. If
-        None, blocked computation is not used. Default is None
+        None, blocked computation is not used. Default is 2000
     :param num_pages: number of pages to break the gradient samples into for GPU
         computation. Only available when blocked computation is not enabled.
         Default is 1
@@ -64,7 +64,7 @@ class MFACOptions:
     num_grads: Union[Dict[float, int], int] = 64
     damp: float = 1e-5
     grads_device: Union[str, int] = "cpu"
-    fisher_block_size: Optional[int] = None
+    fisher_block_size: Optional[int] = 2000
     num_pages: int = 1  # break computation into pages when block size is None
     available_gpus: List[str] = field(default_factory=list)
 


### PR DESCRIPTION
yields better results than running without blocks