### PR TITLE
[hotfix 0.10.1] transformers export and QAT flow fixes

### DIFF
--- a/integrations/huggingface-transformers/README.md
+++ b/integrations/huggingface-transformers/README.md
@@ -116,3 +116,5 @@ python transformers/examples/pytorch/question-answering/run_qa.py \
 
 The DeepSparse Engine [accepts ONNX formats](https://docs.neuralmagic.com/sparseml/source/onnx_export.html) and is engineered to significantly speed up inference on CPUs for the sparsified models from this integration.
 Examples for loading, benchmarking, and deploying can be found in the [DeepSparse repository here](https://github.com/neuralmagic/deepsparse).
+
+**Note: there is currently a known issue where conversion of the BERT models from PyTorch into ONNX is not preserving the accuracy of the model for some tasks and datasets. If you encounter this issue, try rolling back to the 0.9.0 release. As a resolution is being actively investigated, this note will be removed when the issue has been remediated.** 

--- a/integrations/huggingface-transformers/README.md
+++ b/integrations/huggingface-transformers/README.md
@@ -116,5 +116,3 @@ python transformers/examples/pytorch/question-answering/run_qa.py \
 
 The DeepSparse Engine [accepts ONNX formats](https://docs.neuralmagic.com/sparseml/source/onnx_export.html) and is engineered to significantly speed up inference on CPUs for the sparsified models from this integration.
 Examples for loading, benchmarking, and deploying can be found in the [DeepSparse repository here](https://github.com/neuralmagic/deepsparse).
-
-**Note: there is currently a known issue where conversion of the BERT models from PyTorch into ONNX is not preserving the accuracy of the model for some tasks and datasets. If you encounter this issue, try rolling back to the 0.9.0 release. As a resolution is being actively investigated, this note will be removed when the issue has been remediated.** 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ _dev_deps = [
     "flake8==3.9.2",
     "isort==5.8.0",
     "m2r2~=0.2.7",
+    "mistune==0.8.4",
     "myst-parser~=0.14.0",
     "rinohtype~=0.4.2",
     "sphinx~=3.5.0",

--- a/src/sparseml/version.py
+++ b/src/sparseml/version.py
@@ -19,7 +19,7 @@ Functionality for storing and setting the version info for SparseML
 from datetime import date
 
 
-version_base = "0.10.0"
+version_base = "0.10.1"
 is_release = False  # change to True to set the generated version as a release version
 
 


### PR DESCRIPTION
Setting release version to `0.10.1`
* onnx input order fix in `sparseml.transformers.export_onnx`
* option to ignore certain module types in`QuantizationModifier`
* improvement to QAT -> Quant conversion for QAT Embeddings