### PR TITLE
fix symmetric zero points for unit8 quantization

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -521,6 +521,11 @@ def fix_observer_quant_range(module: Module):
             fake_quantize.quant_min is None
             or fake_quantize.quant_max is None
             or (observer.quant_min is not None or observer.quant_max is not None)
+            or (  # do not propagate default uint8 symmetric range
+                observer.qscheme == torch.per_tensor_symmetric
+                and fake_quantize.quant_min == 0
+                and fake_quantize.quant_max == 255
+            )
         ):
             continue
         observer.quant_min = fake_quantize.quant_min


### PR DESCRIPTION
to accomodate custom quantization ranges, in #542 we added a pass to propagate quantization range information from `FakeQuantization` objects to their `Observer` objects (this functionality is missing due to a small pytorch bug).

An unintended side effect, is that now, for default symmetric uint8 quantization (range `[0, 255]`), the range is now considered by torch to be custom, thus calculated as `255 - 0 // 2 = 127` instead of the desired `128` which was hardcoded as the default before.

This changes addresses this bug by skipping over the propagation pass for objects with default symmetric quantization ranges.

Testing can be done using the second input of `QATMatMul` from our BERT integration which should have a symmetric zero point of 128. Prior to this patch, the example shows it to be 127.

```python
from transformers.models.bert.modeling_bert import QATMatMul
from sparseml.pytorch.sparsification import QuantizationModifier
import torch

dummy_sequential = torch.nn.Sequential(QATMatMul())  # give QATMatMul a layer to be wrapped
QuantizationModifier().apply(dummy_sequential)
qat_matmul = dummy_sequential[0]
_ = qat_matmul(torch.randn(10, 10), torch.randn(10, 10))
# print affected zero point, 127 before fix, 128 after
print(qat_matmul.input_quant_stubs[1].activation_post_process.zero_point)
```