### PR TITLE
Fix Transformers LR Logging

### DIFF
--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -260,8 +260,9 @@ class RecipeManagerTrainerInterface:
             return
 
         # allow SparseML to manage LR and set a dummy scheduler
-        self.lr_scheduler = torch.optim.lr_scheduler.LambdaLR(
-            self.optimizer, lambda _: 1.0, -1
+        self.lr_scheduler = torch.optim.lr_scheduler.MultiplicativeLR(
+            self.optimizer, 
+            lambda _: 1,
         )
         _LOGGER.warning("Overrode the lr_scheduler from SparseML recipe")
 

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -262,7 +262,7 @@ class RecipeManagerTrainerInterface:
         # allow SparseML to manage LR and set a dummy scheduler
         self.lr_scheduler = torch.optim.lr_scheduler.MultiplicativeLR(
             self.optimizer, 
-            lambda _: 1,
+            lambda _: 1.0,
         )
         _LOGGER.warning("Overrode the lr_scheduler from SparseML recipe")
 

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -261,7 +261,7 @@ class RecipeManagerTrainerInterface:
 
         # allow SparseML to manage LR and set a dummy scheduler
         self.lr_scheduler = torch.optim.lr_scheduler.MultiplicativeLR(
-            self.optimizer, 
+            self.optimizer,
             lambda _: 1.0,
         )
         _LOGGER.warning("Overrode the lr_scheduler from SparseML recipe")


### PR DESCRIPTION
When using a SparseML LearningRateModifier, the LR logged by the HF integration doesn't correspond to the LR being set by the recipe.

An example run is provided below. The run was continued from epoch 8, so data is only available for epochs 8-10. The same behavior was confirmed for runs starting at epoch 0.

```yaml
Modifier:
training_modifiers:
  - !LearningRateFunctionModifier
    start_epoch: 8.0
    end_epoch: 10.0
    lr_func: linear
    init_lr: 0.00008
    final_lr: 0.00003
```
Reported modifier LR:
![image (1)](https://user-images.githubusercontent.com/66528950/154257367-d3dbb225-8c09-4b75-a20d-46781fa083a7.png)

Reported train LR:
<img width="562" alt="Screen Shot 2022-02-15 at 9 45 13 AM (1)" src="https://user-images.githubusercontent.com/66528950/154257417-16d8ece9-ce15-40cf-8f3c-06d86d107403.png">

Note that the HF train console printouts printed an LR that matched "Reported train LR", not "Reported modifier LR"
Confirmed through debugging that the modifier LR was the one used by the optimizer on step. 

This fix will replace the HF LR scheduler with one that simply multiplies the current LR by 1.0, resulting in synced LR's across the two schedulers.

Example run after the fix:

Reported modifier LR:
<img width="827" alt="Screen Shot 2022-02-16 at 11 45 40 AM" src="https://user-images.githubusercontent.com/66528950/154258435-e0b9249f-6d07-4217-85aa-10c431b627c5.png">

Reported train LR:
<img width="405" alt="Screen Shot 2022-02-16 at 11 46 01 AM" src="https://user-images.githubusercontent.com/66528950/154258477-2b130191-d4bd-418b-a1ba-61c6a99b7492.png">


