### PR TITLE
torch pruning masks - fix repeated apply() calls

### DIFF
--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -328,9 +328,6 @@ class ModuleParamPruningMask(object):
 
             self._param_masks[idx] = value
 
-            if not self._allow_reintroduction:
-                self.apply()
-
             mask_diffs.append(mask_diff)
 
         self._scorer.mask_update(masks, mask_diffs)


### PR DESCRIPTION
in the mask setting flow, apply is unnecessarily called twice. the first time it is called before the `mask_update` hook is applied which will cause issues in the update, especially with M-FAC.