### PR TITLE
One shot MFAC pruning support

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_pruning.py
+++ b/src/sparseml/pytorch/optim/modifier_pruning.py
@@ -829,8 +829,9 @@ class GMPruningModifier(_PruningParamsModifier):
             self._module_masks.enabled = True
             started = True
 
-        self._module_masks.pre_optim_step_update()
-        self._pre_step_completed = True
+        if not self._pre_step_completed:
+            self._module_masks.pre_optim_step_update()
+            self._pre_step_completed = True
 
         if started:
             # set the mask tensors according to the new sparsity
@@ -1372,6 +1373,8 @@ class MFACPruningModifier(GMPruningModifier):
         # create grads for pne-shot pruning
         if "grad_sampler" in kwargs:
             self._collect_grad_samples(module, kwargs["grad_sampler"])
+            self._pre_step_completed = True
+
 
         super()._check_mask_update(module, epoch, steps_per_epoch, **kwargs)
 

--- a/src/sparseml/pytorch/optim/modifier_pruning.py
+++ b/src/sparseml/pytorch/optim/modifier_pruning.py
@@ -1375,7 +1375,6 @@ class MFACPruningModifier(GMPruningModifier):
             self._collect_grad_samples(module, kwargs["grad_sampler"])
             self._pre_step_completed = True
 
-
         super()._check_mask_update(module, epoch, steps_per_epoch, **kwargs)
 
     def _create_pruning_mask(

--- a/src/sparseml/pytorch/utils/mfac_helpers.py
+++ b/src/sparseml/pytorch/utils/mfac_helpers.py
@@ -38,6 +38,8 @@ from torch import Tensor
 from torch.nn import Module
 from torch.nn.parallel.parallel_apply import parallel_apply
 
+from sparseml.pytorch.utils import tensors_module_forward
+
 
 __all__ = [
     "GradSampler",
@@ -79,7 +81,8 @@ class GradSampler:
         """
         if isinstance(data, Tensor):
             data = [data]
-        return module(*data)
+
+        return tensors_module_forward(*data, module)
 
     def module_backward(self, module_outputs: Any, targets: Any):
         """


### PR DESCRIPTION
One shot pruning support for WoodFisher / MFAC. This requires extra support because the method needs a certain number of gradient samples to prune with.  Support is added by offering `dataloader` and `loss_fn` kwargs that will be used to obtain the required samples.

Testing with dummy data/loss function passes through the MFAC pipeline:
Recipe contains - 
```yaml
  - !MFACGlobalPruningModifier
    params: "__ALL_PRUNABLE__"
    init_sparsity: 0.0
    final_sparsity: *target_sparsity
    start_epoch: *pruning_start_epoch
    end_epoch: *pruning_end_epoch
    update_frequency: *pruning_update_frequency
    mask_type: *pruning_mask_type
```

Sample code - 
```python
from sparseml.pytorch.optim import ScheduledModifierManager
from sparseml.pytorch.utils import GradSampler
import torch
from torchvision.models import resnet50

RECIPE_PATH = ""

r = resnet50(False)
manager = ScheduledModifierManager.from_yaml(RECIPE_PATH)

dataloader = ((torch.randn(10,3,224,224), 0) for _ in range(200))
loss_fn = lambda x, _: torch.mean(x)
grad_sampler = GradSampler(dataloader, loss_fn)

manager.apply(r, grad_sampler=grad_sampler)
```
