### PR TITLE
fix QuantizationModifier for Conv/Linear target submodules

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -373,10 +373,11 @@ class QuantizationModifier(ScheduledModifier):
             torch_quantization.propagate_qconfig_(quant_module)
             configure_module_default_qconfigs(quant_module)
             add_quant_dequant(quant_module)
-            # set model to QAT mode
-            torch_quantization.prepare_qat(quant_module, inplace=True)
-            if self._quantize_embeddings:
-                prepare_embeddings_qat(quant_module)
+
+        # set modules with proper qconfigs to QAT mode
+        torch_quantization.prepare_qat(module, inplace=True)
+        if self._quantize_embeddings:
+            prepare_embeddings_qat(module)
         self._qat_enabled = True
 
     def _disable_quantization_observer_update_ready(self, epoch: float) -> bool:


### PR DESCRIPTION
update to `QuantizationModifier` to fix bug where if a `Linear` or `Conv2d` layer was directly referenced as a target submodule, it would not be converted to a QAT module.  Improved the quantization test suite to include deeper testing for various submodule targets

quick python example of quantizing a BERT model with a submodule target that is a `Linear`
```python
from transformers import AutoModelForQuestionAnswering
from sparseml.pytorch.optim import QuantizationModifier
model = AutoModelForQuestionAnswering.from_pretrained("bert-base-uncased")
QuantizationModifier(submodules=["bert.embeddings", "bert.encoder", "qa_outputs"]).apply(model)

print(model.qa_outputs)
```