### PR TITLE
torch QATWrapper class, custom QConfig support

### DIFF
--- a/src/sparseml/pytorch/utils/quantization/helpers.py
+++ b/src/sparseml/pytorch/utils/quantization/helpers.py
@@ -120,8 +120,12 @@ class QATWrapper(Module):
         forward_fn: Callable[[Any], Any],
         num_inputs: int = 1,
         num_outputs: int = 1,
-        input_qconfigs: Union["QConfig", str, List["QConfig"]] = "asymmetric",
-        output_qconfigs: Union["QConfig", str, List["QConfig"]] = "asymmetric",
+        input_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        output_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
     ):
         super().__init__()
 
@@ -204,7 +208,9 @@ class QATWrapper(Module):
 
     @staticmethod
     def _load_qconfigs(
-        name: str, expected_len: int, qconfigs: Union["QConfig", str, List["QConfig"]]
+        name: str,
+        expected_len: int,
+        qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
     ):
         if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
             raise ValueError(

--- a/src/sparseml/pytorch/utils/quantization/helpers.py
+++ b/src/sparseml/pytorch/utils/quantization/helpers.py
@@ -17,7 +17,7 @@ Helper functions for performing quantization aware training with PyTorch
 """
 
 from copy import deepcopy
-from typing import Union
+from typing import Any, Callable, List, Union
 
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Module, ReLU
@@ -34,6 +34,9 @@ from sparseml.pytorch.nn import ReLU as ReLU_nm
 
 
 __all__ = [
+    "QATWrapper",
+    "configure_module_qat_wrappers",
+    "configure_module_default_qconfigs",
     "add_quant_dequant",
     "get_qat_qconfig",
     "fuse_module_conv_bn_relus",
@@ -64,6 +67,208 @@ _QUANTIZABLE_MODULE_TYPES = (
 )
 
 
+class QATWrapper(Module):
+    """
+    Wraps inputs and outputs of a Module or function with QuantStubs for
+    Quantization-Aware-Training (QAT)
+
+    :param forward_fn: function to be wrapped, should generally accept and return
+        torch Tensor(s)
+    :param num_inputs: number of inputs of the forward function to add a QuantStub
+        to. Will wrap the first num_inputs ordered inputs of the function. Default
+        is 1
+    :param num_outputs: number of outputs of the forward function to add a QuantStub
+        to. Will wrap the first num_inputs ordered outputs of the function. Default
+        is 1. Will also add a DeQuantStub for FP32 conversion if
+        torch.quantization.convert is invoked
+    :param input_qconfigs: QConfig to use for calibrating the input QuantStubs. Can
+        be a single QConfig that will be copied to each QuantStub or a list of one
+        QConfig for each input. Instead of a QConfig objects, the string 'asymmetric'
+        or 'symmetric' may be used to use default UINT8 asymmetric and symmetric
+        quantization respectively
+    :param output_qconfigs: QConfig to use for calibrating the output QuantStubs. Can
+        be a single QConfig that will be copied to each QuantStub or a list of one
+        QConfig for each output. Instead of a QConfig objects, the string 'asymmetric'
+        or 'symmetric' may be used to use default UINT8 asymmetric and symmetric
+        quantization respectively
+    """
+
+    @staticmethod
+    def from_module(module: Module) -> "QATWrapper":
+        """
+        :param module: torch Module to create a QATWrapper for
+        :return: QATWrapper object created using the given Module as the forward
+            function. Will attempt to find any other named parameter of the QATWrapper
+            constructor from the attributes of the given Module
+        """
+        qat_wrapper_param_names = [
+            "num_inputs",
+            "num_outputs",
+            "input_qconfigs",
+            "output_qconfigs",
+        ]
+        qat_wrapper_kwargs = {
+            param_name: getattr(module, param_name)
+            for param_name in qat_wrapper_param_names
+            if hasattr(module, param_name)
+        }
+
+        return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
+
+    def __init__(
+        self,
+        forward_fn: Callable[[Any], Any],
+        num_inputs: int = 1,
+        num_outputs: int = 1,
+        input_qconfigs: Union["QConfig", str, List["QConfig"]] = "asymmetric",
+        output_qconfigs: Union["QConfig", str, List["QConfig"]] = "asymmetric",
+    ):
+        super().__init__()
+
+        if torch_quantization is None:
+            raise RuntimeError(
+                "Unable to import package torch.quantization. "
+                "Try upgrading your PyTorch version."
+            )
+
+        if not callable(forward_fn):
+            raise ValueError(
+                "forward_fn of QATWrapper must be callable. "
+                f"Received {type(forward_fn)}"
+            )
+
+        self.forward_fn = forward_fn
+        self.input_qconfigs = self._load_qconfigs(
+            "input_qconfigs", num_inputs, input_qconfigs
+        )
+        self.output_qconfigs = self._load_qconfigs(
+            "output_qconfigs", num_outputs, output_qconfigs
+        )
+
+        self.input_quant_stubs = torch.nn.ModuleList(
+            [torch_quantization.QuantStub() for _ in range(num_inputs)]
+        )
+        self.output_quant_stubs = torch.nn.ModuleList(
+            [torch_quantization.QuantStub() for _ in range(num_outputs)]
+        )
+        self.output_dequant_stubs = torch.nn.ModuleList(
+            [torch_quantization.DeQuantStub() for _ in range(num_outputs)]
+        )
+
+    def forward(self, *args, **kwargs) -> Any:
+        """
+        :param args: arguments to forward function; the first num_inputs of these args
+            will be wrapped by a QuantStub
+        :param kwargs: key word arguments to pass to the wrapped forward function
+        :return: outputs of the forward function with a QuantStub applied to the first
+            num_outputs outputs
+        """
+
+        qat_args = []
+
+        for idx, arg in enumerate(args):
+            if idx < len(self.input_quant_stubs):
+                arg = self.input_quant_stubs[idx](arg)
+            qat_args.append(arg)
+
+        outputs = self.forward_fn(*qat_args, **kwargs)
+
+        if len(self.output_quant_stubs) == 0:
+            # no output wrapping
+            return outputs
+
+        if isinstance(outputs, torch.Tensor):
+            # output is a single Tensor
+            qat_output = self.output_quant_stubs[0](outputs)
+            return self.output_dequant_stubs[0](qat_output)
+
+        qat_outputs = []
+
+        for idx, output in enumerate(outputs):
+            if idx < len(self.output_quant_stubs):
+                output = self.output_quant_stubs[idx](output)
+                output = self._output_deuant_stubs[idx](output)
+            qat_outputs.append(output)
+
+        return qat_outputs
+
+    def configure_qconfig(self):
+        """
+        Sets the qconfigs of the quant stubs to the pre-initialized QConfigs
+        """
+        for quant_stub, qconfig in zip(self.input_quant_stubs, self.input_qconfigs):
+            quant_stub.qconfig = qconfig
+
+        for quant_stub, qconfig in zip(self.output_quant_stubs, self.output_qconfigs):
+            quant_stub.qconfig = qconfig
+
+    @staticmethod
+    def _load_qconfigs(
+        name: str, expected_len: int, qconfigs: Union["QConfig", str, List["QConfig"]]
+    ):
+        if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
+            raise ValueError(
+                f"QATWrapper {name} must be a string, torch.quantization.QConfig, "
+                f"or a List of them. Received a {type(qconfigs)}"
+            )
+
+        if isinstance(qconfigs, (str, torch_quantization.QConfig)):
+            qconfigs = [deepcopy(qconfigs) for _ in range(expected_len)]
+
+        if len(qconfigs) != expected_len:
+            raise ValueError(
+                f"QATWrapper {name} should have exactly one qconfig or one for every "
+                f"argument ({expected_len}). Given {len(qconfigs)}"
+            )
+
+        valid_qconfig_strs = ["asymmetric", "symmetric"]
+        for idx, qconfig in enumerate(qconfigs):
+            if not isinstance(qconfig, str):
+                continue
+
+            if qconfig not in valid_qconfig_strs:
+                raise ValueError(
+                    "QATWrapper qconfig names can either be "
+                    "torch.quantization.QConfig objects or a string "
+                    f"in {valid_qconfig_strs} that will be converted to a QConfig. "
+                    f"Found string with value {qconfig} in {name}"
+                )
+
+            qconfigs[idx] = get_qat_qconfig(
+                symmetric_activations=(qconfig == "symmetric")
+            )
+
+        return qconfigs
+
+
+def configure_module_qat_wrappers(module: Module):
+    """
+    if any submodule of the given module has the attribute wrap_qat == True,
+    then it will be replaced by a QATWrapper of it created by QATWrapper.from_module
+
+    :param module: module to potentially wrap the submodules of
+    """
+    for submodule in module.modules():
+        for child_name, child_module in module.named_children():
+            if hasattr(child_module, "wrap_qat") and child_module.wrap_qat:
+                setattr(submodule, child_name, QATWrapper.from_module(child_module))
+
+
+def configure_module_default_qconfigs(module: Module):
+    """
+    if any submodule of the given module has a configure_qconfig function,
+    configure_qconfig will be called on that submodule to set the qconfig(s) of that
+    module to its default
+
+    :param module: module to set qconfigs for
+    """
+    for submodule in module.modules():
+        if hasattr(submodule, "configure_qconfig") and callable(
+            getattr(submodule, "configure_qconfig")
+        ):
+            submodule.configure_qconfig()
+
+
 def add_quant_dequant(module):
     """
     Wraps all Conv and Linear submodule with a qconfig with a QuantWrapper
@@ -82,19 +287,27 @@ def add_quant_dequant(module):
     return module
 
 
-def get_qat_qconfig() -> torch_quantization.QConfig:
+def get_qat_qconfig(
+    symmetric_activations: bool = False,
+) -> "torch.quantization.QConfig":
     """
+    :param symmetric_activations: if True, activations will have a symmetric
+        quantization range with zero point set to 128. Otherwise activations
+        will use asymmetric quantization with any zero point. Default is False
     :return: A QAT fake quantization config for symmetric weight quantization and
         asymmetric activation quantization.  The difference between this and
         torch.quantization.default_qat_qconfig is that the activation observer
         will not have reduce_range enabled.
     """
+    activation_qscheme = (
+        torch.per_tensor_symmetric if symmetric_activations else torch.per_tensor_affine
+    )
     activation_observer = torch_quantization.FakeQuantize.with_args(
         observer=torch_quantization.MovingAverageMinMaxObserver,
         quant_min=0,
         quant_max=255,
         dtype=torch.quint8,
-        qscheme=torch.per_tensor_affine,
+        qscheme=activation_qscheme,
         reduce_range=False,
     )
     weight_observer = torch_quantization.default_weight_fake_quant

--- a/tests/sparseml/pytorch/utils/quantization/test_helpers.py
+++ b/tests/sparseml/pytorch/utils/quantization/test_helpers.py
@@ -39,8 +39,10 @@ class _QATMatMul(torch.nn.Module):
         super().__init__()
 
         self.wrap_qat = True
-        self.num_inputs = 2
-        self.input_qconfigs = ["asymmetric", "symmetric"]
+        self.qat_wrapper_kwargs = {
+            "num_inputs": 2,
+            "input_qconfigs": ["asymmetric", "symmetric"],
+        }
 
     def forward(self, a: torch.Tensor, b: torch.Tensor):
         return torch.matmul(a, b)

--- a/tests/sparseml/pytorch/utils/quantization/test_helpers.py
+++ b/tests/sparseml/pytorch/utils/quantization/test_helpers.py
@@ -86,10 +86,6 @@ def test_configure_module_qat_wrappers():
 
     configure_module_qat_wrappers(module)
 
-    import pdb
-
-    pdb.set_trace()
-
     qat_matmul = module.module
 
     assert isinstance(qat_matmul, QATWrapper)

--- a/tests/sparseml/pytorch/utils/quantization/test_helpers.py
+++ b/tests/sparseml/pytorch/utils/quantization/test_helpers.py
@@ -19,7 +19,10 @@ import torch
 
 from sparseml.pytorch.models import mobilenet, resnet50
 from sparseml.pytorch.utils.quantization import (
+    QATWrapper,
     add_quant_dequant,
+    configure_module_default_qconfigs,
+    configure_module_qat_wrappers,
     fuse_module_conv_bn_relus,
     get_qat_qconfig,
 )
@@ -31,8 +34,122 @@ except Exception:
     torch_quantization = None
 
 
+class _QATMatMul(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.wrap_qat = True
+        self.num_inputs = 2
+        self.input_qconfigs = ["asymmetric", "symmetric"]
+
+    def forward(self, a: torch.Tensor, b: torch.Tensor):
+        return torch.matmul(a, b)
+
+
+class _ModuleWrapper(torch.nn.Module):
+    def __init__(self, module):
+        super().__init__()
+
+        self.module = module
+
+    def forward(self, *args, **kwargs):
+        return self.module(*args, **kwargs)
+
+
+def _module_has_quant_stubs(module):
+    return any(
+        isinstance(submodule, torch_quantization.QuantStub)
+        for submodule in module.modules()
+    )
+
+
 def _count_submodule_instances(module, clazz):
     return sum(1 for submodule in module.modules() if isinstance(submodule, clazz))
+
+
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
+    reason="Skipping pytorch tests",
+)
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_QUANT_TESTS", False),
+    reason="Skipping pytorch torch quantization tests",
+)
+@pytest.mark.skipif(
+    torch_quantization is None,
+    reason="torch quantization not available",
+)
+def test_configure_module_qat_wrappers():
+    module = _ModuleWrapper(_QATMatMul())
+
+    assert not _module_has_quant_stubs(module)
+
+    configure_module_qat_wrappers(module)
+
+    import pdb
+
+    pdb.set_trace()
+
+    qat_matmul = module.module
+
+    assert isinstance(qat_matmul, QATWrapper)
+    assert _module_has_quant_stubs(module)
+    assert len(qat_matmul.input_quant_stubs) == 2
+    assert len(qat_matmul.output_quant_stubs) == 1
+    assert _count_submodule_instances(module, torch_quantization.QuantStub) == 3
+
+    assert module(torch.randn(3, 3), torch.randn(3, 3)) is not None
+
+
+def _assert_module_quant_stub_configs_exist(module, should_exist):
+    for submodule in module.modules():
+        if isinstance(submodule, torch_quantization.QuantStub):
+            config_exists = (
+                hasattr(submodule, "qconfig") and submodule.qconfig is not None
+            )
+            assert config_exists == should_exist
+
+
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
+    reason="Skipping pytorch tests",
+)
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_QUANT_TESTS", False),
+    reason="Skipping pytorch torch quantization tests",
+)
+@pytest.mark.skipif(
+    torch_quantization is None,
+    reason="torch quantization not available",
+)
+def test_configure_module_default_qconfigs():
+    module = QATWrapper.from_module(_QATMatMul())
+    _assert_module_quant_stub_configs_exist(module, False)
+
+    configure_module_default_qconfigs(module)
+    _assert_module_quant_stub_configs_exist(module, True)
+
+
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
+    reason="Skipping pytorch tests",
+)
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_QUANT_TESTS", False),
+    reason="Skipping pytorch torch quantization tests",
+)
+@pytest.mark.skipif(
+    torch_quantization is None,
+    reason="torch quantization not available",
+)
+def test_configure_module_default_qconfigs_no_config():
+    module = QATWrapper.from_module(_QATMatMul())
+    _assert_module_quant_stub_configs_exist(module, False)
+
+    module.configure_qconfig = None
+
+    configure_module_default_qconfigs(module)
+    _assert_module_quant_stub_configs_exist(module, False)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
goal of this PR is to enable a workflow that allows users to create Modules that do not require sparseml and normally are not quantized in default torch/sparseml quantization flows, but with no further edits, could be converted to a fully quantizable QAT graph using a recipe.

