### PR TITLE
Activation Bits Support + qconfig kwargs for QuantizationModifier

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -86,7 +86,7 @@ class QuantizationModifier(ScheduledModifier):
     |       disable_quantization_observer_epoch: 2.0
     |       freeze_bn_stats_epoch: 3.0
     |       reduce_range: False
-    |       activation_bits: False
+    |       activation_bits: 4
 
     :param start_epoch: The epoch to start the modifier at
     :param submodules: List of submodule names to perform QAT on. Leave None to quantize
@@ -117,7 +117,7 @@ class QuantizationModifier(ScheduledModifier):
         are kept at 32 bits of precision and fake quantizing the outputs harm training
         recovery. Default is True
     :param activation_bits: Number of bits to use for setting quant min/max values for
-            activations. Default is None, which will quantize activations to 8 bits.
+            activations. Default is  8 bits.
     :param num_calibration_steps: Number of steps to run post training calibration for.
             When None, the entire calibration_dataloader is used
     :param exclude_module_types: optional list of module class names
@@ -140,7 +140,7 @@ class QuantizationModifier(ScheduledModifier):
         quantize_embeddings: bool = True,
         reduce_range: bool = False,
         quantize_linear_activations: bool = True,
-        activation_bits: Optional[int] = None,
+        activation_bits: int = 8,
         num_calibration_steps: Optional[int] = None,
         exclude_module_types: Union[List[str], None] = None,
         activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
@@ -599,6 +599,12 @@ class QuantizationModifier(ScheduledModifier):
             if self.activation_qconfig_kwargs
             else {}
         )
