### PR TITLE
Add:Support for ONNX versions 1.8.*, 1.9.* upto 1.10.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ _deps = [
     "numpy>=1.0.0",
     "matplotlib>=3.0.0",
     "merge-args>=0.1.0",
-    "onnx>=1.5.0,<1.8.0",
+    "onnx>=1.5.0,<=1.10.1",
     "onnxruntime>=1.0.0",
     "pandas>=0.25.0",
     "packaging>=20.0",

--- a/src/sparseml/onnx/utils/helpers.py
+++ b/src/sparseml/onnx/utils/helpers.py
@@ -18,6 +18,7 @@ Utility / helper functions
 
 import logging
 from collections import OrderedDict
+from copy import deepcopy
 from functools import reduce
 from typing import Any, Dict, List, NamedTuple, Tuple, Union
 
@@ -25,7 +26,7 @@ import numpy
 import onnx
 import onnxruntime
 from onnx import ModelProto, NodeProto, TensorProto, numpy_helper
-from onnx.helper import get_attribute_value, make_empty_tensor_value_info, make_model
+from onnx.helper import get_attribute_value, make_empty_tensor_value_info
 
 from sparseml.utils import clean_path
 
@@ -240,7 +241,7 @@ def extract_nodes_shapes_ort(model: ModelProto) -> Dict[str, List[List[int]]]:
     :param model: an ONNX model
     :return: a list of NodeArg with their shape exposed
     """
-    model_copy = make_model(model.graph)
+    model_copy = deepcopy(model)
 
     for node in model_copy.graph.node:
         intermediate_layer_value_info = make_empty_tensor_value_info(
@@ -277,7 +278,7 @@ def extract_nodes_shapes_shape_inference(
     :param model: an ONNX model
     :return: a list of NodeProto with their shape exposed
     """
-    model_copy = make_model(model.graph)
+    model_copy = deepcopy(model)
 
     for node in model_copy.graph.node:
         model_copy.graph.output.extend(

--- a/tests/sparseml/onnx/optim/quantization/helpers.py
+++ b/tests/sparseml/onnx/optim/quantization/helpers.py
@@ -135,7 +135,7 @@ def onnx_conv_net() -> ModelProto:
         ],
     )
     opset_id = onnx.helper.make_opsetid("", 11)
-    model = onnx.helper.make_model(graph, opset_imports=[opset_id])
+    model = onnx.helper.make_model(graph, opset_imports=[opset_id], ir_version=6)
     return model
 
 
@@ -174,5 +174,5 @@ def onnx_linear_net() -> ModelProto:
         [matmul1_weight, matmul2_weight],
     )
     opset_id = onnx.helper.make_opsetid("", 11)
-    model = onnx.helper.make_model(graph, opset_imports=[opset_id])
+    model = onnx.helper.make_model(graph, opset_imports=[opset_id], ir_version=6)
     return model


### PR DESCRIPTION
* Replaced usage of onnx.helpers.make_model(model.graph) to deepcopy(model) in [file](https://github.com/neuralmagic/sparseml/blob/main/src/sparseml/onnx/utils/helpers.py) because opset and ir_versions were lost in the process initially which broke Tests when using onnx versions>=1.8.0 
* Added explicit IR_VERSION=6 in usages of onnx.helpers.make_model(...) in [file](https://github.com/neuralmagic/sparseml/blob/main/tests/sparseml/onnx/optim/quantization/helpers.py)
* Updated setup.py to install latest onnx version(at the time of this PR) when installing using pip -e ...

Tested on `Python 3.6.9`, and Linux/Debian system,
Tests ran:`make test TARGETS=onnx`