### PR TITLE
update DeepSparse YOLO examples link

### DIFF
--- a/integrations/ultralytics-yolov3/README.md
+++ b/integrations/ultralytics-yolov3/README.md
@@ -30,7 +30,7 @@ The techniques include, but are not limited to:
 ## Highlights
 
 - Blog: [YOLOv3 on CPUs: Sparsifying to Achieve GPU-Level Performance](https://neuralmagic.com/blog/benchmark-yolov3-on-cpus-with-deepsparse/)
-- Example: [DeepSparse YOLOv3 Inference Example](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolov3)
+- Example: [DeepSparse YOLOv3 Inference Example](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolo)
 - Video: [DeepSparse YOLOv3 Pruned Quantized Performance](https://youtu.be/o5qIYs47MPw)
 
 ## Tutorials
@@ -124,4 +124,4 @@ python models/export.py --weights PATH/TO/weights.pt --img-size 512 512
 ```
 
 The DeepSparse Engine accepts ONNX formats and is engineered to significantly speed up inference on CPUs for the sparsified models from this integration.
-Examples for loading, benchmarking, and deploying can be found in the [DeepSparse repository here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolov3).
+Examples for loading, benchmarking, and deploying can be found in the [DeepSparse repository here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolo).

--- a/integrations/ultralytics-yolov3/tutorials/sparsifying_yolov3_using_recipes.md
+++ b/integrations/ultralytics-yolov3/tutorials/sparsifying_yolov3_using_recipes.md
@@ -236,12 +236,12 @@ The result is a new file added next to the sparsified checkpoint with a `.onnx` 
 
 2. Now you can run the `.onnx` file through a compression algorithm to reduce its deployment size and run it in ONNX-compatible inference engines such as [DeepSparse](https://github.com/neuralmagic/deepsparse).
  
-The DeepSparse Engine is explicitly coded to support running sparsified models for significant improvements in inference performance. An example for benchmarking and deploying YOLOv3 models with DeepSparse can be found [here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolov3).
+The DeepSparse Engine is explicitly coded to support running sparsified models for significant improvements in inference performance. An example for benchmarking and deploying YOLOv3 models with DeepSparse can be found [here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolo).
 
 ## Wrap-Up
 
 Neural Magic recipes simplify the sparsification process by encoding the hyperparameters and instructions needed to create highly accurate pruned and pruned-quantized YOLOv3 models. In this tutorial, you created a pre-trained model to establish a baseline, applied a Neural Magic recipe for sparsification, and exported to ONNX to run through an inference engine.
 
-Now, refer [here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolov3) for an example for benchmarking and deploying YOLOv3 models with DeepSparse.
+Now, refer [here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolo) for an example for benchmarking and deploying YOLOv3 models with DeepSparse.
 
 For Neural Magic Support, sign up or log in to get help with your questions in our **Tutorials channel**: [Discourse Forum](https://discuss.neuralmagic.com/) and/or [Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ). 

--- a/integrations/ultralytics-yolov3/tutorials/yolov3_sparse_transfer_learning.md
+++ b/integrations/ultralytics-yolov3/tutorials/yolov3_sparse_transfer_learning.md
@@ -207,13 +207,13 @@ The [export.py script](https://github.com/neuralmagic/yolov3/blob/master/models/
     ```
 2) Now you can run the `.onnx` file through a compression algorithm to reduce its deployment size and run it in ONNX-compatible inference engines such as [DeepSparse](https://github.com/neuralmagic/deepsparse).
     The DeepSparse Engine is explicitly coded to support running sparsified models for significant improvements in inference performance. 
-    An example for benchmarking and deploying YOLOv3 models with DeepSparse can be found [here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolov3).
+    An example for benchmarking and deploying YOLOv3 models with DeepSparse can be found [here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolo).
 
 ## Wrap-Up
 
 Neural Magic sparse models and recipes simplify the sparsification process by enabling sparse transfer learning to create highly accurate pruned and pruned-quantized YOLOv3 models. 
 In this tutorial, you downloaded a pre-sparsified model, applied a Neural Magic recipe for sparse transfer learning, and exported to ONNX to run through an inference engine.
 
-Now, refer [here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolov3) for an example for benchmarking and deploying YOLOv3 models with DeepSparse.
+Now, refer [here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolo) for an example for benchmarking and deploying YOLOv3 models with DeepSparse.
 
 For Neural Magic Support, sign up or log in to get help with your questions in our Tutorials channel: [Discourse Forum](https://discuss.neuralmagic.com/) and/or [Slack](https://join.slack.com/t/discuss-neuralmagic/shared_invite/zt-q1a1cnvo-YBoICSIw3L1dmQpjBeDurQ).

--- a/integrations/ultralytics-yolov5/README.md
+++ b/integrations/ultralytics-yolov5/README.md
@@ -88,4 +88,4 @@ python models/export.py --weights PATH/TO/weights.pt --img-size 512 512
 ```
 
 The DeepSparse Engine accepts ONNX formats and is engineered to significantly speed up inference on CPUs for the sparsified models from this integration.
-Examples for loading, benchmarking, and deploying can be found in the [DeepSparse repository here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolov3).
+Examples for loading, benchmarking, and deploying can be found in the [DeepSparse repository here](https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolo).


### PR DESCRIPTION
YOLO examples for v3 and v5 are now under a unified directory