### PR TITLE
Fix mfac gradcheck

### DIFF
--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_mfac.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_mfac.py
@@ -96,6 +96,17 @@ def _build_gradient_sampler(
             num_grads=8,
             available_devices=["cpu"],
         ),
+        lambda: MFACPruningModifier(
+            params=["seq.fc1.weight", "seq.fc2.weight"],
+            init_sparsity=0.5,
+            final_sparsity=0.95,
+            start_epoch=2.0,
+            end_epoch=5.0,
+            update_frequency=1.0,
+            inter_func="cubic",
+            num_grads=8,
+            global_sparsity=True,
+        ),
     ],
     scope="function",
 )


### PR DESCRIPTION
When testing M-FAC on very small networks with global sparsity, some batches could produce all-zero gradients. In turn, the modifier will think not all gradients were collected. This fix patches that issue by explicitly counting gradients collected.