### PR TITLE
torch setuptools bugfix

### DIFF
--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -99,7 +99,12 @@ def get_save_dir_and_loggers(
         if task == Tasks.TRAIN:
             logs_dir = os.path.join(logs_dir, model_id)
             create_dirs(logs_dir)
-            loggers.append(TensorBoardLogger(log_path=logs_dir))
+            try:
+                loggers.append(TensorBoardLogger(log_path=logs_dir))
+            except AttributeError:
+                print("Failed to initialize TensorBoard logger, "
+                      "it will not be used for logging")
+
         print(f"Model id is set to {model_id}")
     else:
         # do not log for non main processes

--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -16,6 +16,7 @@
 Helper methods for image classification/detection based tasks
 """
 import os
+import warnings
 from enum import Enum, auto, unique
 from typing import Any, List, Optional, Tuple, Union
 
@@ -102,8 +103,10 @@ def get_save_dir_and_loggers(
             try:
                 loggers.append(TensorBoardLogger(log_path=logs_dir))
             except AttributeError:
-                print("Failed to initialize TensorBoard logger, "
-                      "it will not be used for logging")
+                warnings.warn(
+                    "Failed to initialize TensorBoard logger, "
+                    "it will not be used for logging",
+                )
 
         print(f"Model id is set to {model_id}")
     else:


### PR DESCRIPTION
Few torch versions have introduced a subtle bug, 

When `setuptools>59.6` is used with `torch 1.9 or 1.10`, an `AttributeError` is raised on import of `torch.tensorboard.SummaryWriter`, this causes `sparseml.image_classification.train` to fail. The goal of this PR is to  print occurance and ignore tensorboard logger when this error is observed