### PR TITLE
separate layer-wise and global WoodFisher pruning modifiers

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_pruning.py
+++ b/src/sparseml/pytorch/optim/modifier_pruning.py
@@ -825,6 +825,7 @@ class GMPruningModifier(_PruningParamsModifier):
         self._pre_step_completed = True
 
         if started:
+            # set the mask tensors according to the new sparsity
             if isinstance(self._final_sparsity, List):
                 self._applied_sparsity = [
                     interpolate(

--- a/src/sparseml/pytorch/optim/modifier_pruning.py
+++ b/src/sparseml/pytorch/optim/modifier_pruning.py
@@ -1421,6 +1421,9 @@ class MFACGlobalPruningModifier(MFACPruningModifier):
         immediately after or doing some other prune
     :param inter_func: the type of interpolation function to use:
         [linear, cubic, inverse_cubic]
+    :param phased: True to enable a phased approach where pruning will
+        turn on and off with the update_frequency. Starts with pruning on
+        at start_epoch, off at start_epoch + update_frequency, and so on.
     :param log_types: The loggers to allow the learning rate to be logged to,
         default is __ALL__
     :param mask_type: String to define type of sparsity (options: ['unstructured',
@@ -1445,6 +1448,7 @@ class MFACGlobalPruningModifier(MFACPruningModifier):
         params: Union[str, List[str]],
         leave_enabled: bool = True,
         inter_func: str = "cubic",
+        phased: bool = False,
         log_types: Union[str, List[str]] = ALL_TOKEN,
         mask_type: Union[str, List[int], PruningMaskCreator] = "unstructured",
         mfac_options: Dict[str, Any] = None,
@@ -1458,6 +1462,7 @@ class MFACGlobalPruningModifier(MFACPruningModifier):
             params=params,
             leave_enabled=leave_enabled,
             inter_func=inter_func,
+            phased=phased,
             log_types=log_types,
             mask_type=mask_type,
             global_sparsity=True,

--- a/src/sparseml/pytorch/utils/mfac_helpers.py
+++ b/src/sparseml/pytorch/utils/mfac_helpers.py
@@ -68,9 +68,11 @@ class MFACOptions:
     num_pages: int = 1  # break computation into pages when block size is None
     available_gpus: List[str] = field(default_factory=list)
 
-    def get_num_grads_for_sparsity(self, sparsity: float) -> int:
+    def get_num_grads_for_sparsity(self, sparsity: Union[float, List[float]]) -> int:
         if isinstance(self.num_grads, int):
             return self.num_grads
+        if isinstance(sparsity, List):
+            sparsity = sum(sparsity) / len(sparsity)
 
         sparsity_thresholds = list(sorted(self.num_grads, key=lambda key: float(key)))
         if 0.0 not in sparsity_thresholds:

--- a/tests/sparseml/pytorch/optim/test_modifier_pruning.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_pruning.py
@@ -26,6 +26,7 @@ from sparseml.pytorch.optim import (
     GMPruningModifier,
     LayerPruningModifier,
     MagnitudePruningModifier,
+    MFACGlobalPruningModifier,
     MFACPruningModifier,
     MovementPruningModifier,
     load_mask_creator,
@@ -814,6 +815,7 @@ def test_mfac_pruning_yaml():
     params = "__ALL_PRUNABLE__"
     inter_func = "cubic"
     mask_type = "unstructured"
+    global_sparsity = False
     mfac_options = {"num_grads": 64, "available_gpus": ["cuda:0", "cuda:1"]}
     yaml_str = f"""
     !MFACPruningModifier
@@ -825,9 +827,10 @@ def test_mfac_pruning_yaml():
         params: {params}
         inter_func: {inter_func}
         mask_type: {mask_type}
+        global_sparsity: {global_sparsity}
         mfac_options: {mfac_options}
     """
-    yaml_modifier = MFACPruningModifier.load_obj(yaml_str)  # type: MFACPruningModifier
+    yaml_modifier = MFACPruningModifier.load_obj(yaml_str)
     serialized_modifier = MFACPruningModifier.load_obj(
         str(yaml_modifier)
     )  # type: MFACPruningModifier
@@ -840,10 +843,98 @@ def test_mfac_pruning_yaml():
         params=params,
         inter_func=inter_func,
         mask_type=mask_type,
+        global_sparsity=global_sparsity,
         mfac_options=mfac_options,
     )
 
     assert isinstance(yaml_modifier, MFACPruningModifier)
+    assert (
+        yaml_modifier.init_sparsity
+        == serialized_modifier.init_sparsity
+        == obj_modifier.init_sparsity
+    )
+    assert (
+        yaml_modifier.final_sparsity
+        == serialized_modifier.final_sparsity
+        == obj_modifier.final_sparsity
+    )
+    assert (
+        yaml_modifier.start_epoch
+        == serialized_modifier.start_epoch
+        == obj_modifier.start_epoch
+    )
+    assert (
+        yaml_modifier.end_epoch
+        == serialized_modifier.end_epoch
+        == obj_modifier.end_epoch
+    )
+    assert (
+        yaml_modifier.update_frequency
+        == serialized_modifier.update_frequency
+        == obj_modifier.update_frequency
+    )
+    assert yaml_modifier.params == serialized_modifier.params == obj_modifier.params
+    assert (
+        yaml_modifier.inter_func
+        == serialized_modifier.inter_func
+        == obj_modifier.inter_func
+    )
+    assert (
+        str(yaml_modifier.mask_type)
+        == str(serialized_modifier.mask_type)
+        == str(obj_modifier.mask_type)
+    )
+    assert (
+        str(yaml_modifier.global_sparsity)
+        == str(serialized_modifier.global_sparsity)
+        == str(obj_modifier.global_sparsity)
+    )
+    assert (
+        yaml_modifier.mfac_options
+        == serialized_modifier.mfac_options
+        == obj_modifier.mfac_options
+    )
+
+
+def test_global_mfac_pruning_yaml():
+    init_sparsity = 0.05
+    final_sparsity = 0.8
+    start_epoch = 5.0
+    end_epoch = 15.0
+    update_frequency = 1.0
+    params = "__ALL_PRUNABLE__"
+    inter_func = "cubic"
+    mask_type = "unstructured"
+    mfac_options = {"num_grads": 64, "available_gpus": ["cuda:0", "cuda:1"]}
+    yaml_str = f"""
+    !MFACGlobalPruningModifier
+        init_sparsity: {init_sparsity}
+        final_sparsity: {final_sparsity}
+        start_epoch: {start_epoch}
+        end_epoch: {end_epoch}
+        update_frequency: {update_frequency}
+        params: {params}
+        inter_func: {inter_func}
+        mask_type: {mask_type}
+        mfac_options: {mfac_options}
+    """
+    yaml_modifier = MFACGlobalPruningModifier.load_obj(yaml_str)
+    serialized_modifier = MFACGlobalPruningModifier.load_obj(
+        str(yaml_modifier)
+    )  # type: MFACGlobalPruningModifier
+    obj_modifier = MFACGlobalPruningModifier(
+        init_sparsity=init_sparsity,
+        final_sparsity=final_sparsity,
+        start_epoch=start_epoch,
+        end_epoch=end_epoch,
+        update_frequency=update_frequency,
+        params=params,
+        inter_func=inter_func,
+        mask_type=mask_type,
+        mfac_options=mfac_options,
+    )
+
+    assert isinstance(yaml_modifier, MFACGlobalPruningModifier)
     assert (
         yaml_modifier.init_sparsity
         == serialized_modifier.init_sparsity

--- a/tests/sparseml/pytorch/optim/test_modifier_pruning.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_pruning.py
@@ -357,6 +357,7 @@ class TestGMPruningModifier(ScheduledUpdateModifierTest):
                         applied_sparsities, last_sparsities
                     )
                 )
+
             last_sparsities = applied_sparsities
 
         _ = model(test_batch)  # check forward pass


### PR DESCRIPTION
#292 adds support for a single modifier to prune layers to different levels. This makes it simple to add layer-wise support for WoodFisher/MFAC pruning. This PR sets `global_sparsity` to False in the default `MFACPruningModifier` so that layer wise sparsities may be defined and adds a specific `MFACGlobalPruningModifier` as a convenience for global WF pruning.

Note that all parameters should still be under a single `MFACPruningModifier` when using layer wise, and sparsity groups should be defined for each parameter within the `final_sparsity` arg.