### PR TITLE
Add: Generic calibration dataloader + forward function

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -508,10 +508,7 @@ class QuantizationModifier(ScheduledModifier):
         )
 
         for batch_idx, batch in enumerate(_dataloader):
-            if (
-                    self.num_calibration_steps
-                    and batch_idx >= self.num_calibration_steps
-            ):
+            if self.num_calibration_steps and batch_idx >= self.num_calibration_steps:
                 break
             batch = tensors_to_device(batch, model_device)
             with torch.no_grad():

--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -158,6 +158,7 @@ class QuantizationModifier(ScheduledModifier):
         self._quantize_embeddings = quantize_embeddings
         self._reduce_range = reduce_range
         self._quantize_linear_activations = quantize_linear_activations
+        self._exclude_module_types = exclude_module_types
 
         self._modules_to_quantize = None
         self._qat_enabled = False
@@ -166,7 +167,6 @@ class QuantizationModifier(ScheduledModifier):
         self._calibration_dataloader = None
         self._calibration_function = None
         self._num_calibration_steps = num_calibration_steps
-        self._exclude_module_types = exclude_module_types
         if (
             isinstance(self._model_fuse_fn_name, str)
             and self._model_fuse_fn_name.lower() == "none"

--- a/src/sparseml/pytorch/optim/modifier_quantization.py
+++ b/src/sparseml/pytorch/optim/modifier_quantization.py
@@ -508,10 +508,10 @@ class QuantizationModifier(ScheduledModifier):
         )
 
         for batch_idx, batch in enumerate(_dataloader):
-            _calibration_completed = (
-                self.num_calibration_steps and batch_idx >= self.num_calibration_steps
-            )
-            if _calibration_completed:
+            if (
+                    self.num_calibration_steps
+                    and batch_idx >= self.num_calibration_steps
+            ):
                 break
             batch = tensors_to_device(batch, model_device)
             with torch.no_grad():

--- a/src/sparseml/pytorch/optim/optimizer.py
+++ b/src/sparseml/pytorch/optim/optimizer.py
@@ -17,7 +17,7 @@ Optimizer wrapper for enforcing Modifiers on the training process of a Module.
 """
 
 import warnings
-from typing import List, Union
+from typing import Any, Dict, List, Union
 
 from torch import Tensor
 from torch.nn import Module
@@ -68,7 +68,8 @@ class ScheduledOptimizer(Optimizer):
         when not using can result in irregularities
     :param loggers: loggers to log important info to within the modifiers;
         ex tensorboard or to the console
-
+    :param initialize_kwargs: key word arguments and values to be passed to
+        the recipe manager initialize function
     """
 
     def __init__(
@@ -78,6 +79,7 @@ class ScheduledOptimizer(Optimizer):
         manager: ScheduledModifierManager,
         steps_per_epoch: int,
         loggers: Union[List[BaseLogger], None] = None,
+        initialize_kwargs: Dict[str, Any] = None,
     ):
         # do not call into super since this instance is not passing all calls to
         # the nested optimizer
@@ -87,7 +89,8 @@ class ScheduledOptimizer(Optimizer):
         #     UserWarning,
         # )  TODO: uncomment in next release once docs are ready
 
-        manager.initialize(module, epoch=0.0, loggers=loggers)
+        initialize_kwargs = initialize_kwargs or {}
+        manager.initialize(module, epoch=0.0, loggers=loggers, **initialize_kwargs)
         self._wrapper = RecipeManagerStepWrapper(
             optimizer,
             optimizer,

--- a/tests/sparseml/pytorch/models/classification/test_resnet.py
+++ b/tests/sparseml/pytorch/models/classification/test_resnet.py
@@ -85,7 +85,7 @@ from tests.sparseml.pytorch.models.utils import compare_model
         ("resnext152", False, True, resnext152),
     ],
 )
-def test_resnsets(
+def test_resnets(
     key: str, pretrained: Union[bool, str], test_input: bool, match_const: Callable
 ):
     model = ModelRegistry.create(key, pretrained)

--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -210,6 +210,7 @@ def test_quantization_modifier_yaml():
     reduce_range = True
     quantize_linear_activations = False
     exclude_module_types = ["LayerNorm", "Tanh"]
+    num_calibration_steps = 2
     yaml_str = f"""
         !QuantizationModifier
             start_epoch: {start_epoch}
@@ -221,6 +222,7 @@ def test_quantization_modifier_yaml():
             reduce_range: {reduce_range}
             quantize_linear_activations: {quantize_linear_activations}
             exclude_module_types: {exclude_module_types}
+            num_calibration_steps: {num_calibration_steps}
         """
     yaml_modifier = QuantizationModifier.load_obj(
         yaml_str
@@ -237,6 +239,7 @@ def test_quantization_modifier_yaml():
         quantize_embeddings=quantize_embeddings,
         reduce_range=reduce_range,
         quantize_linear_activations=quantize_linear_activations,
+        num_calibration_steps=num_calibration_steps,
         exclude_module_types=exclude_module_types,
     )
 

--- a/tests/sparseml/pytorch/optim/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/optim/test_modifier_quantization.py
@@ -67,7 +67,7 @@ def _is_valid_submodule(module_name, submodule_names):
     )
 
 
-def _is_quantiable_module(module):
+def _is_quantizable_module(module):
     return isinstance(module, (Conv2d, Linear))
 
 
@@ -104,14 +104,14 @@ def _test_qat_applied(modifier, model):
         assert hasattr(model, "qconfig") and model.qconfig is not None
         submodules = [""]
         for module in model.modules():
-            if _is_quantiable_module(module):
+            if _is_quantizable_module(module):
                 _test_quantizable_module(module, True, modifier)
     else:
         assert not hasattr(model, "qconfig") or model.qconfig is None
         submodules = modifier.submodules
     # check qconfig propagation
     for name, module in model.named_modules():
-        if _is_quantiable_module(module):
+        if _is_quantizable_module(module):
             _test_quantizable_module(
                 module,
                 _is_valid_submodule(name, submodules),


### PR DESCRIPTION
Adds: A generic calibratiion dataloader and a calibration forward function, for calibrating weights after training, (Post Training Quantization)
```python
import torch
from sparseml.pytorch.models import resnet50
from sparseml.pytorch.optim import QuantizationModifier


def random_dataloader(n=5):
    """
    A random generator
    """
    for _ in range(n):
        print(f"Trying to yield batch {_}")
        yield [torch.rand(32, 3, 224, 224)], {}


# Pretrained Model
model = resnet50(pretrained=True)

# Modifier init
modifier = QuantizationModifier(start_epoch=0)

# Modifier Application
modifier.apply(
    module=model,
    calibration_dataloader=random_dataloader(),
)

# Book-Keeping, the model should have non infinity weights
print(model(torch.rand(1, 3, 224, 224)))
print(model)
```
Can also pass in a Calibration function along with dataloader

```python
import torch
from sparseml.pytorch.models import resnet50
from sparseml.pytorch.optim import QuantizationModifier
from sparseml.pytorch.utils import  tensors_module_forward

def random_dataloader(n=5):
    """
    A random generator
    """
    for _ in range(n):
        print(f"Trying to yield batch {_}")
        yield [torch.rand(32, 3, 224, 224)], {}


# Pretrained Model
model = resnet50(pretrained=True)

# Modifier init
modifier = QuantizationModifier(start_epoch=0)

# Modifier Application
modifier.apply(
    module=model,
    calibration_dataloader=random_dataloader(),
    calibration_func=tensors_module_forward,
)

# Book-Keeping, the model should have non infinity weights
print(model(torch.rand(1, 3, 224, 224)))
print(model)
```
