### PR TITLE
Make staged recipes be properly overwritten by `recipe_variables` argument.

### DIFF
--- a/src/sparseml/optim/helpers.py
+++ b/src/sparseml/optim/helpers.py
@@ -209,10 +209,9 @@ def update_recipe_variables(recipe_yaml_str: str, variables: Dict[str, Any]) -> 
         # yaml string does not create a dict, return original string
         return recipe_yaml_str
 
-    key_found = False
-
     if check_if_staged_recipe(container):
         for var_key in variables.keys():
+            key_found = False
             for container_key, container_value in container.items():
 
                 if isinstance(container_value, dict):
@@ -240,8 +239,17 @@ def update_recipe_variables(recipe_yaml_str: str, variables: Dict[str, Any]) -> 
                         container[var_key] = variables[var_key]
                         key_found = True
 
+            if not key_found:
+                raise ValueError(
+                    f"updating recipe variable {var_key} but "
+                    f"{var_key} is not currently "
+                    "set in existing recipe. Set the variable in the recipe in order "
+                    "to overwrite it."
+                )
+
     else:
         for var_key in variables.keys():
+            key_found = False
             for key, value in container.items():
                 # checking contents of the modifiers list
                 if isinstance(value, list):
@@ -255,12 +263,13 @@ def update_recipe_variables(recipe_yaml_str: str, variables: Dict[str, Any]) -> 
                         container[var_key] = variables[var_key]
                         key_found = True
 
-    if not key_found:
-        raise ValueError(
-            f"updating recipe variable {var_key} but {var_key} is not currently "
-            "set in existing recipe. Set the variable in the recipe in order "
-            "to overwrite it."
-        )
+            if not key_found:
+                raise ValueError(
+                    f"updating recipe variable {var_key} but "
+                    f"{var_key} is not currently "
+                    "set in existing recipe. Set the variable in the recipe in order "
+                    "to overwrite it."
+                )
 
     return rewrite_recipe_yaml_string_with_classes(container)
 

--- a/tests/sparseml/optim/test_helpers.py
+++ b/tests/sparseml/optim/test_helpers.py
@@ -24,7 +24,7 @@ from sparseml.optim import (
 
 
 STAGED_RECIPE_COMPLEX = """
-sparsity: 0.9
+sparsity: {sparsity}
 init_lr: 0.05
 final_lr: 0.0
 end_epoch: 100
@@ -36,7 +36,7 @@ ac_dc_phase:
   update_frequency: 5
   end_epoch_global: eval(end_epoch)
   end_epoch: 75
-  num_epochs: 10
+  num_epochs: {num_epochs}
   end_warm_up_epoch: 5.0
   final_lr: eval(final_lr)
   final_lr: 0.256
@@ -58,7 +58,7 @@ ac_dc_phase:
   - !LearningRateFunctionModifier
     start_epoch: eval(end_warm_up_epoch)
     end_epoch: eval(end_epoch_global)
-    lr_func: cosine
+    lr_func: {lr_func}
     init_lr: eval(final_lr)
     final_lr: 0.0
 
@@ -73,7 +73,7 @@ ac_dc_phase:
      global_sparsity: eval(global_sparsity)
 
 next_stage:
-  new_num_epochs: 15
+  new_num_epochs: {new_num_epochs}
 
   modifiers:
     - !EpochRangeModifier
@@ -328,7 +328,13 @@ def _test_nested_equality(val, other):
         (RECIPE_SIMPLE_EVAL, TARGET_RECIPE.format(num_epochs=10.0), False),
         (RECIPE_MULTI_EVAL, TARGET_RECIPE.format(num_epochs=10.0), False),
         (STAGED_RECIPE_SIMPLE, STAGED_RECIPE_SIMPLE_EVAL, True),
-        (STAGED_RECIPE_COMPLEX, STAGED_RECIPE_COMPLEX_EVAL, True),
+        (
+            STAGED_RECIPE_COMPLEX.format(
+                sparsity=0.9, num_epochs=10, lr_func="cosine", new_num_epochs=15
+            ),
+            STAGED_RECIPE_COMPLEX_EVAL,
+            True,
+        ),
     ],
 )
 def test_evaluate_recipe_yaml_str_equations(recipe, expected_recipe, is_staged):
@@ -393,6 +399,20 @@ def test_load_recipe_yaml_str_zoo(zoo_path):
             TARGET_RECIPE.format(num_epochs=100.0),
             {"num_epochs": 10.0},
             TARGET_RECIPE.format(num_epochs=10.0),
+        ),
+        (
+            STAGED_RECIPE_COMPLEX.format(
+                sparsity=0.9, num_epochs=10, lr_func="cosine", new_num_epochs=15
+            ),
+            {
+                "sparsity": 0.5,
+                "num_epochs": 11,
+                "lr_func": "linear",
+                "new_num_epochs": 13,
+            },
+            STAGED_RECIPE_COMPLEX.format(
+                sparsity=0.5, num_epochs=11, lr_func="linear", new_num_epochs=13
+            ),
         ),
     ],
 )


### PR DESCRIPTION
When a manager calls a `from_yaml()` function to construct itself...
<img width="696" alt="image" src="https://user-images.githubusercontent.com/97082108/157060650-31020cfe-f569-44f8-bbb2-f200fbc750b4.png">
...it can take `recipe_variables`  argument. It allows overwriting chosen variables in the recipe. While this function was working correctly with standard recipes, now it also parses staged recipes. The overwriting happens in a greedy way i.e. the code looks at every possible variable in the raw recipe (at every level). If it finds a key that corresponds to the entry it`recipe_variables`: do overwrite.