### PR TITLE
Symmetric quantization for one input of QATMatMul

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -37,6 +37,7 @@ from sparseml.pytorch.optim.modifier import PyTorchModifierYAML, ScheduledModifi
 from sparseml.pytorch.utils import BaseLogger
 from sparseml.pytorch.utils.quantization import (
     add_quant_dequant,
+    configure_module_default_qconfigs,
     fuse_module_conv_bn_relus,
     get_qat_qconfig,
 )
@@ -342,6 +343,7 @@ class QuantizationModifier(ScheduledModifier):
             quant_module.qconfig = qconfig
             # wrap all conv / linear blocks in with quantization observers
             torch_quantization.propagate_qconfig_(quant_module)
+            configure_module_default_qconfigs(quant_module)
             add_quant_dequant(quant_module)
             # set model to QAT mode
             torch_quantization.prepare_qat(quant_module, inplace=True)

--- a/src/sparseml/pytorch/utils/quantization/modules.py
+++ b/src/sparseml/pytorch/utils/quantization/modules.py
@@ -27,6 +27,9 @@ except Exception:
     torch_quantization = None
 
 
+from sparseml.pytorch.utils.quantization.helpers import get_qat_qconfig
+
+
 __all__ = ["QATMatMul"]
 
 
@@ -66,3 +69,12 @@ class QATMatMul(Module):
         prod = torch.matmul(x, y)
         prod = self.quant_out(prod)
         return self.dequant(prod)
+
+    def configure_qconfig(self):
+        """
+        Sets the qconfigs of the quant stubs to use int8 quantization that is
+        asymmetric for the x Tensor and output and symmetric for the output
+        """
+        self.quant_x.qconfig = get_qat_qconfig()
+        self.quant_y.qconfig = get_qat_qconfig(symmetric_activations=True)
+        self.quant_out.qconfig = get_qat_qconfig()


### PR DESCRIPTION
enforcing that one of the two inputs QATMatMul has a zero point of 128 will improve the quantized runtime performance. This PR introduces an optional `configure_qconfig` function for modules that can be called to set a default qconfig for a module when QAT is started by a `QuantizationModifier`.

QATMatMul uses `configure_qconfig` to enforce this zero point restriction.

This can be quickly reproduced with:
```python
from sparseml.pytorch.optim import QuantizationModifier
from sparseml.pytorch.utils.quantization import configure_module_default_qconfigs, QATMatMul

q_mod = QuantizationModifier()
q_matmul = QATMatMul()

q_mod.apply(q_matmul)
```

We can see the desired quantization config is applied:
```python
>>> q_matmul
QATMatMul(
  (quant_x): QuantStub(
    (activation_post_process): FakeQuantize(
      fake_quant_enabled=tensor([1], dtype=torch.uint8), observer_enabled=tensor([1], dtype=torch.uint8),            quant_min=0, quant_max=255, dtype=torch.quint8, qscheme=torch.per_tensor_affine, ch_axis=-1,         scale=tensor([1.]), zero_point=tensor([0])
      (activation_post_process): MovingAverageMinMaxObserver(min_val=inf, max_val=-inf)
    )
  )
  (quant_y): QuantStub(
    (activation_post_process): FakeQuantize(
      fake_quant_enabled=tensor([1], dtype=torch.uint8), observer_enabled=tensor([1], dtype=torch.uint8),            quant_min=0, quant_max=255, dtype=torch.quint8, qscheme=torch.per_tensor_symmetric, ch_axis=-1,         scale=tensor([1.]), zero_point=tensor([0])
      (activation_post_process): MovingAverageMinMaxObserver(min_val=inf, max_val=-inf)
    )
  )
  (quant_out): QuantStub(
    (activation_post_process): FakeQuantize(
      fake_quant_enabled=tensor([1], dtype=torch.uint8), observer_enabled=tensor([1], dtype=torch.uint8),            quant_min=0, quant_max=255, dtype=torch.quint8, qscheme=torch.per_tensor_affine, ch_axis=-1,         scale=tensor([1.]), zero_point=tensor([0])
      (activation_post_process): MovingAverageMinMaxObserver(min_val=inf, max_val=-inf)
    )
  )
  (dequant): DeQuantStub()
)
```