+
+        if not isinstance(self.activation_bits, int) or self.activation_bits < 0:
+            raise ValueError(
+                f"activation_bits must be a positive integer, "
+                f"but got {self.activation_bits}"
+            )
 
         # update qconfig_kwargs for activation_bits
         if self.activation_bits and (

--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -32,7 +32,6 @@ from typing import (
     Union,
 )
 
-
 import torch
 from torch.nn import Module
 from torch.optim.optimizer import Optimizer
@@ -350,7 +349,7 @@ class QuantizationModifier(ScheduledModifier):
 
         """
         return self._weight_qconfig_kwargs
-    
+
     @ModifierProp()
     def num_calibration_steps(self) -> Optional[int]:
         """
@@ -595,8 +594,11 @@ class QuantizationModifier(ScheduledModifier):
             module.train()
 
     def _get_updated_activation_qconfig_kwargs(self):
-        activation_qconfig_kwargs = self.activation_qconfig_kwargs.copy() \
-            if self.activation_qconfig_kwargs else {}
+        activation_qconfig_kwargs = (
+            self.activation_qconfig_kwargs.copy()
+            if self.activation_qconfig_kwargs
+            else {}
+        )
 
         # update qconfig_kwargs for activation_bits
         if self.activation_bits and (

--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -86,7 +86,7 @@ class QuantizationModifier(ScheduledModifier):
     |       disable_quantization_observer_epoch: 2.0
     |       freeze_bn_stats_epoch: 3.0
     |       reduce_range: False
-    |       activation_bits: 4
+    |       activation_bits: False
 
     :param start_epoch: The epoch to start the modifier at
     :param submodules: List of submodule names to perform QAT on. Leave None to quantize
@@ -117,7 +117,7 @@ class QuantizationModifier(ScheduledModifier):
         are kept at 32 bits of precision and fake quantizing the outputs harm training
         recovery. Default is True
     :param activation_bits: Number of bits to use for setting quant min/max values for
-            activations. Default is  8 bits.
+            activations. Default is None, which will quantize activations to 8 bits.
     :param num_calibration_steps: Number of steps to run post training calibration for.
             When None, the entire calibration_dataloader is used
     :param exclude_module_types: optional list of module class names
@@ -140,7 +140,7 @@ class QuantizationModifier(ScheduledModifier):
         quantize_embeddings: bool = True,
         reduce_range: bool = False,
         quantize_linear_activations: bool = True,
-        activation_bits: int = 8,
+        activation_bits: Optional[int] = None,
         num_calibration_steps: Optional[int] = None,
         exclude_module_types: Union[List[str], None] = None,
         activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
@@ -599,12 +599,6 @@ class QuantizationModifier(ScheduledModifier):
             if self.activation_qconfig_kwargs
             else {}
         )
-
-        if not isinstance(self.activation_bits, int) or self.activation_bits < 0:
-            raise ValueError(
-                f"activation_bits must be a positive integer, "
-                f"but got {self.activation_bits}"
-            )
 
         # update qconfig_kwargs for activation_bits
         if self.activation_bits and (

--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -24,7 +24,6 @@ import torch
 from torch.nn import Module
 from torch.optim.optimizer import Optimizer
 
-
 try:
     from torch import quantization as torch_quantization
     from torch.nn import intrinsic as torch_intrinsic
@@ -33,7 +32,8 @@ except Exception:
     torch_intrinsic = None
 
 from sparseml.optim import BaseModifier, ModifierProp
-from sparseml.pytorch.optim.modifier import PyTorchModifierYAML, ScheduledModifier
+from sparseml.pytorch.optim.modifier import PyTorchModifierYAML, \
+    ScheduledModifier
 from sparseml.pytorch.utils import BaseLogger
 from sparseml.pytorch.utils.quantization import (
     add_quant_dequant,
@@ -46,7 +46,6 @@ from sparseml.pytorch.utils.quantization import (
     remove_activation_qat_by_layer_name,
 )
 from sparseml.sparsification import SparsificationTypes
-
 
 __all__ = [
     "QuantizationModifier",
@@ -109,21 +108,21 @@ class QuantizationModifier(ScheduledModifier):
     """
 
     def __init__(
-        self,
-        start_epoch: float = -1.0,
-        submodules: Union[List[str], None] = None,
-        model_fuse_fn_name: Union[str, None] = None,
-        disable_quantization_observer_epoch: Union[float, None] = None,
-        freeze_bn_stats_epoch: Union[float, None] = None,
-        end_epoch: float = -1,
-        model_fuse_fn_kwargs: Dict[str, Any] = None,
-        quantize_embeddings: bool = True,
-        reduce_range: bool = False,
-        quantize_linear_activations: bool = True,
-        int4_activations: bool = False,
-        exclude_module_types: Union[List[str], None] = None,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+            self,
+            start_epoch: float = -1.0,
+            submodules: Union[List[str], None] = None,
+            model_fuse_fn_name: Union[str, None] = None,
+            disable_quantization_observer_epoch: Union[float, None] = None,
+            freeze_bn_stats_epoch: Union[float, None] = None,
+            end_epoch: float = -1,
+            model_fuse_fn_kwargs: Dict[str, Any] = None,
+            quantize_embeddings: bool = True,
+            reduce_range: bool = False,
+            quantize_linear_activations: bool = True,
+            int4_activations: bool = False,
+            exclude_module_types: Union[List[str], None] = None,
+            activation_qconfig_kwargs: Dict[str, Any] = {},
+            weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         if torch_quantization is None or torch_intrinsic is None:
             raise RuntimeError(
@@ -137,7 +136,8 @@ class QuantizationModifier(ScheduledModifier):
                 " -1. Given {}".format(end_epoch)
             )
 
-        super().__init__(start_epoch=start_epoch, end_epoch=-1.0, end_comparator=-1)
+        super().__init__(start_epoch=start_epoch, end_epoch=-1.0,
+                         end_comparator=-1)
 
         self._start_epoch = start_epoch
         self._submodules = submodules
@@ -159,8 +159,8 @@ class QuantizationModifier(ScheduledModifier):
         self._weight_qconfig_kwargs = weight_qconfig_kwargs
 
         if (
-            isinstance(self._model_fuse_fn_name, str)
-            and self._model_fuse_fn_name.lower() == "none"
+                isinstance(self._model_fuse_fn_name, str)
+                and self._model_fuse_fn_name.lower() == "none"
         ):
             self._model_fuse_fn_name = None
         if isinstance(self._submodules, list):
@@ -173,7 +173,8 @@ class QuantizationModifier(ScheduledModifier):
         """
         :return: the sparsification types this modifier instance will apply
         """
-        return [SparsificationTypes.quantization, SparsificationTypes.structured]
+        return [SparsificationTypes.quantization,
+                SparsificationTypes.structured]
 
     @ModifierProp()
     def submodules(self) -> Union[List[str], None]:
@@ -213,8 +214,8 @@ class QuantizationModifier(ScheduledModifier):
         """
         self._model_fuse_fn_name = value
         if (
-            isinstance(self._model_fuse_fn_name, str)
-            and self._model_fuse_fn_name.lower() == "none"
+                isinstance(self._model_fuse_fn_name, str)
+                and self._model_fuse_fn_name.lower() == "none"
         ):
             self._model_fuse_fn_name = None
         self._validate_params()
@@ -327,11 +328,11 @@ class QuantizationModifier(ScheduledModifier):
         return self._weight_qconfig_kwargs
 
     def initialize(
-        self,
-        module: Module,
-        epoch: float = 0,
-        loggers: Optional[List[BaseLogger]] = None,
-        **kwargs,
+            self,
+            module: Module,
+            epoch: float = 0,
+            loggers: Optional[List[BaseLogger]] = None,
+            **kwargs,
     ):
         """
         Grab the module / submodule to perform QAT on
@@ -349,7 +350,8 @@ class QuantizationModifier(ScheduledModifier):
             found_submodules = []
             for name, submodule in module.named_modules():
                 if name in self._submodules:
-                    self._modules_to_quantize.append(_ModuleToQuantize(name, submodule))
+                    self._modules_to_quantize.append(
+                        _ModuleToQuantize(name, submodule))
                     found_submodules.append(name)
             if not len(found_submodules) == len(self._submodules):
                 raise RuntimeError(
@@ -364,7 +366,8 @@ class QuantizationModifier(ScheduledModifier):
         self._check_quantization_update(module, epoch, steps_per_epoch=0)
 
     def finalize(
-        self, module: Optional[Module] = None, reset_loggers: bool = True, **kwargs
+            self, module: Optional[Module] = None, reset_loggers: bool = True,
+            **kwargs
     ):
         """
         Cleans up any state
@@ -381,7 +384,8 @@ class QuantizationModifier(ScheduledModifier):
         self._modules_to_quantize = None
 
     def update(
-        self, module: Module, optimizer: Optimizer, epoch: float, steps_per_epoch: int
+            self, module: Module, optimizer: Optimizer, epoch: float,
+            steps_per_epoch: int
     ):
         """
         If start_pending(), fuses the model, sets the model quantization config,
@@ -413,15 +417,15 @@ class QuantizationModifier(ScheduledModifier):
             return False
 
         pending = (
-            self.start_pending(epoch, steps_per_epoch)
-            or self._disable_quantization_observer_update_ready(epoch)
-            or self._freeze_bn_stats_update_ready(epoch)
+                self.start_pending(epoch, steps_per_epoch)
+                or self._disable_quantization_observer_update_ready(epoch)
+                or self._freeze_bn_stats_update_ready(epoch)
         )
 
         return pending
 
     def _check_quantization_update(
-        self, module: Module, epoch: float, steps_per_epoch: int
+            self, module: Module, epoch: float, steps_per_epoch: int
     ):
         if self.start_pending(epoch, steps_per_epoch) and not self._qat_enabled:
             self._enable_module_qat(module)
@@ -439,8 +443,8 @@ class QuantizationModifier(ScheduledModifier):
     def _enable_module_qat(self, module: Module):
         # fuse module Conv-BNs
         if (
-            self._model_fuse_fn_name is not None
-            and self._model_fuse_fn_name != "no_fuse"
+                self._model_fuse_fn_name is not None
+                and self._model_fuse_fn_name != "no_fuse"
         ):  # module class fn
             module_fuse_fn = getattr(module, self._model_fuse_fn_name, None)
             if module_fuse_fn is None or not callable(module_fuse_fn):
@@ -455,27 +459,12 @@ class QuantizationModifier(ScheduledModifier):
             self._model_fuse_fn_kwargs["inplace"] = True
             fuse_module_conv_bn_relus(module, **self._model_fuse_fn_kwargs)
 
-        # update qconfig_kwargs
-        quant_min = 0
-        quant_max = 255
-        dtype = torch.quint8
-
-        if self._int4_activations:
-            quant_min = 0
-            quant_max = 15
-
-        self._activation_qconfig_kwargs["quant_min"] = quant_min
-        self._activation_qconfig_kwargs["quant_max"] = quant_max
-        self._activation_qconfig_kwargs["dtype"] = dtype
-
-        self._weight_qconfig_kwargs["quant_min"] = quant_min
-        self._weight_qconfig_kwargs["quant_max"] = quant_max
-        self._weight_qconfig_kwargs["dtype"] = dtype
+        activation_qconfig_kwargs = self._get_updated_activation_qconfig_kwargs()
 
         # prepare each module / submodule for quantization
         qconfig = get_qat_qconfig(
             reduce_range=self._reduce_range,
-            activation_qconfig_kwargs=self.activation_qconfig_kwargs,
+            activation_qconfig_kwargs=activation_qconfig_kwargs,
             weight_qconfig_kwargs=self.weight_qconfig_kwargs,
         )
         for name, quant_module in self._modules_to_quantize:
@@ -483,7 +472,7 @@ class QuantizationModifier(ScheduledModifier):
             configure_module_qat_wrappers(
                 quant_module,
                 reduce_range=self._reduce_range,
-                activation_qconfig_kwargs=self.activation_qconfig_kwargs,
+                activation_qconfig_kwargs=activation_qconfig_kwargs,
                 weight_qconfig_kwargs=self.weight_qconfig_kwargs,
             )
             # set quantization config (asymmetric activations, symmetric weights)
@@ -507,7 +496,7 @@ class QuantizationModifier(ScheduledModifier):
             prepare_embeddings_qat(
                 module,
                 reduce_range=self._reduce_range,
-                activation_qconfig_kwargs=self.activation_qconfig_kwargs,
+                activation_qconfig_kwargs=activation_qconfig_kwargs,
                 weight_qconfig_kwargs=self.weight_qconfig_kwargs,
             )
 
@@ -516,18 +505,45 @@ class QuantizationModifier(ScheduledModifier):
 
         self._qat_enabled = True
 
+    def _get_updated_activation_qconfig_kwargs(self):
+        # update qconfig_kwargs
+        if self.int4_activations and (
+                self.activation_qconfig_kwargs.get("quant_min")
+                or self.activation_qconfig_kwargs.get("quant_max")
+        ):
+            raise ValueError(
+                "Cannot override quant_max and quant_min with int4_activations enabled")
+
+        activation_qconfig_kwargs = self.activation_qconfig_kwargs.copy()
+        quant_min = activation_qconfig_kwargs.get("quant_min", 0)
+        quant_max = activation_qconfig_kwargs.get("quant_max", 255)
+        dtype = activation_qconfig_kwargs.get("dtype", torch.quint8)
+
+        if self._int4_activations:
+            quant_min = 0
+            quant_max = 15
+
+        activation_qconfig_kwargs.update(
+            dict(
+                quant_min=quant_min,
+                quant_max=quant_max,
+                dtype=dtype,
+            )
+        )
+        return activation_qconfig_kwargs
+
     def _disable_quantization_observer_update_ready(self, epoch: float) -> bool:
         return (
-            self._disable_quantization_observer_epoch is not None
-            and epoch >= self._disable_quantization_observer_epoch
-            and not self._quantization_observer_disabled
+                self._disable_quantization_observer_epoch is not None
+                and epoch >= self._disable_quantization_observer_epoch
+                and not self._quantization_observer_disabled
         )
 
     def _freeze_bn_stats_update_ready(self, epoch: float) -> bool:
         return (
-            self._freeze_bn_stats_epoch is not None
-            and epoch >= self._freeze_bn_stats_epoch
-            and not self._bn_stats_frozen
+                self._freeze_bn_stats_epoch is not None
+                and epoch >= self._freeze_bn_stats_epoch
+                and not self._bn_stats_frozen
         )
 
     def _strip_excluded_module_qconfigs(self, module: Module):
@@ -536,14 +552,14 @@ class QuantizationModifier(ScheduledModifier):
         excluded_classes = set(self._exclude_module_types)
         for submodule in module.modules():
             if submodule.__class__.__name__ in excluded_classes and hasattr(
-                submodule, "qconfig"
+                    submodule, "qconfig"
             ):
                 submodule.qconfig = None
 
     def _validate_params(self):
         if (
-            self._disable_quantization_observer_epoch is not None
-            and self._disable_quantization_observer_epoch < self._start_epoch
+                self._disable_quantization_observer_epoch is not None
+                and self._disable_quantization_observer_epoch < self._start_epoch
         ):
             raise ValueError(
                 f"disable_quantization_observer_epoch may not be greater than "
@@ -553,8 +569,8 @@ class QuantizationModifier(ScheduledModifier):
             )
 
         if (
-            self._freeze_bn_stats_epoch is not None
-            and self._freeze_bn_stats_epoch < self._start_epoch
+                self._freeze_bn_stats_epoch is not None
+                and self._freeze_bn_stats_epoch < self._start_epoch
         ):
             raise ValueError(
                 "freeze_bn_stats_epoch may not be greater than start_epoch"

--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -39,6 +39,7 @@ from sparseml.pytorch.utils.quantization import (
     add_quant_dequant,
     configure_module_default_qconfigs,
     configure_module_qat_wrappers,
+    fix_observer_quant_range,
     fuse_module_conv_bn_relus,
     get_qat_qconfig,
     prepare_embeddings_qat,
@@ -488,6 +489,10 @@ class QuantizationModifier(ScheduledModifier):
                 reduce_range=self._reduce_range,
                 activation_kwargs=self.qconfig_activation_kwargs,
             )
+
+        # propagate custom quant min/max range from FakeQuantize to Observer objects
+        fix_observer_quant_range(module)
+
         self._qat_enabled = True
 
     def _disable_quantization_observer_update_ready(self, epoch: float) -> bool:

--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -18,7 +18,6 @@ Utility / helper functions
 
 import random
 import re
-import warnings
 from collections import OrderedDict, namedtuple
 from contextlib import contextmanager
 from copy import deepcopy
@@ -36,6 +35,7 @@ from torch.utils.data import DataLoader
 try:
     quant_err = None
     from torch.nn.qat import Conv2d as QATConv2d
+    from torch.nn.qat import Conv3d as QATConv3d
     from torch.nn.qat import Linear as QATLinear
     from torch.quantization import QuantWrapper
 except Exception as _err:
@@ -43,11 +43,6 @@ except Exception as _err:
     QuantWrapper = None
     QATLinear = None
     QATConv2d = None
-
-try:
-    from torch.nn.qat import Conv3d as QATConv3d
-except Exception as _err:
-    quant_conv3d_err = _err
     QATConv3d = None
 
 from sparseml.utils import create_dirs, save_numpy
@@ -796,7 +791,7 @@ def get_quantizable_layers(module: Module) -> List[Tuple[str, Module]]:
         if (
             isinstance(mod, Linear)
             or isinstance(mod, Conv2d)
-            or (QATConv3d and isinstance(mod, Conv3d))
+            or isinstance(mod, Conv3d)
         )
     ]
 
@@ -813,23 +808,15 @@ def get_quantized_layers(module: Module) -> List[Tuple[str, Module]]:
             "Please install a QAT compatible version of PyTorch"
         )
 
-    quantized_layers = []
-    for (name, mod) in module.named_modules():
+    return [
+        (name, mod)
+        for (name, mod) in module.named_modules()
         if (
             (QATLinear and isinstance(mod, QATLinear))
             or (QATConv2d and isinstance(mod, QATConv2d))
             or (QATConv3d and isinstance(mod, QATConv3d))
-        ):
-            quantized_layers.append((name, mod))
-
-        elif isinstance(mod, QATConv3d) and not QATConv3d:
-            warnings.warn(
-                "Pytorch version is not setup for Conv3D Quantization. "
-                "Quantization of Conv3D layers will be skipped",
-                UserWarning,
-            )
-
-    return quantized_layers
+        )
+    ]
 
 
 def get_layer_param(param: str, layer: str, module: Module) -> Parameter:

--- a/src/sparseml/pytorch/utils/quantization/helpers.py
+++ b/src/sparseml/pytorch/utils/quantization/helpers.py
@@ -105,7 +105,7 @@ class QATWrapper(Module):
     def from_module(
         module: Module,
         reduce_range: bool = None,
-        activation_kwargs: Dict = {},
+        activation_kwargs: Dict[str, Any] = {},
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for

--- a/src/sparseml/pytorch/utils/quantization/helpers.py
+++ b/src/sparseml/pytorch/utils/quantization/helpers.py
@@ -17,7 +17,7 @@ Helper functions for performing quantization aware training with PyTorch
 """
 
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Union, Optional
 
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Embedding, Module, ReLU
@@ -436,8 +436,8 @@ def get_qat_qconfig(
     symmetric_activations: bool = False,
     symmetric_weights: bool = True,
     reduce_range: bool = False,
-    activation_qconfig_kwargs: Dict[str, Any] = {},
-    weight_qconfig_kwargs: Dict[str, Any] = {},
+    activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
@@ -450,9 +450,9 @@ def get_qat_qconfig(
         This may prevent overflow issues with model execution on certain hardware
         Default is False
     :param activation_qconfig_kwargs: Additional kwargs for quantization of
-            activations. Default is {}
+            activations.
     :param weight_qconfig_kwargs: Additional kwargs for quantization of
-            weights. Default is {}
+            weights.
     :return: A QAT fake quantization config for symmetric weight quantization and
         asymmetric activation quantization.  The difference between this and
         torch.quantization.default_qat_qconfig is that the activation observer
@@ -469,7 +469,7 @@ def get_qat_qconfig(
         qscheme=activation_qscheme,
         reduce_range=reduce_range,
     )
-    activation_observer_kwargs.update(activation_qconfig_kwargs)
+    activation_observer_kwargs.update(activation_qconfig_kwargs or {})
     activation_observer = torch_quantization.FakeQuantize.with_args(
         **activation_observer_kwargs,
     )
@@ -485,7 +485,7 @@ def get_qat_qconfig(
         reduce_range=reduce_range,
     )
 
-    weight_observer_kwargs.update(weight_qconfig_kwargs)
+    weight_observer_kwargs.update(weight_qconfig_kwargs or {})
     weight_observer = torch_quantization.FakeQuantize.with_args(
         **weight_observer_kwargs,
     )

--- a/src/sparseml/pytorch/utils/quantization/helpers.py
+++ b/src/sparseml/pytorch/utils/quantization/helpers.py
@@ -17,7 +17,7 @@ Helper functions for performing quantization aware training with PyTorch
 """
 
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Union, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Embedding, Module, ReLU

--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -92,6 +92,12 @@ def _test_quantizable_module(module, qat_expected, modifier):
         )
         if module.qconfig.activation is not Identity:
             assert module.qconfig.activation.p.keywords["reduce_range"] == reduce_range
+        if modifier.activation_bits is not None:
+            expected_quant_min  = 0
+            expected_quant_max = (1 << modifier.activation_bits) - 1
+
+            assert module.qconfig.activation.p.keywords["quant_min"] == expected_quant_min
+            assert module.qconfig.activation.p.keywords["quant_max"] == expected_quant_max
 
         if isinstance(module, Linear):
             assert isinstance(module.activation_post_process, Identity) == (

--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -56,7 +56,7 @@ QUANTIZATION_MODIFIERS = [
     ),
     lambda: QuantizationModifier(
         start_epoch=0.0,
-        int4_activations=True,
+        activation_bits=4,
     ),
     lambda: QuantizationModifier(
         start_epoch=0.0,
@@ -78,7 +78,6 @@ def _is_quantizable_module(module):
 def _test_quantizable_module(module, qat_expected, modifier):
     reduce_range = modifier.reduce_range
     quantize_linear_activations = modifier.quantize_linear_activations
-    int4_activations = modifier.int4_activations
 
     excluded_types = modifier.exclude_module_types or []
     qat_expected = qat_expected and module.__class__.__name__ not in excluded_types
@@ -216,7 +215,7 @@ def test_quantization_modifier_yaml():
     reduce_range = True
     quantize_linear_activations = False
     exclude_module_types = ["LayerNorm", "Tanh"]
-    int4_activations = True
+    activation_bits = 4
     yaml_str = f"""
         !QuantizationModifier
             start_epoch: {start_epoch}
@@ -228,7 +227,7 @@ def test_quantization_modifier_yaml():
             reduce_range: {reduce_range}
             quantize_linear_activations: {quantize_linear_activations}
             exclude_module_types: {exclude_module_types}
-            int4_activations: {int4_activations}
+            activation_bits: {activation_bits}
         """
     yaml_modifier = QuantizationModifier.load_obj(
         yaml_str
@@ -245,7 +244,7 @@ def test_quantization_modifier_yaml():
         quantize_embeddings=quantize_embeddings,
         reduce_range=reduce_range,
         quantize_linear_activations=quantize_linear_activations,
-        int4_activations=int4_activations,
+        activation_bits=activation_bits,
         exclude_module_types=exclude_module_types,
     )
 
@@ -291,9 +290,9 @@ def test_quantization_modifier_yaml():
         == obj_modifier.quantize_linear_activations
     )
     assert (
-        yaml_modifier.int4_activations
-        == serialized_modifier.int4_activations
-        == obj_modifier.int4_activations
+        yaml_modifier.activation_bits
+        == serialized_modifier.activation_bits
+        == obj_modifier.activation_bits
     )
     assert (
         yaml_modifier.exclude_module_types

--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -91,11 +91,15 @@ def _test_quantizable_module(module, qat_expected, modifier):
         if module.qconfig.activation is not Identity:
             assert module.qconfig.activation.p.keywords["reduce_range"] == reduce_range
         if modifier.activation_bits is not None:
-            expected_quant_min  = 0
+            expected_quant_min = 0
             expected_quant_max = (1 << modifier.activation_bits) - 1
 
-            assert module.qconfig.activation.p.keywords["quant_min"] == expected_quant_min
-            assert module.qconfig.activation.p.keywords["quant_max"] == expected_quant_max
+            assert (
+                module.qconfig.activation.p.keywords["quant_min"] == expected_quant_min
+            )
+            assert (
+                module.qconfig.activation.p.keywords["quant_max"] == expected_quant_max
+            )
 
         if isinstance(module, Linear):
             assert isinstance(module.activation_post_process, Identity) == (

--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -224,6 +224,10 @@ def test_quantization_modifier_yaml():
     num_calibration_steps = 2
     exclude_module_types = ["LayerNorm", "Tanh"]
     activation_bits = 4
+    averaging_constant = 0.05
+    activation_qconfig_kwargs = dict(
+        averaging_constant=averaging_constant,
+    )
     yaml_str = f"""
         !QuantizationModifier
             start_epoch: {start_epoch}
@@ -237,6 +241,7 @@ def test_quantization_modifier_yaml():
             num_calibration_steps: {num_calibration_steps}
             exclude_module_types: {exclude_module_types}
             activation_bits: {activation_bits}
+            activation_qconfig_kwargs: {activation_qconfig_kwargs}
         """
     yaml_modifier = QuantizationModifier.load_obj(
         yaml_str
@@ -256,6 +261,7 @@ def test_quantization_modifier_yaml():
         activation_bits=activation_bits,
         num_calibration_steps=num_calibration_steps,
         exclude_module_types=exclude_module_types,
+        activation_qconfig_kwargs=activation_qconfig_kwargs,
     )
 
     assert isinstance(yaml_modifier, QuantizationModifier)
@@ -313,4 +319,9 @@ def test_quantization_modifier_yaml():
         yaml_modifier.exclude_module_types
         == serialized_modifier.exclude_module_types
         == obj_modifier.exclude_module_types
+    )
+    assert (
+        yaml_modifier.activation_qconfig_kwargs
+        == serialized_modifier.activation_qconfig_kwargs
+        == obj_modifier.activation_qconfig_kwargs
     )


### PR DESCRIPTION
```python
import torch
from sparseml.pytorch.models import resnet50
from sparseml.pytorch.optim import QuantizationModifier


# Pretrained Model
model = resnet50(pretrained=True)

# Modifier init
modifier = QuantizationModifier(start_epoch=0, activation_bits=4)

# Modifier Application
modifier.apply(
    module=model,
)

# Book-Keeping, the model should have non infinity weights
print(model(torch.rand(1, 3, 224, 224)))

for param in model.parameters():
    print(param.data.min(), param.data.max())

```