### PR TITLE
delete unused initializers in ONNX Quant conversion

### DIFF
--- a/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
@@ -972,7 +972,7 @@ def quantize_torch_qat_export(
     quantized_residual_add_optim(model)
     _remove_duplicate_quantize_ops(model)
     _cleanup_unused_quants(model)
-    
+
     graph = ONNXGraph(model)
     graph.sort_nodes_topologically()
     graph.delete_unused_initializers()

--- a/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/utils/quantization/quantize_qat_export.py
@@ -972,7 +972,10 @@ def quantize_torch_qat_export(
     quantized_residual_add_optim(model)
     _remove_duplicate_quantize_ops(model)
     _cleanup_unused_quants(model)
-    ONNXGraph(model).sort_nodes_topologically()
+    
+    graph = ONNXGraph(model)
+    graph.sort_nodes_topologically()
+    graph.delete_unused_initializers()
 
     if output_file_path:
         onnx.save(model, output_file_path)


### PR DESCRIPTION
BERT QAT->Quant models are raising many of the warnings below when loaded by ORT. This adds an extra cleanup pass to remove them before saving the model.
```python
2021-07-21 13:48:38.857641570 [W:onnxruntime:, graph.cc:3093 CleanUnusedInitializers] Removing initializer '3174'. It is not used by any node and should be removed from the model.
2021-07-21 13:48:38.857648218 [W:onnxruntime:, graph.cc:3093 CleanUnusedInitializers] Removing initializer '3353'. It is not used by any node and should be removed from the model.
2021-07-21 13:48:38.857653386 [W:onnxruntime:, graph.cc:3093 CleanUnusedInitializers] Removing initializer '3280'. It is not used by any node and should be removed from the model.
2021-07-21 13:48:38.857659247 [W:onnxruntime:, graph.cc:3093 CleanUnusedInitializers] Removing initializer '2331'. It is not used by any node and should be removed from the model.
2021-07-21 13:48:38.857664439 [W:onnxruntime:, graph.cc:3093 CleanUnusedInitializers] Removing initializer '2651'. It is not used by any node and should be removed from the model.
2021-07-21 13:48:38.857670344 [W:onnxruntime:, graph.cc:3093 CleanUnusedInitializers] Removing initializer '3350'. It is not used by any node and should be removed from the model.
2021-07-21 13:48:38.857675334 [W:onnxruntime:, graph.cc:3093 CleanUnusedInitializers] Removing initializer '4473'. It is not used by any node and should be removed from the model.
```