### PR TITLE
fix _params already deleted error in Mask object __del__

### DIFF
--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -499,6 +499,9 @@ class ModuleParamPruningMask(object):
                 )
 
     def _delete_hooks(self):
+        if not hasattr(self, "_params"):
+            return
+
         for idx in range(len(self._params)):
             if self._forward_hooks[idx] is not None:
                 self._forward_hooks[idx].remove()


### PR DESCRIPTION
When exiting on an error during PyTorch pruning, the following exception is raised in the mask object's `__del__` function:
```
  File "/home/ben/sparseml/src/sparseml/pytorch/optim/mask_pruning.py", line 516, in _delete_hooks
    for idx in range(len(self._params)):
AttributeError: 'ModuleParamPruningMask' object has no attribute '_params'
```
This PR adds a check to see if `_params` has already been deleted.