### PR TITLE
mask creator refactor

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py
@@ -20,9 +20,8 @@ from torch.optim.optimizer import Optimizer
 
 from sparseml.pytorch.optim.modifier import ModifierProp, PyTorchModifierYAML
 from sparseml.pytorch.sparsification.pruning.mask_creator import (
-    FourBlockMaskCreator,
     PruningMaskCreator,
-    UnstructuredPruningMaskCreator,
+    get_mask_creator_default,
 )
 from sparseml.pytorch.sparsification.pruning.modifier_pruning_base import (
     BasePruningModifier,
@@ -70,9 +69,9 @@ class ACDCPruningModifier(BasePruningModifier):
         immediately after or doing some other prune. Default is True
     :param log_types: The loggers to allow the learning rate to be logged to,
         default is __ALL__
-    :param mask_type: String to define type of sparsity (options: ['unstructured',
-        'channel', 'filter']), List to define block shape of a parameters in and out
-         channels, or a SparsityMaskCreator object. default is 'unstructured'
+    :param mask_type: String to define type of sparsity to apply. May be 'unstructred'
+        for unstructured pruning or 'block4' for four block pruning or a list of two
+        integers for a custom block shape. Default is 'unstructured'
     :param momentum_buffer_reset: set True to reset momentum buffer
         before algorithm enters a consecutive decompression phase.
         According to the paper:
@@ -225,15 +224,7 @@ class ACDCPruningModifier(BasePruningModifier):
         :param params: list of Parameters to be masked
         :return: mask creator object to be used by this pruning algorithm
         """
-        if self._mask_type == "unstructured":
-            return UnstructuredPruningMaskCreator()
-        elif self._mask_type == "block":
-            return FourBlockMaskCreator()
-        else:
-            raise ValueError(
-                f"Unknown mask_type {self._mask_type}. Supported mask types include "
-                "'unstructured' and 'block'"
-            )
+        return get_mask_creator_default(self.mask_type)
 
     @staticmethod
     def _reset_momentum_buffer(optimizer):

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_magnitude.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_magnitude.py
@@ -24,9 +24,8 @@ from torch.nn import Parameter
 
 from sparseml.pytorch.optim.modifier import PyTorchModifierYAML
 from sparseml.pytorch.sparsification.pruning.mask_creator import (
-    FourBlockMaskCreator,
     PruningMaskCreator,
-    UnstructuredPruningMaskCreator,
+    get_mask_creator_default,
 )
 from sparseml.pytorch.sparsification.pruning.modifier_pruning_base import (
     BaseGradualPruningModifier,
@@ -104,8 +103,9 @@ class GMPruningModifier(BaseGradualPruningModifier, BaseGMPruningModifier):
         [linear, cubic, inverse_cubic]
     :param log_types: The loggers to allow the learning rate to be logged to,
         default is __ALL__
-    :param mask_type: String to define type of sparsity to apply. May be 'unstructured'
-        for unstructured pruning or 'block' for four block pruning
+    :param mask_type: String to define type of sparsity to apply. May be 'unstructred'
+        for unstructured pruning or 'block4' for four block pruning or a list of two
+        integers for a custom block shape. Default is 'unstructured'
     """
 
     def __init__(
@@ -152,15 +152,7 @@ class GMPruningModifier(BaseGradualPruningModifier, BaseGMPruningModifier):
         :param params: list of parameters to be masked
         :return: mask creator object to be used by this pruning algorithm
         """
-        if self.mask_type == "unstructured":
-            return UnstructuredPruningMaskCreator()
-        elif self.mask_type == "block":
-            return FourBlockMaskCreator()
-        else:
-            raise ValueError(
-                f"Unknown mask_type {self.mask_type}. Supported mask types include "
-                "'unstructured' and 'block'"
-            )
+        return get_mask_creator_default(self.mask_type)
 
     def _get_scorer(self, params: List[Parameter]) -> PruningParamsScorer:
         """
@@ -221,7 +213,8 @@ class MagnitudePruningModifier(GMPruningModifier):
     :param log_types: The loggers to allow the learning rate to be logged to,
         default is __ALL__
     :param mask_type: String to define type of sparsity to apply. May be 'unstructred'
-        for unstructured pruning or 'block' for four block pruning
+        for unstructured pruning or 'block4' for four block pruning or a list of two
+        integers for a custom block shape. Default is 'unstructured'
     """
 
     # just an alias for GMPruningModifier
@@ -274,7 +267,8 @@ class GlobalMagnitudePruningModifier(GMPruningModifier):
     :param log_types: The loggers to allow the learning rate to be logged to,
         default is __ALL__
     :param mask_type: String to define type of sparsity to apply. May be 'unstructred'
-        for unstructured pruning or 'block' for four block pruning
+        for unstructured pruning or 'block4' for four block pruning or a list of two
+        integers for a custom block shape. Default is 'unstructured'
     """
 
     def __init__(

--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_magnitude.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_magnitude.py
@@ -87,7 +87,7 @@ from tests.sparseml.pytorch.helpers import (  # noqa isort:skip
             end_epoch=25.0,
             update_frequency=1.0,
             inter_func="cubic",
-            mask_type="block",
+            mask_type="block4",
         ),
         lambda: GMPruningModifier(
             params=["__ALL_PRUNABLE__"],
@@ -109,7 +109,7 @@ from tests.sparseml.pytorch.helpers import (  # noqa isort:skip
             end_epoch=25.0,
             update_frequency=1.0,
             inter_func="cubic",
-            mask_type="block",
+            mask_type="block4",
         ),
     ],
     scope="function",
@@ -289,7 +289,7 @@ def test_magnitude_pruning_yaml():
     update_frequency = 1.0
     params = "__ALL_PRUNABLE__"
     inter_func = "cubic"
-    mask_type = "block"
+    mask_type = "block4"
     yaml_str = f"""
     !MagnitudePruningModifier
         init_sparsity: {init_sparsity}

--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_mfac.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_mfac.py
@@ -289,7 +289,7 @@ def test_mfac_pruning_yaml(params, init_sparsity, final_sparsity):
     fisher_block_size = 20
     num_pages = 1
     available_devices = ["cpu"]
-    mask_type = "block"
+    mask_type = "block4"
     yaml_str = f"""
     !MFACPruningModifier
         init_sparsity: {init_sparsity}


### PR DESCRIPTION
* rename "block" mask creator to "block4"
* reintroduce formerly removed `[x,y]` block mask creator/notation
* helper function for creating basic mask creators
* checked through existing zoo and example recipes to confirm none are affected