### PR TITLE
Add: calibration dataloader + forward func

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -18,7 +18,9 @@ Modifier for models through quantization aware training.
 PyTorch version must support quantization (>=1.2, ONNX export support introduced in 1.7)
 """
 import logging
-from functools import partial
+import warnings
+from contextlib import suppress
+from itertools import cycle
 from typing import (
     Any,
     Callable,
@@ -113,6 +115,8 @@ class QuantizationModifier(ScheduledModifier):
         transformer based models such as BERT where the quantized MatMul outputs
         are kept at 32 bits of precision and fake quantizing the outputs harm training
         recovery. Default is True
+    :param num_steps: Number of steps to run post training calibration for.
+            When None, the entire calibration_dataloader is used
     """
 
     def __init__(
@@ -127,6 +131,7 @@ class QuantizationModifier(ScheduledModifier):
         quantize_embeddings: bool = True,
         reduce_range: bool = False,
         quantize_linear_activations: bool = True,
+        num_calibration_steps: Optional[int] = None,
     ):
         if torch_quantization is None or torch_intrinsic is None:
             raise RuntimeError(
@@ -158,6 +163,7 @@ class QuantizationModifier(ScheduledModifier):
         self._bn_stats_frozen = False
         self._calibration_dataloader = None
         self._calibration_function = None
+        self._num_calibration_steps = num_calibration_steps
 
         if (
             isinstance(self._model_fuse_fn_name, str)
@@ -293,6 +299,14 @@ class QuantizationModifier(ScheduledModifier):
         """
         return self._quantize_linear_activations
 
+    @ModifierProp()
+    def num_calibration_steps(self) -> Optional[int]:
+        """
+        :return: Number of steps to run post training calibration for.
+            When None, the entire calibration_dataloader is used
+        """
+        return self._num_calibration_steps
+
     def initialize(
         self,
         module: Module,
@@ -312,8 +326,10 @@ class QuantizationModifier(ScheduledModifier):
         :param calibration_dataloader: optional dataloader for running post training
             quantization with the given model. if present, calibration will be run
             immediately after quantization is enabled
-        :param calibration_function: optional function to use for calibration of
-            model parameters post training.
+        :param calibration_function: An Optional callable to use for
+            calibration of module parameters post training. Should be able to
+            accept a batch of inputs along with a module.
+            Example: func(batch, module), Defaults to tensors_module_forward
         :param kwargs: Optional kwargs to support specific arguments
             for individual modifiers.
         """
@@ -452,14 +468,28 @@ class QuantizationModifier(ScheduledModifier):
         if self._quantize_embeddings:
             prepare_embeddings_qat(module, reduce_range=self._reduce_range)
         self._qat_enabled = True
+        self._calibrate_if_possible(module)
 
-        if self._calibration_dataloader is not None:
+    def _calibrate_if_possible(self, module):
+        if self.num_calibration_steps == 0 and self._calibration_dataloader:
+            warnings.warn(
+                f"num_calibration_steps is {self.num_calibration_steps}."
+                f"Calibration data loader will not be used."
+            )
+        elif self.num_calibration_steps and not self._calibration_dataloader:
+            raise ValueError(
+                f"num_calibration_steps is {self.num_calibration_steps}. "
+                "Calibration data loader is not set. Pass a "
+                "calibration_data_loader with initialize(...) method."
+            )
+
+        elif not self._calibration_dataloader or not self._qat_enabled:
+            return
+
+        elif self._calibration_dataloader:
             self._calibrate(module)
 
     def _calibrate(self, module):
-        if not self._calibration_dataloader or not self._qat_enabled:
-            return
-
         _LOGGER.info("Running quantization calibration using calibration_dataloader")
 
         module_training = module.training
@@ -468,18 +498,30 @@ class QuantizationModifier(ScheduledModifier):
         forward_fn: Callable = (
             self._calibration_function
             if self._calibration_function
-            else partial(tensors_module_forward, module=module)
+            else tensors_module_forward
         )
 
         model_device = next(module.parameters()).device
+        _dataloader = (
+            self._calibration_dataloader
+            if self.num_calibration_steps is None
+            else cycle(self._calibration_dataloader)
+        )
+        with suppress(StopIteration):
+            batch = next(_dataloader)
+            batch_number = 1
+            done = False
+            while not done:
+                batch = tensors_to_device(batch, model_device)
+                with torch.no_grad():
+                    forward_fn(batch, module=module)
+                done = (
+                    self.num_calibration_steps is not None
+                    and batch_number >= self.num_calibration_steps
+                )
+                batch = next(_dataloader)
+                batch_number += 1
 
-        for batch in self._calibration_dataloader:
-            batch = tensors_to_device(batch, model_device)
-            with torch.no_grad():
-                try:
-                    forward_fn(batch)
-                except Exception:
-                    module(batch)
         if module_training:
             module.train()
 

--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -19,8 +19,10 @@ PyTorch version must support quantization (>=1.2, ONNX export support introduced
 """
 
 
-from typing import Any, Dict, List, NamedTuple, Optional, Union
+import logging
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
 
+import torch
 from torch.nn import Module
 from torch.optim.optimizer import Optimizer
 
@@ -45,6 +47,9 @@ from sparseml.pytorch.utils.quantization import (
     remove_activation_qat_by_layer_name,
 )
 from sparseml.sparsification import SparsificationTypes
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 __all__ = [
@@ -143,6 +148,7 @@ class QuantizationModifier(ScheduledModifier):
         self._qat_enabled = False
         self._quantization_observer_disabled = False
         self._bn_stats_frozen = False
+        self._calibration_dataloader = None
 
         if (
             isinstance(self._model_fuse_fn_name, str)
@@ -283,6 +289,7 @@ class QuantizationModifier(ScheduledModifier):
         module: Module,
         epoch: float = 0,
         loggers: Optional[List[BaseLogger]] = None,
+        calibration_dataloader: Optional[Iterable[Tuple[List, Dict[str, Any]]]] = None,
         **kwargs,
     ):
         """
@@ -292,11 +299,15 @@ class QuantizationModifier(ScheduledModifier):
         :param epoch: The epoch to initialize the modifier and module at.
             Defaults to 0 (start of the training process)
         :param loggers: Optional list of loggers to log the modification process to
+        :param calibration_dataloader: optional dataloader for running post training
+            quantization with the given model. if present, calibration will be run
+            immediately after quantization is enabled
         :param kwargs: Optional kwargs to support specific arguments
             for individual modifiers.
         """
         super().initialize(module, epoch, loggers, **kwargs)
         self._modules_to_quantize = []
+        self._calibration_dataloader = calibration_dataloader
         if self._submodules is not None:
             found_submodules = []
             for name, submodule in module.named_modules():
@@ -428,6 +439,25 @@ class QuantizationModifier(ScheduledModifier):
         if self._quantize_embeddings:
             prepare_embeddings_qat(module, reduce_range=self._reduce_range)
         self._qat_enabled = True
+
+        if self._calibration_dataloader is not None:
+            self._calibrate(module)
+
+    def _calibrate(self, module):
+        if not self._calibration_dataloader or not self._qat_enabled:
+            return
+
+        _LOGGER.info("Running quantization calibration using calibration_dataloader")
+
+        module_training = module.training
+        module.eval()
+
+        for args, kwargs in self._calibration_dataloader:
+            with torch.no_grad():
+                module(*args, **kwargs)
+
+        if module_training:
+            module.train()
 
     def _disable_quantization_observer_update_ready(self, epoch: float) -> bool:
         return (

--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -17,10 +17,19 @@ Modifier for models through quantization aware training.
 
 PyTorch version must support quantization (>=1.2, ONNX export support introduced in 1.7)
 """
-
-
 import logging
-from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, Union
+from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import torch
 from torch.nn import Module
@@ -36,7 +45,7 @@ except Exception:
 
 from sparseml.optim import BaseModifier, ModifierProp
 from sparseml.pytorch.optim.modifier import PyTorchModifierYAML, ScheduledModifier
-from sparseml.pytorch.utils import BaseLogger
+from sparseml.pytorch.utils import BaseLogger, tensors_module_forward, tensors_to_device
 from sparseml.pytorch.utils.quantization import (
     add_quant_dequant,
     configure_module_default_qconfigs,
@@ -50,7 +59,6 @@ from sparseml.sparsification import SparsificationTypes
 
 
 _LOGGER = logging.getLogger(__name__)
-
 
 __all__ = [
     "QuantizationModifier",
@@ -149,6 +157,7 @@ class QuantizationModifier(ScheduledModifier):
         self._quantization_observer_disabled = False
         self._bn_stats_frozen = False
         self._calibration_dataloader = None
+        self._calibration_function = None
 
         if (
             isinstance(self._model_fuse_fn_name, str)
@@ -290,6 +299,7 @@ class QuantizationModifier(ScheduledModifier):
         epoch: float = 0,
         loggers: Optional[List[BaseLogger]] = None,
         calibration_dataloader: Optional[Iterable[Tuple[List, Dict[str, Any]]]] = None,
+        calibration_function: Optional[Callable] = None,
         **kwargs,
     ):
         """
@@ -302,12 +312,15 @@ class QuantizationModifier(ScheduledModifier):
         :param calibration_dataloader: optional dataloader for running post training
             quantization with the given model. if present, calibration will be run
             immediately after quantization is enabled
+        :param calibration_function: optional function to use for calibration of
+            model parameters post training.
         :param kwargs: Optional kwargs to support specific arguments
             for individual modifiers.
         """
         super().initialize(module, epoch, loggers, **kwargs)
         self._modules_to_quantize = []
         self._calibration_dataloader = calibration_dataloader
+        self._calibration_function = calibration_function
         if self._submodules is not None:
             found_submodules = []
             for name, submodule in module.named_modules():
@@ -452,10 +465,21 @@ class QuantizationModifier(ScheduledModifier):
         module_training = module.training
         module.eval()
 
-        for args, kwargs in self._calibration_dataloader:
-            with torch.no_grad():
-                module(*args, **kwargs)
+        forward_fn: Callable = (
+            self._calibration_function
+            if self._calibration_function
+            else partial(tensors_module_forward, module=module)
+        )
 
+        model_device = next(module.parameters()).device
+
+        for batch in self._calibration_dataloader:
+            batch = tensors_to_device(batch, model_device)
+            with torch.no_grad():
+                try:
+                    forward_fn(batch)
+                except Exception:
+                    module(batch)
         if module_training:
             module.train()
 

--- a/src/sparseml/pytorch/optim/optimizer.py
+++ b/src/sparseml/pytorch/optim/optimizer.py
@@ -17,7 +17,7 @@ Optimizer wrapper for enforcing Modifiers on the training process of a Module.
 """
 
 import warnings
-from typing import List, Union
+from typing import Any, Dict, List, Union
 
 from torch import Tensor
 from torch.nn import Module
@@ -68,7 +68,8 @@ class ScheduledOptimizer(Optimizer):
         when not using can result in irregularities
     :param loggers: loggers to log important info to within the modifiers;
         ex tensorboard or to the console
-
+    :param initialize_kwargs: key word arguments and values to be passed to
+        the recipe manager initialize function
     """
 
     def __init__(
@@ -78,6 +79,7 @@ class ScheduledOptimizer(Optimizer):
         manager: ScheduledModifierManager,
         steps_per_epoch: int,
         loggers: Union[List[BaseLogger], None] = None,
+        initialize_kwargs: Dict[str, Any] = None,
     ):
         # do not call into super since this instance is not passing all calls to
         # the nested optimizer
@@ -87,7 +89,8 @@ class ScheduledOptimizer(Optimizer):
         #     UserWarning,
         # )  TODO: uncomment in next release once docs are ready
 
-        manager.initialize(module, epoch=0.0, loggers=loggers)
+        initialize_kwargs = initialize_kwargs or {}
+        manager.initialize(module, epoch=0.0, loggers=loggers, **initialize_kwargs)
         self._wrapper = RecipeManagerStepWrapper(
             optimizer,
             optimizer,

--- a/tests/sparseml/pytorch/models/classification/test_resnet.py
+++ b/tests/sparseml/pytorch/models/classification/test_resnet.py
@@ -85,7 +85,7 @@ from tests.sparseml.pytorch.models.utils import compare_model
         ("resnext152", False, True, resnext152),
     ],
 )
-def test_resnsets(
+def test_resnets(
     key: str, pretrained: Union[bool, str], test_input: bool, match_const: Callable
 ):
     model = ModelRegistry.create(key, pretrained)

--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -207,6 +207,7 @@ def test_quantization_modifier_yaml():
     quantize_embeddings = False
     reduce_range = True
     quantize_linear_activations = False
+    num_calibration_steps = 2
     yaml_str = f"""
         !QuantizationModifier
             start_epoch: {start_epoch}
@@ -217,6 +218,7 @@ def test_quantization_modifier_yaml():
             quantize_embeddings: {quantize_embeddings}
             reduce_range: {reduce_range}
             quantize_linear_activations: {quantize_linear_activations}
+            num_calibration_steps: {num_calibration_steps}
         """
     yaml_modifier = QuantizationModifier.load_obj(
         yaml_str
@@ -233,6 +235,7 @@ def test_quantization_modifier_yaml():
         quantize_embeddings=quantize_embeddings,
         reduce_range=reduce_range,
         quantize_linear_activations=quantize_linear_activations,
+        num_calibration_steps=num_calibration_steps,
     )
 
     assert isinstance(yaml_modifier, QuantizationModifier)

--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -63,7 +63,7 @@ def _is_valid_submodule(module_name, submodule_names):
     )
 
 
-def _is_quantiable_module(module):
+def _is_quantizable_module(module):
     return isinstance(module, (Conv2d, Linear))
 
 
@@ -96,7 +96,7 @@ def _test_qat_applied(modifier, model):
         assert hasattr(model, "qconfig") and model.qconfig is not None
         submodules = [""]
         for module in model.modules():
-            if _is_quantiable_module(module):
+            if _is_quantizable_module(module):
                 _test_quantizable_module(
                     module,
                     True,
@@ -108,7 +108,7 @@ def _test_qat_applied(modifier, model):
         submodules = modifier.submodules
     # check qconfig propagation
     for name, module in model.named_modules():
-        if _is_quantiable_module(module):
+        if _is_quantizable_module(module):
             _test_quantizable_module(
                 module,
                 _is_valid_submodule(name, submodules),

--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -33,7 +33,6 @@ try:
 except Exception:
     torch_quantization = None
 
-
 QUANTIZATION_MODIFIERS = [
     lambda: QuantizationModifier(
         start_epoch=0.0,
@@ -278,4 +277,9 @@ def test_quantization_modifier_yaml():
         yaml_modifier.quantize_linear_activations
         == serialized_modifier.quantize_linear_activations
         == obj_modifier.quantize_linear_activations
+    )
+    assert (
+        yaml_modifier.num_calibration_steps
+        == serialized_modifier.num_calibration_steps
+        == obj_modifier.num_calibration_steps
     )


### PR DESCRIPTION
Adds: A generic calibratiion dataloader and a calibration forward function, for calibrating weights after training, (Post Training Quantization)

```python
import torch
from sparseml.pytorch.models import resnet50
from sparseml.pytorch.optim import QuantizationModifier


def random_dataloader(n=5):
    """
    A random generator
    """
    for _ in range(n):
        print(f"Trying to yield batch {_}")
        yield [torch.rand(32, 3, 224, 224)], {}


# Pretrained Model
model = resnet50(pretrained=True)

# Modifier init
modifier = QuantizationModifier(start_epoch=0)

# Modifier Application
modifier.apply(
    module=model,
    calibration_dataloader=random_dataloader(),
)

# Book-Keeping, the model should have non infinity weights
print(model(torch.rand(1, 3, 224, 224)))
print(model)

```

Can also pass in a Calibration function along with dataloader

```python
import torch
from sparseml.pytorch.models import resnet50
from sparseml.pytorch.optim import QuantizationModifier
from sparseml.pytorch.utils import  tensors_module_forward

def random_dataloader(n=5):
    """
    A random generator
    """
    for _ in range(n):
        print(f"Trying to yield batch {_}")
        yield [torch.rand(32, 3, 224, 224)], {}


# Pretrained Model
model = resnet50(pretrained=True)

# Modifier init
modifier = QuantizationModifier(start_epoch=0)

# Modifier Application
modifier.apply(
    module=model,
    calibration_dataloader=random_dataloader(),
    calibration_func=tensors_module_forward,
)

# Book-Keeping, the model should have non infinity weights
print(model(torch.rand(1, 3, 224, 224)))
print(model)

```