### PR TITLE
Accept pytest args from env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SPARSEZOO_TEST_MODE := "true"
 
 BUILD_ARGS :=  # set nightly to build nightly release
 TARGETS := ""  # targets for running pytests: deepsparse,keras,onnx,pytorch,pytorch_models,pytorch_datasets,tensorflow_v1,tensorflow_v1_models,tensorflow_v1_datasets
-PYTEST_ARGS := ""
+PYTEST_ARGS ?= ""
 ifneq ($(findstring deepsparse,$(TARGETS)),deepsparse)
     PYTEST_ARGS := $(PYTEST_ARGS) --ignore tests/sparseml/deepsparse
 endif


### PR DESCRIPTION
The goal of this PR is to be able to allow the `make test` command to optionally allow the invoker to pass pytest’s `--junitxml [FILE]` flag to be able to record a JUnit-formatted test result file.

I initially tried making this work the approach `make test PYTEST_ARGS='[args]'`, but it seems that when passing a variable to make this way, it simply overrides any assignments to that same variable within the Makefile (based on my specific experience).

As such, I went with the approach in this PR of simply changing the initial assignment of `PYTEST_ARGS` to use `?=`. This allows the base value of that arg to be set via an environment variable and does not disrupt any further existing behavior (e.g. with `TARGETS=[values]` and allows the following approach to set a base set of pytest args which gets combined with the ones derived from the value of `TARGETS`:

```sh
PYTEST_ARGS='--co' make test
PYTEST_ARGS='--junitxml deepsparse-report.xml' make test TARGETS=deepsparse
```