### PR TITLE
Install Sparseml-Transformers deps dyanmically on import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,12 +30,6 @@ version_nm_deps = f"{version_major_minor}.0"
 
 _PACKAGE_NAME = "sparseml" if is_release else "sparseml-nightly"
 
-transformers_branch = "master" if not is_release else f"release/{version_major_minor}"
-transformers_requirement = (
-    "transformers @ git+https://github.com/neuralmagic/transformers.git"
-    f"@{transformers_branch}"
-)
-
 _deps = [
     "jupyter>=1.0.0",
     "ipywidgets>=7.0.0",
@@ -69,13 +63,6 @@ _tensorflow_v1_gpu_deps = [
     "tf2onnx>=1.0.0,<1.6",
 ]
 _keras_deps = ["tensorflow~=2.2.0", "keras2onnx>=1.0.0"]
-_transformers_deps = [
-    "torch>=1.1.0,<1.9.0",
-    transformers_requirement,
-    "datasets",
-    "sklearn",
-    "seqeval",
-] + _pytorch_deps[1:]
 
 _dev_deps = [
     "beautifulsoup4==4.9.3",
@@ -122,7 +109,6 @@ def _setup_extras() -> Dict:
         "tf_v1": _tensorflow_v1_deps,
         "tf_v1_gpu": _tensorflow_v1_gpu_deps,
         "tf_keras": _keras_deps,
-        "transformers": _transformers_deps,
     }
 
 

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -47,24 +47,25 @@ def _install_transformers_and_deps():
         f"@{transformers_branch}"
     )
 
-    _pip.main(
-        [
-            "install",
-            transformers_requirement,
-            "datasets",
-            "sklearn",
-            "seqeval",
-        ]
-    )
-
     try:
+        _pip.main(
+            [
+                "install",
+                transformers_requirement,
+                "datasets",
+                "sklearn",
+                "seqeval",
+            ]
+        )
+
         import transformers as _transformers
 
         _LOGGER.info("sparseml-transformers and dependencies successfully installed")
     except Exception:
         raise ValueError(
-            "Unable to install sparseml-transformers dependencies try installing "
-            f"via `pip install git+https://github.com/neuralmagic/transformers.git`"
+            "Unable to install and import sparseml-transformers dependencies check "
+            "that transformers is installed, if not, install via "
+            "`pip install git+https://github.com/neuralmagic/transformers.git`"
         )
 
 

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -21,19 +21,59 @@ Tools for integrating SparseML with transformers training flows
 try:
     import transformers as _transformers
 
-    transformers_import_error = None
-except Exception as transformers_import_err:
-    transformers_import_error = transformers_import_err
+    _transformers_import_error = None
+except Exception as _transformers_import_err:
+    _transformers_import_error = _transformers_import_err
+
+
+def _install_transformers_and_deps():
+    import logging as _logging
+
+    import pip as _pip
+    import sparseml as _sparseml
+
+    logger = _logging.getLogger(__name__)
+
+    logger.info(
+        "No installation of transformers found. Installing sparseml-transformers "
+        "dependencies"
+    )
+    transformers_branch = (
+        "master"
+        if not _sparseml.is_release
+        else f"release/{_sparseml.version_major_minor}"
+    )
+    transformers_requirement = (
+        "transformers @ git+https://github.com/neuralmagic/transformers.git"
+        f"@{transformers_branch}"
+    )
+
+    _pip.main(
+        [
+            "install",
+            transformers_requirement,
+            "datasets",
+            "sklearn",
+            "seqeval",
+        ]
+    )
+
+    try:
+        import transformers as _transformers
+
+        logger.info("sparseml-transformers and dependencies successfully installed")
+    except Exception:
+        raise ValueError(
+            "Unable to install sparseml-transformers dependencies try installing "
+            f"via `pip install git+https://github.com/neuralmagic/transformers.git"
+        )
 
 
 def _check_transformers_install():
-    if transformers_import_error is None:
+    if _transformers_import_error is None:
         return
-    raise ImportError(
-        "No installation of transformers found. It is recommended to use the "
-        "sparseml fork of transformers which can be installed under "
-        "sparseml[transformers] or git+https://github.com/neuralmagic/transformers.git"
-    )
+    else:
+        _install_transformers_and_deps()
 
 
 _check_transformers_install()

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -73,10 +73,10 @@ def _check_transformers_install():
     if _transformers_import_error is not None:
         import os
 
