### PR TITLE
Add: generic calibration dataloader

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -19,8 +19,10 @@ PyTorch version must support quantization (>=1.2, ONNX export support introduced
 """
 
 
-from typing import Any, Dict, List, NamedTuple, Optional, Union
+import logging
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
 
+import torch
 from torch.nn import Module
 from torch.optim.optimizer import Optimizer
 
@@ -44,6 +46,9 @@ from sparseml.pytorch.utils.quantization import (
     prepare_embeddings_qat,
     remove_activation_qat_by_layer_name,
 )
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 __all__ = [
@@ -142,6 +147,7 @@ class QuantizationModifier(ScheduledModifier):
         self._qat_enabled = False
         self._quantization_observer_disabled = False
         self._bn_stats_frozen = False
+        self._calibration_dataloader = None
 
         if (
             isinstance(self._model_fuse_fn_name, str)
@@ -275,6 +281,7 @@ class QuantizationModifier(ScheduledModifier):
         module: Module,
         epoch: float = 0,
         loggers: Optional[List[BaseLogger]] = None,
+        calibration_dataloader: Optional[Iterable[Tuple[List, Dict[str, Any]]]] = None,
         **kwargs,
     ):
         """
@@ -284,11 +291,15 @@ class QuantizationModifier(ScheduledModifier):
         :param epoch: The epoch to initialize the modifier and module at.
             Defaults to 0 (start of the training process)
         :param loggers: Optional list of loggers to log the modification process to
+        :param calibration_dataloader: optional dataloader for running post training
+            quantization with the given model. if present, calibration will be run
+            immediately after quantization is enabled
         :param kwargs: Optional kwargs to support specific arguments
             for individual modifiers.
         """
         super().initialize(module, epoch, loggers, **kwargs)
         self._modules_to_quantize = []
+        self._calibration_dataloader = calibration_dataloader
         if self._submodules is not None:
             found_submodules = []
             for name, submodule in module.named_modules():
@@ -420,6 +431,25 @@ class QuantizationModifier(ScheduledModifier):
         if self._quantize_embeddings:
             prepare_embeddings_qat(module, reduce_range=self._reduce_range)
         self._qat_enabled = True
+
+        if self._calibration_dataloader is not None:
+            self._calibrate(module)
+
+    def _calibrate(self, module):
+        if not self._calibration_dataloader or not self._qat_enabled:
+            return
+
+        _LOGGER.info("Running quantization calibration using calibration_dataloader")
+
+        module_training = module.training
+        module.eval()
+
+        for args, kwargs in self._calibration_dataloader:
+            with torch.no_grad():
+                module(*args, **kwargs)
+
+        if module_training:
+            module.train()
 
     def _disable_quantization_observer_update_ready(self, epoch: float) -> bool:
         return (

--- a/src/sparseml/pytorch/optim/optimizer.py
+++ b/src/sparseml/pytorch/optim/optimizer.py
@@ -17,7 +17,7 @@ Optimizer wrapper for enforcing Modifiers on the training process of a Module.
 """
 
 import warnings
-from typing import List, Union
+from typing import Any, Dict, List, Union
 
 from torch import Tensor
 from torch.nn import Module
@@ -68,7 +68,8 @@ class ScheduledOptimizer(Optimizer):
         when not using can result in irregularities
     :param loggers: loggers to log important info to within the modifiers;
         ex tensorboard or to the console
-
+    :param initialize_kwargs: key word arguments and values to be passed to
+        the recipe manager initialize function
     """
 
     def __init__(
@@ -78,6 +79,7 @@ class ScheduledOptimizer(Optimizer):
         manager: ScheduledModifierManager,
         steps_per_epoch: int,
         loggers: Union[List[BaseLogger], None] = None,
+        initialize_kwargs: Dict[str, Any] = None,
     ):
         # do not call into super since this instance is not passing all calls to
         # the nested optimizer
@@ -87,7 +89,8 @@ class ScheduledOptimizer(Optimizer):
         #     UserWarning,
         # )  TODO: uncomment in next release once docs are ready
 
-        manager.initialize(module, epoch=0.0, loggers=loggers)
+        initialize_kwargs = initialize_kwargs or {}
+        manager.initialize(module, epoch=0.0, loggers=loggers, **initialize_kwargs)
         self._wrapper = RecipeManagerStepWrapper(
             optimizer,
             optimizer,

--- a/tests/sparseml/pytorch/models/classification/test_resnet.py
+++ b/tests/sparseml/pytorch/models/classification/test_resnet.py
@@ -85,7 +85,7 @@ from tests.sparseml.pytorch.models.utils import compare_model
         ("resnext152", False, True, resnext152),
     ],
 )
-def test_resnsets(
+def test_resnets(
     key: str, pretrained: Union[bool, str], test_input: bool, match_const: Callable
 ):
     model = ModelRegistry.create(key, pretrained)

--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -63,7 +63,7 @@ def _is_valid_submodule(module_name, submodule_names):
     )
 
 
-def _is_quantiable_module(module):
+def _is_quantizable_module(module):
     return isinstance(module, (Conv2d, Linear))
 
 
@@ -96,7 +96,7 @@ def _test_qat_applied(modifier, model):
         assert hasattr(model, "qconfig") and model.qconfig is not None
         submodules = [""]
         for module in model.modules():
-            if _is_quantiable_module(module):
+            if _is_quantizable_module(module):
                 _test_quantizable_module(
                     module,
                     True,
@@ -108,7 +108,7 @@ def _test_qat_applied(modifier, model):
         submodules = modifier.submodules
     # check qconfig propagation
     for name, module in model.named_modules():
-        if _is_quantiable_module(module):
+        if _is_quantizable_module(module):
             _test_quantizable_module(
                 module,
                 _is_valid_submodule(name, submodules),


### PR DESCRIPTION
This pull request adds a generic `calibration_dataloader` to `QuantizationModifier`

Steps to Test:
```python
import torch
from sparseml.pytorch.models import resnet50
from sparseml.pytorch.optim import QuantizationModifier


def random_dataloader(n=5):
    """
    A random generator
    """
    for _ in range(n):
        print(f"Trying to yield batch {_}")
        yield [torch.rand(32, 3, 224, 224)], {}


# Pretrained Model
model = resnet50(pretrained=True)

# Modifier init
modifier = QuantizationModifier(start_epoch=0)

# Modifier Application
modifier.apply(
    module=model,
    calibration_dataloader=random_dataloader(),
)

# Book-Keeping, the model should have non infinity weights
print(model(torch.rand(1, 3, 224, 224)))
print(model)

``` 

Observer weights post modifier application and after first forward pass should look like 
```
(activation_post_process): MovingAverageMinMaxObserver(min_val=-4.431874752044678, max_val=6.029556751251221)
```

