### PR TITLE
Hotfix: ACDCPruningModifier; allow arguments `start_epoch`, `end_epoch`, `update_frequency` to be floats.

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py
@@ -293,6 +293,7 @@ class ACDCPruningModifier(BasePruningModifier):
             raise ValueError(
                 f"The ACDCPruningModifier assumes that attributes "
                 f"`start_epoch`, `end epoch` and `update frequency` "
-                f"are integers. However, type({x}) is float."
+                f"are integers or floats, which evaluate to integers. 
+                f"However: type(x)==float and x.is_integer() == False."
             )
         return int(x)

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py
@@ -86,9 +86,9 @@ class ACDCPruningModifier(BasePruningModifier):
     def __init__(
         self,
         compression_sparsity: float,
-        start_epoch: float,
-        end_epoch: float,
-        update_frequency: float,
+        start_epoch: Union[int, float],
+        end_epoch: Union[int, float],
+        update_frequency: Union[int, float],
         params: Union[str, List[str]],
         global_sparsity: bool = True,
         leave_enabled: bool = True,
@@ -96,6 +96,11 @@ class ACDCPruningModifier(BasePruningModifier):
         mask_type: str = "unstructured",
         log_types: Union[str, List[str]] = ALL_TOKEN,
     ):
+        # AC/DC assumes that variables `start_epoch`, `end_epoch`
+        # and `update_frequency` are integers.
+        start_epoch = self._assert_is_integer(start_epoch)
+        end_epoch = self._assert_is_integer(end_epoch)
+        update_frequency = self._assert_is_integer(update_frequency)
 
         # because method does not involve any interpolation
         # compression sparsity (final sparsity) is a single float.
@@ -273,3 +278,21 @@ class ACDCPruningModifier(BasePruningModifier):
                 end_epoch -= 1
 
         return end_epoch
+
+    @staticmethod
+    def _assert_is_integer(x):
+        """
+        Check if x, which is expected to be either a float or int,
+        can be evaluated as int.
+        If True, return and integer, else, raise ValueError.
+
+        :param x: an integer or a float.
+        :return: an integer
+        """
+        if isinstance(x, float) and not x.is_integer():
+            raise ValueError(
+                f"The ACDCPruningModifier assumes that attributes "
+                f"`start_epoch`, `end epoch` and `update frequency` "
+                f"are integers. However, type({x}) is float."
+            )
+        return int(x)

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py
@@ -291,9 +291,9 @@ class ACDCPruningModifier(BasePruningModifier):
         """
         if isinstance(x, float) and not x.is_integer():
             raise ValueError(
-                f"The ACDCPruningModifier assumes that attributes "
-                f"`start_epoch`, `end epoch` and `update frequency` "
-                f"are integers or floats, which evaluate to integers. 
-                f"However: type(x)==float and x.is_integer() == False."
+                "The ACDCPruningModifier assumes that attributes"
+                "`start_epoch`, `end epoch` and `update frequency` "
+                "are integers, or floats which evaluate to integers."
+                "However: type(x)==float and x.is_integer() == False."
             )
         return int(x)

--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_acdc.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_acdc.py
@@ -76,8 +76,8 @@ def test_finish_on_compression(
         ),
         lambda: ACDCPruningModifier(
             compression_sparsity=0.8,
-            start_epoch=6,
-            end_epoch=26,
+            start_epoch=6.0,
+            end_epoch=26.0,
             update_frequency=1,
             params=["re:.*weight"],
             momentum_buffer_reset=True,


### PR DESCRIPTION
In SparseML recipes, by convention, modifier arguments `start_epoch`, `end_epoch` and `update_frequency` are assumed to be floats. 

In `ACDCPruningModifier`, we are using those three arguments to figure out the mapping from epoch number to "ac/dc phase" (either compression or decompression). This mapping happens in L260. `src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py`:

```
 compression_phases = [
            math.floor(epoch / update_frequency) % 2 == 0.0
            for epoch in range(start_epoch, end_epoch)
]
```
The `range` function requires `start_epoch` and `end_epoch` to be integers. IMO, this requirement is consistent with the implicit assumptions in the original paper/code of ACDC. This implicit assumption, to my mind, also extends to the `update_frequency` variable.

At the current state, the user has to specify those three arguments explicitly as integers in a recipe. This PR asserts that the user has the freedom to either define them as int or float, as long as this float can be directly evaluated as an integer.

E.g `start_epoch` can be `6` or `6.0` but cannot be `6.1`. 