-        if os.getenv("SPARSEML_NO_AUTOINSTALL_TRANSFORMERS", False):
+        if os.getenv("NM_NO_AUTOINSTALL_TRANSFORMERS", False):
             _LOGGER.warning(
                 "Unable to import transformers, skipping auto installation "
-                "due to SPARSEML_NO_AUTOINSTALL_TRANSFORMERS"
+                "due to NM_NO_AUTOINSTALL_TRANSFORMERS"
             )
             # skip any further checks
             return
@@ -87,7 +87,7 @@ def _check_transformers_install():
             )
             _install_transformers_and_deps()
 
-    # check sparseml fork installed with QATMatMul available
+    # check NM fork installed with QATMatMul available
     try:
         import transformers as _transformers
 
@@ -95,8 +95,9 @@ def _check_transformers_install():
     except Exception:
         _LOGGER.warning(
             "transformers.models.bert.modeling_bert.QATMatMul not availalbe. the"
-            "sparseml fork of transformers may not be installed. it can be installed "
-            "via `pip install git+https://github.com/neuralmagic/transformers.git`"
+            "neuralmagic fork of transformers may not be installed. it can be "
+            "installed via "
+            "`pip install git+https://github.com/neuralmagic/transformers.git`"
         )
 
 

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -18,6 +18,9 @@ Tools for integrating SparseML with transformers training flows
 
 # flake8: noqa
 
+import logging as _logging
+
+
 try:
     import transformers as _transformers
 
@@ -26,15 +29,15 @@ except Exception as _transformers_import_err:
     _transformers_import_error = _transformers_import_err
 
 
+_LOGGER = _logging.getLogger(__name__)
+
+
 def _install_transformers_and_deps():
-    import logging as _logging
 
     import pip as _pip
     import sparseml as _sparseml
 
-    logger = _logging.getLogger(__name__)
-
-    logger.info(
+    _LOGGER.info(
         "No installation of transformers found. Installing sparseml-transformers "
         "dependencies"
     )
@@ -61,19 +64,29 @@ def _install_transformers_and_deps():
     try:
         import transformers as _transformers
 
-        logger.info("sparseml-transformers and dependencies successfully installed")
+        _LOGGER.info("sparseml-transformers and dependencies successfully installed")
     except Exception:
         raise ValueError(
             "Unable to install sparseml-transformers dependencies try installing "
-            f"via `pip install git+https://github.com/neuralmagic/transformers.git"
+            f"via `pip install git+https://github.com/neuralmagic/transformers.git`"
         )
 
 
 def _check_transformers_install():
-    if _transformers_import_error is None:
-        return
-    else:
+    if _transformers_import_error is not None:
         _install_transformers_and_deps()
+
+    # check sparseml fork installed with QATMatMul available
+    try:
+        import transformers as _transformers
+
+        _transformers.models.bert.modeling_bert.QATMatMul
+    except Exception:
+        _LOGGER.warning(
+            "transformers.models.bert.modeling_bert.QATMatMul not availalbe. the"
+            "sparseml fork of transformers may not be installed. it can be installed "
+            "via `pip install git+https://github.com/neuralmagic/transformers.git`"
+        )
 
 
 _check_transformers_install()

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -37,10 +37,6 @@ def _install_transformers_and_deps():
     import pip as _pip
     import sparseml as _sparseml
 
-    _LOGGER.info(
-        "No installation of transformers found. Installing sparseml-transformers "
-        "dependencies"
-    )
     transformers_branch = (
         "master"
         if not _sparseml.is_release
@@ -74,7 +70,21 @@ def _install_transformers_and_deps():
 
 def _check_transformers_install():
     if _transformers_import_error is not None:
-        _install_transformers_and_deps()
+        import os
+
+        if os.getenv("SPARSEML_NO_AUTOINSTALL_TRANSFORMERS", False):
+            _LOGGER.warning(
+                "Unable to import transformers, skipping auto installation "
+                "due to SPARSEML_NO_AUTOINSTALL_TRANSFORMERS"
+            )
+            # skip any further checks
+            return
+        else:
+            _LOGGER.info(
+                "No installation of transformers found. Installing sparseml-transformers "
+                "dependencies"
+            )
+            _install_transformers_and_deps()
 
     # check sparseml fork installed with QATMatMul available
     try:


### PR DESCRIPTION
removes the `sparseml[transformers]` install pathway and instead installs the dependencies on any import from `sparseml.transformers`. Auto install can be prevented by setting the environment variable `SPARSEML_NO_AUTOINSTALL_TRANSFORMERS`.

Example:
From a new virtual environment:
```bash
cd sparseml
pip install -e ./[torch]

# will trigger sparseml-transformers install
sparseml.transformers.export_onnx -h
```