### PR TITLE
Update: line 247 of nm_argparser_.py for compatibility with python3.6

### DIFF
--- a/integrations/pytorch/argparser_/nm_argparser_.py
+++ b/integrations/pytorch/argparser_/nm_argparser_.py
@@ -244,7 +244,7 @@ class NmArgumentParser(ArgumentParser):
             # additional namespace.
             outputs.append(namespace)
         if return_remaining_strings:
-            return *outputs, remaining_args
+            return (*outputs, remaining_args)
         else:
             if remaining_args:
                 raise ValueError(


### PR DESCRIPTION
In python3.6 we need a bracket for tuple unpacking while returning
StackOverflow discussion on this: [tuple-unpacking-in-return-statement](https://stackoverflow.com/questions/47272460/python-tuple-unpacking-in-return-statement) 