### PR TITLE
Mark test_one_shot_ks_perf_sensitivity as flaky

### DIFF
--- a/tests/sparseml/onnx/optim/test_sensitivity_ks.py
+++ b/tests/sparseml/onnx/optim/test_sensitivity_ks.py
@@ -221,6 +221,7 @@ def test_one_shot_ks_loss_sensitivity(
 @pytest.mark.skipif(
     deepsparse is None, reason="deepsparse is not installed on the system"
 )
+@flaky(max_runs=2, min_passes=1)
 def test_one_shot_ks_perf_sensitivity(
     onnx_models_with_analysis: OnnxModelAnalysisFixture,
 ):


### PR DESCRIPTION
Marking the below test as flaky per a previous conversation:

`tests/sparseml/onnx/optim/test_sensitivity_ks.py::test_one_shot_ks_perf_sensitivity`
