### PR TITLE
update transformers install to point to tarball + small fixes

### DIFF
--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -57,7 +57,7 @@ def _install_transformers_and_deps():
             [
                 "install",
                 transformers_requirement,
-                "datasets",
+                "datasets<1.18.0",
                 "sklearn",
                 "seqeval",
             ]

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -24,12 +24,19 @@ import logging as _logging
 try:
     import transformers as _transformers
 
+    # triggers error if neuralmagic/transformers is not installed
+    _transformers.models.bert.modeling_bert.QATMatMul
     _transformers_import_error = None
 except Exception as _transformers_import_err:
     _transformers_import_error = _transformers_import_err
 
 
 _LOGGER = _logging.getLogger(__name__)
+_NM_TRANSFORMERS_TAR_TEMPLATE = (
+    "https://github.com/neuralmagic/transformers/releases/download/"
+    "{version}/transformers-4.7.0.dev0.tar.gz"
+)
+_NM_TRANSFORMERS_NIGHTLY = _NM_TRANSFORMERS_TAR_TEMPLATE.format(version="nightly")
 
 
 def _install_transformers_and_deps():
@@ -37,16 +44,14 @@ def _install_transformers_and_deps():
     import pip as _pip
     import sparseml as _sparseml
 
-    transformers_branch = (
-        "master"
+    nm_transformers_release = (
+        "nightly"
         if not _sparseml.is_release
-        else f"release/{_sparseml.version_major_minor}"
+        else f"release/v{_sparseml.version_major_minor}.0"
     )
-    transformers_requirement = (
-        "transformers @ git+https://github.com/neuralmagic/transformers.git"
-        f"@{transformers_branch}"
+    transformers_requirement = _NM_TRANSFORMERS_TAR_TEMPLATE.format(
+        version=nm_transformers_release
     )
-
     try:
         _pip.main(
             [
@@ -65,7 +70,7 @@ def _install_transformers_and_deps():
         raise ValueError(
             "Unable to install and import sparseml-transformers dependencies check "
             "that transformers is installed, if not, install via "
-            "`pip install git+https://github.com/neuralmagic/transformers.git`"
+            f"`pip install {_NM_TRANSFORMERS_NIGHTLY}`"
         )
 
 
@@ -75,19 +80,21 @@ def _check_transformers_install():
 
         if os.getenv("NM_NO_AUTOINSTALL_TRANSFORMERS", False):
             _LOGGER.warning(
-                "Unable to import transformers, skipping auto installation "
+                "Unable to import, skipping auto installation "
                 "due to NM_NO_AUTOINSTALL_TRANSFORMERS"
             )
             # skip any further checks
             return
         else:
-            _LOGGER.info(
-                "No installation of transformers found. Installing sparseml-transformers "
-                "dependencies"
+            _LOGGER.warning(
+                "sparseml-transformers installation not detected. Installing "
+                "sparseml-transformers dependencies if transformers is already "
+                "installed in the environment, it will be overwritten. Set "
+                "environment variable NM_NO_AUTOINSTALL_TRANSFORMERS to disable"
             )
             _install_transformers_and_deps()
 
-    # check NM fork installed with QATMatMul available
+    # re check import after potential install
     try:
         import transformers as _transformers
 
@@ -97,7 +104,7 @@ def _check_transformers_install():
             "transformers.models.bert.modeling_bert.QATMatMul not availalbe. the"
             "neuralmagic fork of transformers may not be installed. it can be "
             "installed via "
-            "`pip install git+https://github.com/neuralmagic/transformers.git`"
+            f"`pip install {_NM_TRANSFORMERS_NIGHTLY}`"
         )
 
 

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -19,6 +19,7 @@ Tools for integrating SparseML with transformers training flows
 # flake8: noqa
 
 import logging as _logging
+import sys
 
 
 try:
@@ -41,7 +42,9 @@ _NM_TRANSFORMERS_NIGHTLY = _NM_TRANSFORMERS_TAR_TEMPLATE.format(version="nightly
 
 def _install_transformers_and_deps():
 
-    import pip as _pip
+    import subprocess as _subprocess
+    import sys as _sys
+
     import sparseml as _sparseml
 
     nm_transformers_release = (
@@ -53,8 +56,11 @@ def _install_transformers_and_deps():
         version=nm_transformers_release
     )
     try:
-        _pip.main(
+        _subprocess.check_call(
             [
+                sys.executable,
+                "-m",
+                "pip",
                 "install",
                 transformers_requirement,
                 "datasets<1.18.0",

--- a/src/sparseml/transformers/utils/export.py
+++ b/src/sparseml/transformers/utils/export.py
@@ -29,7 +29,7 @@ Export a trained transformers model to an ONNX file
 
 optional arguments:
   -h, --help            show this help message and exit
-  --task TASK           task to create the model for. i.e. mlm, qa, glue, ner
+  --task TASK           Task to create the model for. i.e. mlm, qa, glue, ner
   --model_path MODEL_PATH
                         Path to directory where model files for weights, config,
                         and tokenizer are stored
@@ -37,13 +37,13 @@ optional arguments:
                         Sequence length to use. Default is 384. Can be overwritten
                         later
   --convert_qat CONVERT_QAT
-                        Set True to convert QAT graph exports to fully quantized.
-                        Default is True
+                        Set flag to not perform QAT to fully quantized conversion
+                        after export
   --finetuning_task FINETUNING_TASK
                         optional finetuning task for text classification and token
                         classification exports
   --onnx_file_name ONNX_FILE_NAME
-                        name for exported ONNX file in the model directory. Default
+                        Name for exported ONNX file in the model directory. Default
                         and reccomended value for pipeline compatibility is
                         'model.onnx'
 
@@ -207,12 +207,9 @@ def _parse_args() -> argparse.Namespace:
         help="Sequence length to use. Default is 384. Can be overwritten later",
     )
     parser.add_argument(
-        "--convert_qat",
-        type=bool,
-        default=True,
-        help=(
-            "Set True to convert QAT graph exports to fully quantized. Default is True"
-        ),
+        "--no_convert_qat",
+        action="store_false",
+        help=("Set flag to not perform QAT to fully quantized conversion after export"),
     )
     parser.add_argument(
         "--finetuning_task",

--- a/src/sparseml/transformers/utils/trainer.py
+++ b/src/sparseml/transformers/utils/trainer.py
@@ -180,10 +180,12 @@ class SparseMLTrainer:
         super().create_optimizer()
         if not self.recipe:
             return
-        steps_per_epoch = math.ceil(
-            len(self.train_dataset)
-            / (self.args.per_device_train_batch_size * self.args._n_gpu)
+        total_batch_size = (
+            self.args.per_device_train_batch_size
+            * self.args._n_gpu
+            * self.args.gradient_accumulation_steps
         )
+        steps_per_epoch = math.ceil(len(self.train_dataset) / total_batch_size)
         if hasattr(self, "scaler"):
             self.scaler = self.manager.modify(
                 self.model,


### PR DESCRIPTION
* transformers install now points to a tarball from releases of neuralmagic/transformers
* update logic flow so previous installs of transformers are overwritten if they are not from the NM fork
* manager num_steps calculation bug fix from @eldarkurtic 
* convert_qat flag improvement
* pin datasets version to `1<.18.0` due to a new issue with the squad dataset
* use a subprocess call to perform pip install instead of pip API due to an issue found by @dbarbuzzi 