`QATWrapper` achieves this by allowing users to wrap arbitrary operations with Modules that can later be wrapped as long as `wrap_qat` is set to True in the module.

This PR also introduces support that allows users to override the default QConfigs assigned to Modules if a module provides its own `configure_qconfig` method.

## QAT MatMul Example
The following can be used to Quantize the non-parameterized MatMul in the attention layers of transformer models. `sparseml` is not a dependency, and until it is processed by SparseML, the following module behaves just like `torch.matmul`
```python
import torch

class QATMatMul(torch.nn.Module):
    def __init__(self):
        super().__init__()

        self.wrap_qat = True
        self.qat_wrapper_kwargs = {
            "num_inputs": 2,
            "input_qconfigs": ["asymmetric", "symmetric"],
        }

    def forward(self, a: torch.Tensor, b: torch.Tensor):
        return torch.matmul(a, b)
```

#### After ONNX export:
<img width="311" alt="Screen Shot 2021-08-03 at 5 00 49 PM" src="https://user-images.githubusercontent.com/11316925/128085521-6a20cd4f-bfa1-4ec3-aee9-9f77ec4b1bac.png">

#### After QAT -> Quant conversion:
(notice the `b` tensor has a symmetric zero point)
<img width="321" alt="Screen Shot 2021-08-03 at 5 00 57 PM" src="https://user-images.githubusercontent.com/11316925/128085538-13d22cd6-c8c0-4da3-9049-97b0a895cb6d.png">
