### PR TITLE
Mask creator int -> round

### DIFF
--- a/src/sparseml/pytorch/optim/mask_creator_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_creator_pruning.py
@@ -176,7 +176,7 @@ class UnstructuredPruningMaskCreator(PruningMaskCreator):
             local_rng = random.Random(42)
             local_rng.shuffle(rand_indices)
             num_elem = tensor.numel()
-            num_mask = int(num_elem * sparsity_target)
+            num_mask = round(num_elem * sparsity_target)
             rand_indices = rand_indices[:num_mask]
             rand_indices = tensor.new_tensor(rand_indices, dtype=torch.int64)
             zero_indices = zero_indices[rand_indices, :]

--- a/src/sparseml/pytorch/sparsification/pruning/mask_creator.py
+++ b/src/sparseml/pytorch/sparsification/pruning/mask_creator.py
@@ -140,7 +140,7 @@ class UnstructuredPruningMaskCreator(PruningMaskCreator):
             local_rng = random.Random(42)
             local_rng.shuffle(rand_indices)
             num_elem = tensor.numel()
-            num_mask = int(num_elem * sparsity_target)
+            num_mask = round(num_elem * sparsity_target)
             rand_indices = rand_indices[:num_mask]
             rand_indices = tensor.new_tensor(rand_indices, dtype=torch.int64)
             zero_indices = zero_indices[rand_indices, :]


### PR DESCRIPTION
Currently ` _threshold_from_sparsity` uses `round()` to determine number of weights to prune while `create_sparsity_masks` may use `int()`. When pruning back to back with identical sparsity, this can create a one-off error where a pruned weight is subsequently unpruned. Simple one-liner to make both use `round()` (in refactor and legacy mask_creator copies)