### PR TITLE
Update: Save Strategy

### DIFF
--- a/integrations/pytorch/recipes/resnet50-imagenette-pruned.md
+++ b/integrations/pytorch/recipes/resnet50-imagenette-pruned.md
@@ -133,7 +133,7 @@ Alternatively, a full walk-through notebook is located at `sparseml/integrations
 *script command:*
 
 ```
-python integrations/pytorch/scripts/train.py \
+python integrations/pytorch/train.py \
     --recipe-path zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original \
     --pretrained True \
     --arch-key resnet50 \

--- a/integrations/pytorch/recipes/resnet50-imagenette-pruned.md
+++ b/integrations/pytorch/recipes/resnet50-imagenette-pruned.md
@@ -127,7 +127,7 @@ using a SGD optimizer.
 When running, adjust hyperparameters based on training environment and dataset.
 
 ## Training
-The training script can be found at `sparseml/integrations/pytorch/scripts/train.py`. 
+The training script can be found at `sparseml/integrations/pytorch/train.py`. 
 Alternatively, a full walk-through notebook is located at `sparseml/integrations/pytorch/notebooks/classification.ipynb`.
 
 *script command:*

--- a/integrations/pytorch/train.py
+++ b/integrations/pytorch/train.py
@@ -220,7 +220,7 @@ class TrainingArguments:
     :param logs_dir: The path to the directory for saving logs.
     :param save_best_after: int epoch number to start saving the best
         validation result after until the end of training.
-    :param save_epochs: int epochs to save checkpoints at.
+    :param save_epochs: List of int epochs to save checkpoints at.
     :param use_mixed_precision: bool to train model using mixed precision.
         Supported environments are single GPU and multiple GPUs using
         DistributedDataParallel with one GPU per process.
@@ -366,7 +366,7 @@ class TrainingArguments:
             "epoch completes until the end of training"
         },
     )
-    save_epochs: int = field(
+    save_epochs: List[int] = field(
         default_factory=lambda: [], metadata={"help": "epochs to save checkpoints at"}
     )
 

--- a/integrations/pytorch/train.py
+++ b/integrations/pytorch/train.py
@@ -248,6 +248,7 @@ class TrainingArguments:
         default=4.
     :param loader_pin_memory: bool to use pinned memory for data loading,
         default=True.
+    :param save_last_epoch: bool to save last completed epoch
     """
 
     train_batch_size: int = field(

--- a/integrations/pytorch/train.py
+++ b/integrations/pytorch/train.py
@@ -454,6 +454,11 @@ class TrainingArguments:
         default=True, metadata={"help": "Use pinned memory for data loading"}
     )
 
+    save_last_epoch: bool = field(
+        default=False,
+        metadata={"help": "Use save-last-epoch for saving last completed epoch"},
+    )
+
     def __post_init__(self):
         # add ddp args
         env_world_size = int(os.environ.get("WORLD_SIZE", 1))
@@ -618,7 +623,8 @@ def train(
 
             # save checkpoints
             _save_epoch = (
-                train_args.is_main_process
+                train_args.save_last_epoch
+                or train_args.is_main_process
                 and train_args.save_epochs
                 and epoch in train_args.save_epochs
             )

--- a/integrations/pytorch/train.py
+++ b/integrations/pytorch/train.py
@@ -456,7 +456,7 @@ class TrainingArguments:
     )
 
     save_last_epoch: bool = field(
-        default=False,
+        default=True,
         metadata={"help": "Use save-last-epoch for saving last completed epoch"},
     )
 
@@ -622,10 +622,21 @@ def train(
                     )
                     best_loss = val_loss
 
+            # save latest-completed epoch
+            if train_args.save_last_epoch:
+                utils.save_model_training(
+                    model,
+                    optim,
+                    input_shape,
+                    "checkpoint-latest",
+                    save_dir,
+                    epoch,
+                    val_res,
+                )
+
             # save checkpoints
             _save_epoch = (
-                train_args.save_last_epoch
-                or train_args.is_main_process
+                train_args.is_main_process
                 and train_args.save_epochs
                 and epoch in train_args.save_epochs
             )

--- a/integrations/pytorch/utils.py
+++ b/integrations/pytorch/utils.py
@@ -64,6 +64,24 @@ class Tasks(Enum):
     PR_SENSITIVITY = auto()
 
 
+@unique
+class SaveStrategy(Enum):
+    """
+    A class representing supported save strategies
+    """
+
+    NO = "no"
+    STEPS = "steps"
+    EPOCHS = "epochs"
+
+    @classmethod
+    def _missing_(cls, value):
+        raise ValueError(
+            f"{value} is not a valid {cls.__name__}, please select one of "
+            f"{list(cls._value2member_map_.keys())}"
+        )
+
+
 # loggers
 def get_save_dir_and_loggers(
     args: Any, task: Optional[Tasks] = None
@@ -204,7 +222,8 @@ def _create_val_dataset_and_loader(
                 )
             print(f"created val_dataset: {val_dataset}")
         else:
-            val_loader = None  # only val dataset needed to get the number of classes
+            # only val dataset needed to get the number of classes
+            val_loader = None
         return val_dataset, val_loader
     return None, None  # val dataset not needed
 


### PR DESCRIPTION
- Update the train script to use a save strategy using command line argument `--save-strategy`.
  The save strategy can be one of the following:
        - `no`: No save is done during training.
        - `epoch`: Save is done at the end of each epoch.
        - `steps`: Save is done every :obj:`save_steps`
 - Add support to delete older checkpoints using `--save-total-limit` argument
 - Specify save steps using `--save-steps`