### PR TITLE
Fixes `self._dim` when `isinstance(dim, str)` in DimensionSparsityMaskCreator class

### DIFF
--- a/src/sparseml/pytorch/optim/mask_creator_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_creator_pruning.py
@@ -399,7 +399,7 @@ class DimensionSparsityMaskCreator(GroupedPruningMaskCreator):
         grouping_fn_name: str = "mean",
     ):
         if isinstance(dim, int):
-            dim = [dim]
+            self._dim = [dim]  # List[int]
         self._dim_name = None
         self._grouping_fn_name = grouping_fn_name
         if isinstance(dim, str):
@@ -413,7 +413,6 @@ class DimensionSparsityMaskCreator(GroupedPruningMaskCreator):
                         dim, valid_dim_names
                     )
                 )
-        self._dim = dim  # List[int]
 
     def create_sparsity_masks(
         self,


### PR DESCRIPTION
When using a GMPruningModifier, the argument `mask_type` can be (according to the doc) `unstructured`, `channel` of `filter`.

Unfortunately, it can currently only be `unstructured` because of "a typo" in the class `DimensionSparsityMaskCreator` where `self._dim` was overriden.

This pull request fixes the issue https://github.com/neuralmagic/sparseml/issues/441