### PR TITLE
Image Classification Training Wrapper

### DIFF
--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -21,7 +21,6 @@ usage: train.py [-h] --train-batch-size TRAIN_BATCH_SIZE --test-batch-size
                 --dataset-path DATASET_PATH
                 [--checkpoint-path CHECKPOINT_PATH] [--init-lr INIT_LR]
                 [--optim-args OPTIM_ARGS] [--recipe-path RECIPE_PATH]
-                [--sparse-transfer-learn [SPARSE_TRANSFER_LEARN]]
                 [--eval-mode [EVAL_MODE]] [--optim OPTIM]
                 [--logs-dir LOGS_DIR] [--save-best-after SAVE_BEST_AFTER]
                 [--save-epochs SAVE_EPOCHS]
@@ -207,10 +206,6 @@ class TrainingArguments:
     :param recipe_path: The path to the yaml file containing the modifiers and
         schedule to apply them with; Can also provide a SparseZoo stub prefixed
         with 'zoo:'.
-    :param sparse_transfer_learn: Boolean to enable sparse transfer learning
-        modifiers to enforce
-        the sparsity for already sparse layers. The modifiers are added to
-        the ones to be loaded from the recipe-path.
     :param eval_mode: bool to start evaluation mode so that the model can be
         evaluated on the desired dataset.
     :param optim: str representing the optimizer type to use, one of
@@ -328,15 +323,6 @@ class TrainingArguments:
             "schedule to apply them with. Can also provide a "
             "SparseZoo stub prefixed with 'zoo:' with an optional "
             "'?recipe_type=' argument"
-        },
-    )
-
-    sparse_transfer_learn: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Enable sparse transfer learning modifiers to enforce the "
-            "sparsity for already sparse layers. The modifiers are "
-            "added to the ones to be loaded from the recipe-path"
         },
     )
 
@@ -676,7 +662,6 @@ def _init_image_classification_trainer_and_save_dirs(
             ddp=ddp,
             device=device,
             use_mixed_precision=train_args.use_mixed_precision,
-            sparse_transfer_learn=train_args.sparse_transfer_learn,
             val_loader=val_loader,
             train_loader=train_loader,
             is_main_process=train_args.is_main_process,

--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -59,11 +59,11 @@ optional arguments:
                         The root path to where the dataset is stored
   --arch-key ARCH_KEY   The type of model to use, ex: resnet50, vgg16,
                         mobilenet put as help to see the full list (will raise
-                        an exceptionwith the list)
+                        an exception with the list)
   --checkpoint-path CHECKPOINT_PATH
                         A path to a previous checkpoint to load the state from
                         and resume the state for. If provided, pretrained will
-                        be ignored . If using a SparseZoo recipe, can also
+                        be ignored. If using a SparseZoo recipe, can also
                         provide 'zoo' to load the base weights associated with
                         that recipe
   --init-lr INIT_LR     The initial learning rate to use while training, the

--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -16,23 +16,33 @@
 """
 ######
 Command help:
-usage: train.py [-h] --train-batch-size TRAIN_BATCH_SIZE --test-batch-size
-                TEST_BATCH_SIZE --arch-key ARCH_KEY --dataset DATASET
-                --dataset-path DATASET_PATH
-                [--checkpoint-path CHECKPOINT_PATH] [--init-lr INIT_LR]
-                [--optim-args OPTIM_ARGS] [--recipe-path RECIPE_PATH]
-                [--eval-mode [EVAL_MODE]] [--optim OPTIM]
-                [--logs-dir LOGS_DIR] [--save-best-after SAVE_BEST_AFTER]
-                [--save-epochs SAVE_EPOCHS]
-                [--use-mixed-precision [USE_MIXED_PRECISION]]
-                [--debug-steps DEBUG_STEPS] [--pretrained PRETRAINED]
-                [--pretrained-dataset PRETRAINED_DATASET]
-                [--model-kwargs MODEL_KWARGS]
-                [--dataset-kwargs DATASET_KWARGS] [--model-tag MODEL_TAG]
-                [--save-dir SAVE_DIR] [--device DEVICE]
-                [--loader-num-workers LOADER_NUM_WORKERS]
-                [--no-loader-pin-memory]
-                [--loader-pin-memory [LOADER_PIN_MEMORY]]
+usage: sparseml.image_classification.train [-h] --train-batch-size
+                                           TRAIN_BATCH_SIZE --test-batch-size
+                                           TEST_BATCH_SIZE --dataset DATASET
+                                           --dataset-path DATASET_PATH
+                                           [--arch-key ARCH_KEY]
+                                           [--checkpoint-path CHECKPOINT_PATH]
+                                           [--init-lr INIT_LR]
+                                           [--optim-args OPTIM_ARGS]
+                                           [--recipe-path RECIPE_PATH]
+                                           [--eval-mode [EVAL_MODE]]
+                                           [--optim OPTIM]
+                                           [--logs-dir LOGS_DIR]
+                                           [--save-best-after SAVE_BEST_AFTER]
+                                           [--save-epochs SAVE_EPOCHS [SAVE_EPOCHS ...]]
+                                           [--use-mixed-precision [USE_MIXED_PRECISION]]
+                                           [--debug-steps DEBUG_STEPS]
+                                           [--pretrained PRETRAINED]
+                                           [--pretrained-dataset PRETRAINED_DATASET]
+                                           [--model-kwargs MODEL_KWARGS]
+                                           [--dataset-kwargs DATASET_KWARGS]
+                                           [--model-tag MODEL_TAG]
+                                           [--save-dir SAVE_DIR]
+                                           [--device DEVICE]
+                                           [--loader-num-workers LOADER_NUM_WORKERS]
+                                           [--no-loader-pin-memory]
+                                           [--loader-pin-memory [LOADER_PIN_MEMORY]]
+                                           [--image-size IMAGE_SIZE]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -40,9 +50,6 @@ optional arguments:
                         The batch size to use while training
   --test-batch-size TEST_BATCH_SIZE
                         The batch size to use while testing
-  --arch-key ARCH_KEY   The type of model to use, ex: resnet50, vgg16,
-                        mobilenet put as help to see the full list (will raise
-                        an exception with the list)
   --dataset DATASET     The dataset to use for training, ex: imagenet,
                         imagenette, cifar10, etc. Set to imagefolder for a
                         generic dataset setup with an image folder structure
@@ -50,10 +57,13 @@ optional arguments:
                         sparseml.pytorch.datasets
   --dataset-path DATASET_PATH
                         The root path to where the dataset is stored
+  --arch-key ARCH_KEY   The type of model to use, ex: resnet50, vgg16,
+                        mobilenet put as help to see the full list (will raise
+                        an exceptionwith the list)
   --checkpoint-path CHECKPOINT_PATH
                         A path to a previous checkpoint to load the state from
                         and resume the state for. If provided, pretrained will
-                        be ignored. If using a SparseZoo recipe, can also
+                        be ignored . If using a SparseZoo recipe, can also
                         provide 'zoo' to load the base weights associated with
                         that recipe
   --init-lr INIT_LR     The initial learning rate to use while training, the
@@ -67,20 +77,18 @@ optional arguments:
                         schedule to apply them with. Can also provide a
                         SparseZoo stub prefixed with 'zoo:' with an optional
                         '?recipe_type=' argument
-  --sparse-transfer-learn [SPARSE_TRANSFER_LEARN]
-                        Enable sparse transfer learning modifiers to enforce
-                        the sparsity for already sparse layers. The modifiers
-                        are added to the ones to be loaded from the recipe-
-                        path
   --eval-mode [EVAL_MODE]
                         Puts into evaluation mode so that the model can be
                         evaluated on the desired dataset
-  --optim OPTIM         The optimizer type to use, one of [SGD, Adam, RMSprop]
+  --optim OPTIM         The optimizer type to use, one of ['Adadelta',
+                        'Adagrad', 'Adam', 'AdamW', 'SparseAdam', 'Adamax',
+                        'ASGD', 'SGD', 'RAdam', 'Rprop', 'RMSprop',
+                        'Optimizer', 'NAdam', 'LBFGS']. Defaults to `Adam`
   --logs-dir LOGS_DIR   The path to the directory for saving logs
   --save-best-after SAVE_BEST_AFTER
                         start saving the best validation result after the
                         given epoch completes until the end of training
-  --save-epochs SAVE_EPOCHS
+  --save-epochs SAVE_EPOCHS [SAVE_EPOCHS ...]
                         epochs to save checkpoints at
   --use-mixed-precision [USE_MIXED_PRECISION]
                         Trains model using mixed precision. Supported
@@ -118,6 +126,9 @@ optional arguments:
                         Do not use pinned memory for data loading
   --loader-pin-memory [LOADER_PIN_MEMORY]
                         Use pinned memory for data loading
+  --image-size IMAGE_SIZE
+                        The size of the image input to the model
+
 #########
 EXAMPLES
 #########
@@ -333,10 +344,13 @@ class TrainingArguments:
             "evaluated on the desired dataset"
         },
     )
-
+    optim_choices = [key for key in torch.optim.__dict__.keys() if key[0].isupper()]
     optim: str = field(
         default="SGD",
-        metadata={"help": "The optimizer type to use, one of [SGD, Adam, RMSprop]"},
+        metadata={
+            "help": f"The optimizer type to use, one of {optim_choices}."
+            " Defaults to `Adam`"
+        },
     )
 
     logs_dir: str = field(

--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -76,7 +76,7 @@ optional arguments:
                         The path to the yaml file containing the modifiers and
                         schedule to apply them with. Can also provide a
                         SparseZoo stub prefixed with 'zoo:' with an optional
-                        '?recipe_type=' argument
+                        'recipe_type=' argument
   --eval-mode [EVAL_MODE]
                         Puts into evaluation mode so that the model can be
                         evaluated on the desired dataset

--- a/src/sparseml/pytorch/image_classification/utils/__init__.py
+++ b/src/sparseml/pytorch/image_classification/utils/__init__.py
@@ -14,5 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sparseml.pytorch.image_classification.utils.helpers import *
-from sparseml.pytorch.image_classification.utils.nm_argparser import *
+from .helpers import *
+from .nm_argparser import *
+from .trainer import *

--- a/src/sparseml/pytorch/image_classification/utils/__init__.py
+++ b/src/sparseml/pytorch/image_classification/utils/__init__.py
@@ -14,6 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .helpers import *
 from .nm_argparser import *
 from .trainer import *

--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -22,31 +22,36 @@ from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from torch.nn import Module
-from torch.nn import functional as torch_functional
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 
 from sparseml.pytorch.datasets import DatasetRegistry, ssd_collate_fn, yolo_collate_fn
 from sparseml.pytorch.models import ModelRegistry
-from sparseml.pytorch.optim import ScheduledModifierManager, ScheduledOptimizer
-from sparseml.pytorch.sparsification import ConstantPruningModifier
+from sparseml.pytorch.optim import ScheduledModifierManager
 from sparseml.pytorch.utils import (
     DEFAULT_LOSS_KEY,
-    CrossEntropyLossWrapper,
-    InceptionCrossEntropyLossWrapper,
-    LossWrapper,
     ModuleExporter,
     ModuleRunResults,
     PythonLogger,
-    SSDLossWrapper,
     TensorBoardLogger,
-    TopKAccuracy,
-    YoloLossWrapper,
     early_stop_data_loader,
+    model_to_device,
     torch_distributed_zero_first,
 )
 from sparseml.utils import create_dirs
 from sparsezoo import Zoo
+
+
+__all__ = [
+    "Tasks",
+    "get_save_dir_and_loggers",
+    "get_train_and_validation_loaders",
+    "create_model",
+    "infer_num_classes",
+    "save_recipe",
+    "save_model_training",
+    "device_setup",
+]
 
 
 @unique
@@ -66,6 +71,12 @@ class Tasks(Enum):
 def get_save_dir_and_loggers(
     args: Any, task: Optional[Tasks] = None
 ) -> Tuple[Union[str, None], List]:
+    """
+    :param args: Object containing relevant configuration for the task
+    :param task: The current task being performed
+
+    :return: A tuple of the save directory and a list of loggers
+    """
     if args.is_main_process:
         save_dir = os.path.abspath(os.path.expanduser(args.save_dir))
         logs_dir = (
@@ -116,8 +127,193 @@ def get_save_dir_and_loggers(
     return save_dir, loggers
 
 
-# data helpers_
-def _get_collate_fn(arch_key: str, task: Optional[Tasks] = None):
+# data helpers
+def get_train_and_validation_loaders(args: Any, task: Optional[Tasks] = None):
+    """
+    :param args: Object containing relevant configuration for the task
+    :param task: The current task being performed
+    :return: 4 element tuple with the following format (train_dataset,
+        train_loader, val_dataset, val_loader)
+    """
+    train_dataset, train_loader = _create_train_dataset_and_loader(
+        args, args.image_size, task=task
+    )
+    val_dataset, val_loader = _create_val_dataset_and_loader(
+        args, args.image_size, task=task
+    )
+    return train_dataset, train_loader, val_dataset, val_loader
+
+
+# Model creation Helpers
+def create_model(args: Any, num_classes: int) -> Module:
+    """
+    :param args: object with configuration for model classes
+    :param num_classes: Integer representing the number of output classes
+    :returns: A tuple containing the model and the model's arch_key
+    """
+    with torch_distributed_zero_first(args.local_rank):
+        # only download once locally
+        if args.checkpoint_path == "zoo":
+            args.checkpoint_path = _download_model_from_zoo_using_recipe(
+                recipe_stub=args.recipe_path,
+            )
+
+        result = ModelRegistry.create(
+            key=args.arch_key,
+            pretrained=args.pretrained,
+            pretrained_path=args.checkpoint_path,
+            pretrained_dataset=args.pretrained_dataset,
+            num_classes=num_classes,
+            **args.model_kwargs,
+        )
+
+        if not isinstance(result, tuple):
+            model, arch_key = result, args.arch_key
+        else:
+            model, arch_key = result
+
+        return model, arch_key
+
+
+def infer_num_classes(args: Any, train_dataset, val_dataset):
+    """
+    :param args: Object with configuration settings
+    :param train_dataset: dataset representing training data
+    :param val_dataset: dataset representing validation data
+    :return: An integer representing the number of classes
+    """
+    if "num_classes" in args.model_kwargs:
+        # handle manually overriden num classes
+        num_classes = args.model_kwargs["num_classes"]
+        del args.model_kwargs["num_classes"]
+    elif args.dataset == "imagefolder":
+        dataset = val_dataset or train_dataset  # get non None dataset
+        num_classes = dataset.num_classes
+    else:
+        dataset_attributes = DatasetRegistry.attributes(args.dataset)
+        num_classes = dataset_attributes["num_classes"]
+    return num_classes
+
+
+def get_arch_key(arch_key: Optional[str], checkpoint_path: Optional[str]) -> str:
+    """
+    Utility method to read and return the arch_key from the checkpoint, if it
+    is not passed and exists in the checkpoint. if passed the passed value is
+    returned
+
+    :param arch_key: Optional[str] The arch_key to use for the model
+    :checkpoint_path: Optiona[str] The path to the checkpoint
+    """
+    if arch_key is None:
+        if checkpoint_path:
+            checkpoint = torch.load(checkpoint_path)
+        else:
+            raise ValueError(
+                "Must provide a checkpoint path if no arch_key is provided"
+            )
+        if "arch_key" in checkpoint:
+            arch_key = checkpoint["arch_key"]
+        else:
+            raise ValueError(
+                "Checkpoint does not contain "
+                "arch_key, provide one using "
+                "--arch_key"
+            )
+
+    return arch_key
+
+
+# saving helpers
+
+
+def save_recipe(
+    recipe_manager: ScheduledModifierManager,
+    save_dir: str,
+):
+    """
+    :param recipe_manager: The ScheduleModified manager to save recipes
+    :param save_dir: The directory to save the recipe
+    """
+    recipe_save_path = os.path.join(save_dir, "recipe.yaml")
+    recipe_manager.save(recipe_save_path)
+    print(f"Saved recipe to {recipe_save_path}")
+
+
+def save_model_training(
+    model: Module,
+    optim: Optimizer,
+    save_name: str,
+    save_dir: str,
+    epoch: int,
+    val_res: Optional[ModuleRunResults],
+    arch_key: Optional[str] = None,
+):
+    """
+    :param model: model architecture
+    :param optim: The optimizer used
+    :param input_shape: A tuple of integers representing the input shape
+    :param save_name: name to save model to
+    :param save_dir: directory to save results in
+    :param epoch: integer representing umber of epochs to
+    :param val_res: results from validation run
+    :param convert_qat: True if model is to be quantized before saving
+    :param arch_key: if provided, the `arch_key` will be saved in the
+        checkpoint
+    """
+    has_top1 = "top1acc" in val_res.results
+    metric_name = "top-1 accuracy" if has_top1 else "val_loss"
+    metric = val_res.result_mean("top1acc" if has_top1 else DEFAULT_LOSS_KEY).item()
+    print(
+        f"Saving model for epoch {epoch} and {metric_name} "
+        f"{metric} to {save_dir} for {save_name}"
+    )
+    exporter = ModuleExporter(model, save_dir)
+    exporter.export_pytorch(
+        optim,
+        epoch,
+        f"{save_name}.pth",
+        arch_key=arch_key,
+    )
+    info_path = os.path.join(save_dir, f"{save_name}.txt")
+
+    with open(info_path, "w") as info_file:
+        info_lines = [
+            f"epoch: {epoch}",
+        ]
+
+        if val_res is not None:
+            for loss in val_res.results.keys():
+                info_lines.append(f"{loss}: {val_res.result_mean(loss).item()}")
+
+        info_file.write("\n".join(info_lines))
+
+
+# device helpers
+def device_setup(model, rank: int, local_rank: int, device: Union[str, int]):
+    """
+    Move the model to the correct device.
+
+    :param model: The model to move to the correct device
+    :param rank: The rank of the process in network
+    :param local_rank: The rank of the process on the local machine
+    :param device: The device to move the model to
+    :return: A tuple of (model, device, ddp)
+    """
+    if rank == -1:
+        ddp = False
+    else:
+        torch.cuda.set_device(local_rank)
+        device = local_rank
+        ddp = True
+    model, device, _ = model_to_device(model=model, device=device, ddp=ddp)
+    return model, device, ddp
+
+
+# private methods
+def _get_collate_fn(arch_key: Optional[str] = None, task: Optional[Tasks] = None):
+    if not arch_key:
+        return None
+
     is_ssd = "ssd" in arch_key.lower()
     need_collate_function = (
         is_ssd or "yolo" in arch_key.lower()
@@ -160,6 +356,7 @@ def _create_train_dataset_and_loader(
         shuffle = True if sampler is None else False
         batch_size = args.train_batch_size if task == Tasks.TRAIN else args.batch_size
 
+        arch_key = args.arch_key if hasattr(args, "arch_key") else None
         train_loader = DataLoader(
             train_dataset,
             batch_size=batch_size,
@@ -167,7 +364,7 @@ def _create_train_dataset_and_loader(
             num_workers=args.loader_num_workers,
             pin_memory=args.loader_pin_memory,
             sampler=sampler,
-            collate_fn=_get_collate_fn(arch_key=args.arch_key, task=task),
+            collate_fn=_get_collate_fn(arch_key=arch_key, task=task),
         )
         print(f"created train_dataset: {train_dataset}")
         return train_dataset, train_loader
@@ -214,239 +411,25 @@ def _create_val_dataset_and_loader(
     return None, None  # val dataset not needed
 
 
-def get_train_and_validation_loaders(
-    args: Any, image_size: Tuple[int, ...], task: Optional[Tasks] = None
-):
+def _download_model_from_zoo_using_recipe(
+    recipe_stub: str,
+) -> Optional[str]:
     """
-    :param args: Object containing relevant configuration for the task
-    :param image_size: A Tuple of integers representing the shape of input image
-    :param task: The current task being performed
-    :return: 4 element tuple with the following format (train_dataset,
-        train_loader, val_dataset, val_loader)
+    Download a model from the zoo using a recipe stub and return the
+    path to the downloaded model.
+
+    :param recipe_stub: Path to a valid recipe stub
+    :return: Path to the downloaded model
     """
-    train_dataset, train_loader = _create_train_dataset_and_loader(
-        args, image_size, task=task
-    )
-    val_dataset, val_loader = _create_val_dataset_and_loader(
-        args, image_size, task=task
-    )
-    return train_dataset, train_loader, val_dataset, val_loader
+    valid_recipe_stub = recipe_stub and recipe_stub.startswith("zoo:")
 
-
-# Model creation Helpers
-
-
-def get_arch_key(arch_key: Optional[str], checkpoint_path: Optional[str]) -> str:
-    """
-    Utility method to read and return the arch_key from the checkpoint, if it
-    is not passed and exists in the checkpoint. if passed the passed value is
-    returned
-
-    :param arch_key: Optional[str] The arch_key to use for the model
-    :checkpoint_path: Optiona[str] The path to the checkpoint
-    """
-    if arch_key is None:
-        if checkpoint_path:
-            checkpoint = torch.load(checkpoint_path)
-        else:
-            raise ValueError(
-                "Must provide a checkpoint path if no arch_key is provided"
-            )
-        if "arch_key" in checkpoint:
-            arch_key = checkpoint["arch_key"]
-        else:
-            raise ValueError(
-                "Checkpoint does not contain "
-                "arch_key, provide one using "
-                "--arch_key"
-            )
-
-    return arch_key
-
-
-def create_model(args: Any, num_classes: int) -> Module:
-    """
-    :param args: object with configuration for model classes
-    :param num_classes: Integer representing the number of output classes
-    :returns: A Module object representing the created model
-    """
-    with torch_distributed_zero_first(args.local_rank):  # only download once locally
-        if args.checkpoint_path == "zoo":
-            if args.recipe_path and args.recipe_path.startswith("zoo:"):
-                args.checkpoint_path = Zoo.download_recipe_base_framework_files(
-                    args.recipe_path, extensions=[".pth"]
-                )[0]
-            else:
-                raise ValueError(
-                    "'zoo' provided as --checkpoint-path but a SparseZoo stub"
-                    " prefixed by 'zoo:' not provided as --recipe-path"
-                )
-
-        model = ModelRegistry.create(
-            args.arch_key,
-            args.pretrained,
-            args.checkpoint_path,
-            args.pretrained_dataset,
-            num_classes=num_classes,
-            **args.model_kwargs,
+    if not valid_recipe_stub:
+        raise ValueError(
+            "The recipe path must start with 'zoo:' to download from the zoo"
+            f" but got {recipe_stub} instead"
         )
-    print(f"created model: {model}")
-    return model
 
+    files = Zoo.download_recipe_base_framework_files(recipe_stub, extensions=[".pth"])
 
-def infer_num_classes(args: Any, train_dataset, val_dataset):
-    """
-    :param args: Object with configuration settings
-    :param train_dataset: dataset representing training data
-    :param val_dataset: dataset representing validation data
-    :return: An integer representing the number of classes
-    """
-    if "num_classes" in args.model_kwargs:
-        # handle manually overriden num classes
-        num_classes = args.model_kwargs["num_classes"]
-        del args.model_kwargs["num_classes"]
-    elif args.dataset == "imagefolder":
-        dataset = val_dataset or train_dataset  # get non None dataset
-        num_classes = dataset.num_classes
-    else:
-        dataset_attributes = DatasetRegistry.attributes(args.dataset)
-        num_classes = dataset_attributes["num_classes"]
-    return num_classes
-
-
-def get_loss_wrapper(
-    arch_key: str, training: bool = False, task: Optional[Tasks] = None
-):
-    """
-    :param arch_key: The model architecture
-    :param training: True if training task started else False
-    :param task: current task being executed
-    """
-    if "ssd" in arch_key.lower():
-        return SSDLossWrapper()
-    if "yolo" in arch_key.lower():
-        return YoloLossWrapper()
-
-    extras = {"top1acc": TopKAccuracy(1), "top5acc": TopKAccuracy(5)}
-    if task == Tasks.TRAIN:
-        return (
-            CrossEntropyLossWrapper(extras)
-            if training and "inception" not in arch_key
-            else InceptionCrossEntropyLossWrapper(extras)
-        )
-    return LossWrapper(loss_fn=torch_functional.cross_entropy, extras=extras)
-
-
-#  optimizer helper
-def create_scheduled_optimizer(
-    train_args: Any,
-    model: Module,
-    train_loader: DataLoader,
-    loggers: List[Any],
-) -> Tuple[int, ScheduledOptimizer, ScheduledModifierManager]:
-    """
-    :param train_args : An object with task specific config
-    :param model: model architecture to train
-    :param train_loader: A DataLoader for training data
-    :param loggers: List of loggers to use during training process
-    :type train_args: TrainingArguments
-    """
-    # # optimizer setup
-    optim_const = torch.optim.__dict__[train_args.optim]
-    optim = optim_const(
-        model.parameters(), lr=train_args.init_lr, **train_args.optim_args
-    )
-    print(f"created optimizer: {optim}")
-    print(
-        "note, the lr for the optimizer may not reflect the manager yet until "
-        "the recipe config is created and run"
-    )
-
-    # restore from previous check point
-    if train_args.checkpoint_path:
-        # currently optimizer restoring is unsupported
-        # mapping of the restored params to the correct device is not working
-        # load_optimizer(args.checkpoint_path, optim)
-        epoch = 0  # load_epoch(args.checkpoint_path) + 1
-        print(
-            f"restored checkpoint from {train_args.checkpoint_path} for "
-            f"epoch {epoch - 1}"
-        )
-    else:
-        epoch = 0
-
-    # modifier setup
-    add_mods = (
-        ConstantPruningModifier.from_sparse_model(model)
-        if train_args.sparse_transfer_learn
-        else None
-    )
-    manager = ScheduledModifierManager.from_yaml(
-        file_path=train_args.recipe_path, add_modifiers=add_mods
-    )
-    optim = ScheduledOptimizer(
-        optim,
-        model,
-        manager,
-        steps_per_epoch=len(train_loader),
-        loggers=loggers,
-    )
-    print(f"created manager: {manager}")
-    return epoch, optim, manager
-
-
-# saving helpers
-
-
-def save_recipe(
-    recipe_manager: ScheduledModifierManager,
-    save_dir: str,
-):
-    """
-    :param recipe_manager: The ScheduleModified manager to save recipes
-    :param save_dir: The directory to save the recipe
-    """
-    recipe_save_path = os.path.join(save_dir, "recipe.yaml")
-    recipe_manager.save(recipe_save_path)
-    print(f"Saved recipe to {recipe_save_path}")
-
-
-def save_model_training(
-    model: Module,
-    optim: Optimizer,
-    save_name: str,
-    save_dir: str,
-    epoch: int,
-    val_res: Union[ModuleRunResults, None],
-):
-    """
-    :param model: model architecture
-    :param optim: The optimizer used
-    :param input_shape: A tuple of integers representing the input shape
-    :param save_name: name to save model to
-    :param save_dir: directory to save results in
-    :param epoch: integer representing umber of epochs to
-    :param val_res: results from validation run
-    :param convert_qat: True if model is to be quantized before saving
-    """
-    has_top1 = "top1acc" in val_res.results
-    metric_name = "top-1 accuracy" if has_top1 else "val_loss"
-    metric = val_res.result_mean("top1acc" if has_top1 else DEFAULT_LOSS_KEY).item()
-    print(
-        f"Saving model for epoch {epoch} and {metric_name} "
-        f"{metric} to {save_dir} for {save_name}"
-    )
-    exporter = ModuleExporter(model, save_dir)
-    exporter.export_pytorch(optim, epoch, f"{save_name}.pth")
-    info_path = os.path.join(save_dir, f"{save_name}.txt")
-
-    with open(info_path, "w") as info_file:
-        info_lines = [
-            f"epoch: {epoch}",
-        ]
-
-        if val_res is not None:
-            for loss in val_res.results.keys():
-                info_lines.append(f"{loss}: {val_res.result_mean(loss).item()}")
-
-        info_file.write("\n".join(info_lines))
+    checkpoint_path = files[0]
+    return checkpoint_path

--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -35,7 +35,6 @@ from sparseml.pytorch.utils import (
     PythonLogger,
     TensorBoardLogger,
     early_stop_data_loader,
-    model_to_device,
     torch_distributed_zero_first,
 )
 from sparseml.utils import create_dirs
@@ -50,7 +49,6 @@ __all__ = [
     "infer_num_classes",
     "save_recipe",
     "save_model_training",
-    "device_setup",
 ]
 
 
@@ -284,29 +282,6 @@ def save_model_training(
                 info_lines.append(f"{loss}: {val_res.result_mean(loss).item()}")
 
         info_file.write("\n".join(info_lines))
-
-
-# device helpers
-def device_setup(
-    model, rank: int, local_rank: int, device: Union[str, int]
-) -> Tuple[Module, int, int]:
-    """
-    Move the model to the correct device.
-
-    :param model: The model to move to the correct device
-    :param rank: The rank of the process in network
-    :param local_rank: The rank of the process on the local machine
-    :param device: The device to move the model to
-    :return: A tuple of (model, device, ddp)
-    """
-    if rank == -1:
-        ddp = False
-    else:
-        torch.cuda.set_device(local_rank)
-        device = local_rank
-        ddp = True
-    model, device, _ = model_to_device(model=model, device=device, ddp=ddp)
-    return model, device, ddp
 
 
 # private methods

--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -145,7 +145,7 @@ def get_train_and_validation_loaders(args: Any, task: Optional[Tasks] = None):
 
 
 # Model creation Helpers
-def create_model(args: Any, num_classes: int) -> Module:
+def create_model(args: Any, num_classes: int) -> Tuple[Module, str]:
     """
     :param args: object with configuration for model classes
     :param num_classes: Integer representing the number of output classes
@@ -251,12 +251,10 @@ def save_model_training(
     """
     :param model: model architecture
     :param optim: The optimizer used
-    :param input_shape: A tuple of integers representing the input shape
     :param save_name: name to save model to
     :param save_dir: directory to save results in
     :param epoch: integer representing umber of epochs to
     :param val_res: results from validation run
-    :param convert_qat: True if model is to be quantized before saving
     :param arch_key: if provided, the `arch_key` will be saved in the
         checkpoint
     """
@@ -289,7 +287,9 @@ def save_model_training(
 
 
 # device helpers
-def device_setup(model, rank: int, local_rank: int, device: Union[str, int]):
+def device_setup(
+    model, rank: int, local_rank: int, device: Union[str, int]
+) -> Tuple[Module, int, int]:
     """
     Move the model to the correct device.
 

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Trainers for image classification.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List, Optional
+
+import torch
+from torch.utils.data import DataLoader
+
+from sparseml.pytorch.optim import ScheduledModifierManager, ScheduledOptimizer
+from sparseml.pytorch.sparsification import ConstantPruningModifier
+from sparseml.pytorch.utils import (
+    DEFAULT_LOSS_KEY,
+    CrossEntropyLossWrapper,
+    ModuleDeviceContext,
+    ModuleTester,
+    ModuleTrainer,
+    default_device,
+)
+
+
+_LOGGER = logging.getLogger(__file__)
+
+__all__ = [
+    "ImageClassificationTrainer",
+]
+
+
+class Trainer(ABC):
+    """
+    Abstract class for Trainers.
+    Creates a contract that all trainers must have a run_one_epoch method.
+    """
+
+    @abstractmethod
+    def run_one_epoch(self):
+        """
+        Runs one epoch of training.
+        """
+        raise NotImplementedError
+
+
+class ImageClassificationTrainer(Trainer):
+    """
+    Trainer for image classification.
+
+    :param model: The loaded torch model to train.
+    :param key: The arch key of the model.
+    :param recipe_path: The path to the yaml file containing the modifiers and
+        schedule to apply them with; Can also provide a SparseZoo stub prefixed
+        with 'zoo:'.
+    :param ddp: bool indicating whether to use Distributed Data Parallel.
+    :param device: The device to train on. Defaults to torch default device.
+    :param use_mixed_precision: Whether to use mixed precision FP16 training.
+        Defaults to False.
+    :param sparse_transfer_learn: True if transfer learning on a sparse model,
+        else False. Defaults to False.
+    :param val_loader: A DataLoader for validation data.
+    :param train_loader: A DataLoader for training data.
+    :param is_main_process: Whether the current process is the main process,
+        while training using DDP. Defaults to True.
+    :param loggers: A list of loggers to use during training process.
+    :param loss_fn: A Callabale loss function for training and validation
+        losses.
+    :param init_lr: The initial learning rate for the optimizer.Defaults to
+        1e-9
+    :param optim_name: str respresenting the optimizer type to use, one of
+        [SGD, Adam, RMSprop]. Defaults to `adam`.
+    :param optim_kwargs: dict of additional kwargs to pass to the optimizer.
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        key: str,
+        recipe_path: str,
+        ddp: bool = False,
+        device: str = default_device(),
+        use_mixed_precision: bool = False,
+        sparse_transfer_learn: bool = False,
+        val_loader: Optional[DataLoader] = None,
+        train_loader: Optional[DataLoader] = None,
+        is_main_process: bool = True,
+        loggers: Optional[List[Any]] = None,
+        loss_fn: Callable = lambda: CrossEntropyLossWrapper(),
+        init_lr=1e-9,
+        optim_name="adam",
+        optim_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        """
+        Initializes the trainer.
+        """
+        self.recipe_path = recipe_path
+        self.ddp = ddp
+        self.is_main_process = is_main_process
+        self.optim_kwargs = optim_kwargs or {}
+        self.device = device
+        self.use_mixed_precision = use_mixed_precision
+        self.model, self.key = model, key
+        self.loss_fn = loss_fn()
+        self.init_lr = init_lr
+        self.val_loader = val_loader
+        self.train_loader = train_loader
+        self.loggers = loggers
+        self.sparse_transfer_learn = sparse_transfer_learn
+
+        self.val_loss = loss_fn()
+        _LOGGER.info(f"created loss for validation: {self.val_loss}")
+
+        self.train_loss = loss_fn()
+        _LOGGER.info(f"created loss for training: {self.train_loss}")
+
+        self.optim_name = optim_name
+        self.epoch = 0
+
+        if self.train_loader is not None:
+            (
+                self.epoch,
+                self.optim,
+                self.manager,
+            ) = self._initialize_scheduled_optimizer()
+            self.trainer = self._initialize_trainer()
+        else:
+            self.optim = self.manager = self.trainer = None
+
+        if self.val_loader is not None:
+            self.tester = self._initialize_tester()
+        else:
+            self.tester = None
+
+        self.target_metric = (
+            "top1acc"
+            if self.tester and "top1acc" in self.tester.loss.available_losses
+            else DEFAULT_LOSS_KEY
+        )
+
+        if self.epoch > 0:
+            _LOGGER.info("adjusting ScheduledOptimizer to restore point")
+            self.optim.adjust_current_step(self.epoch, 0)
+
+    def run_one_epoch(
+        self,
+        mode: str = "train",
+        max_steps: Optional[int] = None,
+    ):
+        """
+        Runs one epoch of training or validation.
+
+        :param mode: str representing the mode to run in, one of
+            ['train', 'val']
+        :param max_steps: int representing the maximum number of steps to run
+            in this epoch
+        :returns: Result from validation run if result is not None.
+        """
+        train_mode = mode == "train"
+        validation_mode = not train_mode
+
+        if validation_mode:
+            self._run_validation_epoch(max_steps=max_steps)
+
+        if train_mode:
+            val_metric = self._run_train_epoch(max_steps=max_steps)
+            if val_metric:
+                return val_metric
+
+    @property
+    def max_epochs(self):
+        """
+        :return: the maximum number of epochs from manager
+        """
+        return self.manager.max_epochs if self.manager is not None else 0
+
+    def _initialize_tester(self):
+        tester = ModuleTester(
+            module=self.model,
+            device=self.device,
+            loss=self.val_loss,
+            loggers=self.loggers,
+            log_steps=-1,
+        )
+        return tester
+
+    def _initialize_scheduled_optimizer(self):
+        # optimizer setup
+        optim_constructor = torch.optim.__dict__[self.optim_name]
+        optim = optim_constructor(
+            self.model.parameters(), lr=self.init_lr, **self.optim_kwargs
+        )
+        _LOGGER.info(f"created optimizer: {optim}")
+        _LOGGER.info(
+            "note, the lr for the optimizer may not reflect the manager "
+            "yet until the recipe config is created and run"
+        )
+
+        epoch = 0
+
+        # modifier setup
+        add_mods = (
+            ConstantPruningModifier.from_sparse_model(self.model)
+            if self.sparse_transfer_learn
+            else None
+        )
+        manager = ScheduledModifierManager.from_yaml(
+            file_path=self.recipe_path, add_modifiers=add_mods
+        )
+        optim = ScheduledOptimizer(
+            optim,
+            self.model,
+            manager,
+            steps_per_epoch=len(self.train_loader),
+            loggers=self.loggers,
+        )
+        _LOGGER.info(f"created manager: {manager}")
+        return epoch, optim, manager
+
+    def _initialize_trainer(self):
+        trainer = ModuleTrainer(
+            module=self.model,
+            device=self.device,
+            loss=self.train_loss,
+            optimizer=self.optim,
+            loggers=self.loggers,
+            device_context=ModuleDeviceContext(
+                use_mixed_precision=self.use_mixed_precision,
+            ),
+        )
+        _LOGGER.info(f"created Module Trainer: {trainer}")
+
+        return trainer
+
+    def _run_validation_epoch(
+        self,
+        max_steps: Optional[int] = None,
+    ):
+        # Note: This method should not be called directly,
+        # use run_one_epoch instead
+
+        if self.is_main_process:
+            assert self.tester, "tester is not initialized"
+
+            # initial baseline eval run
+            self.tester.run_epoch(
+                self.val_loader,
+                epoch=self.epoch - 1,
+                max_steps=max_steps,
+            )
+
+    def _run_train_epoch(
+        self,
+        max_steps: Optional[int] = None,
+    ):
+        # Note: This method should not be called directly,
+        # use run_one_epoch instead
+
+        if max_steps and max_steps > 0:
+            # correct since all optimizer steps are not
+            # taken in the epochs for debug mode
+            self.optim.adjust_current_step(self.epoch, 0)
+
+        if self.ddp:  # sync DDP dataloaders
+            assert hasattr(self.train_loader.sampler, "set_epoch")
+            self.train_loader.sampler.set_epoch(self.epoch)
+
+        self.trainer.run_epoch(
+            data_loader=self.train_loader,
+            epoch=self.epoch,
+            max_steps=max_steps,
+            show_progress=self.is_main_process,
+        )
+
+        # testing steps
+        if self.is_main_process:
+            # only test on main process
+            val_res = self.tester.run_epoch(
+                data_loader=self.val_loader,
+                epoch=self.epoch,
+                max_steps=max_steps,
+            )
+            return val_res

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -73,12 +73,12 @@ class ImageClassificationTrainer(Trainer):
     :param is_main_process: Whether the current process is the main process,
         while training using DDP. Defaults to True.
     :param loggers: A list of loggers to use during training process.
-    :param loss_fn: A Callabale loss function for training and validation
+    :param loss_fn: A Callable loss function for training and validation
         losses.
     :param init_lr: The initial learning rate for the optimizer.Defaults to
         1e-9
-    :param optim_name: str respresenting the optimizer type to use, one of
-        [SGD, Adam, RMSprop]. Defaults to `adam`.
+    :param optim_name: str representing the optimizer type to use.
+        Defaults to `Adam`.
     :param optim_kwargs: dict of additional kwargs to pass to the optimizer.
     """
 
@@ -96,7 +96,7 @@ class ImageClassificationTrainer(Trainer):
         loggers: Optional[List[Any]] = None,
         loss_fn: Callable = lambda: CrossEntropyLossWrapper(),
         init_lr=1e-9,
-        optim_name="adam",
+        optim_name="Adam",
         optim_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """

--- a/src/sparseml/pytorch/models/registry.py
+++ b/src/sparseml/pytorch/models/registry.py
@@ -77,7 +77,7 @@ class ModelRegistry(object):
         load_strict: bool = True,
         ignore_error_tensors: List[str] = None,
         **kwargs,
-    ) -> Module:
+    ) -> Union[Module, Tuple[Module, Optional[str]]]:
         """
         Create a new model for the given key
 
@@ -95,22 +95,22 @@ class ModelRegistry(object):
         :return: The instantiated model if key is given else a Tuple containing
             the instantiated model and the loaded key
         """
-        _key = key
+        key_copy = key
 
-        if _key is None:
+        if key_copy is None:
             _checkpoint = torch.load(pretrained_path)
             if "arch_key" in _checkpoint:
-                _key = _checkpoint["arch_key"]
+                key_copy = _checkpoint["arch_key"]
             else:
                 raise ValueError("No `arch_key` found in checkpoint")
 
-        if _key not in ModelRegistry._CONSTRUCTORS:
+        if key_copy not in ModelRegistry._CONSTRUCTORS:
             raise ValueError(
                 "key {} is not in the model registry; available: {}".format(
-                    _key, ModelRegistry._CONSTRUCTORS
+                    key_copy, ModelRegistry._CONSTRUCTORS
                 )
             )
-        model = ModelRegistry._CONSTRUCTORS[_key](
+        model = ModelRegistry._CONSTRUCTORS[key_copy](
             pretrained=pretrained,
             pretrained_path=pretrained_path,
             pretrained_dataset=pretrained_dataset,
@@ -118,7 +118,7 @@ class ModelRegistry(object):
             ignore_error_tensors=ignore_error_tensors,
             **kwargs,
         )
-        return (model, _key) if key is None else model
+        return (model, key_copy) if key is None else model
 
     @staticmethod
     def create_zoo_model(

--- a/src/sparseml/pytorch/models/registry.py
+++ b/src/sparseml/pytorch/models/registry.py
@@ -16,8 +16,9 @@
 Code related to the PyTorch model registry for easily creating models.
 """
 
-from typing import Any, Callable, Dict, List, NamedTuple, Tuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
+import torch
 from torch.nn import Module
 
 from merge_args import merge_args
@@ -31,7 +32,6 @@ from sparsezoo.objects import Model
 __all__ = [
     "ModelRegistry",
 ]
-
 
 """
 Simple named tuple object to store model info
@@ -70,7 +70,7 @@ class ModelRegistry(object):
 
     @staticmethod
     def create(
-        key: str,
+        key: Optional[str] = None,
         pretrained: Union[bool, str] = False,
         pretrained_path: str = None,
         pretrained_dataset: str = None,
@@ -81,7 +81,8 @@ class ModelRegistry(object):
         """
         Create a new model for the given key
 
-        :param key: the model key (name) to create
+        :param key: the model key (name) to create. If None, the key is read
+            from the state_dict['arch_key'] of the model.
         :param pretrained: True to load pretrained weights; to load a specific version
             give a string with the name of the version (pruned-moderate, base).
             Default None
@@ -91,16 +92,25 @@ class ModelRegistry(object):
             loaded in model, False otherwise; default True
         :param ignore_error_tensors: tensors to ignore if there are errors in loading
         :param kwargs: any keyword args to supply to the model constructor
-        :return: the instantiated model
+        :return: The instantiated model if key is given else a Tuple containing
+            the instantiated model and the loaded key
         """
-        if key not in ModelRegistry._CONSTRUCTORS:
+        _key = key
+
+        if _key is None:
+            _checkpoint = torch.load(pretrained_path)
+            if "arch_key" in _checkpoint:
+                _key = _checkpoint["arch_key"]
+            else:
+                raise ValueError("No `arch_key` found in checkpoint")
+
+        if _key not in ModelRegistry._CONSTRUCTORS:
             raise ValueError(
                 "key {} is not in the model registry; available: {}".format(
-                    key, ModelRegistry._CONSTRUCTORS
+                    _key, ModelRegistry._CONSTRUCTORS
                 )
             )
-
-        return ModelRegistry._CONSTRUCTORS[key](
+        model = ModelRegistry._CONSTRUCTORS[_key](
             pretrained=pretrained,
             pretrained_path=pretrained_path,
             pretrained_dataset=pretrained_dataset,
@@ -108,6 +118,7 @@ class ModelRegistry(object):
             ignore_error_tensors=ignore_error_tensors,
             **kwargs,
         )
+        return (model, _key) if key is None else model
 
     @staticmethod
     def create_zoo_model(
@@ -124,6 +135,7 @@ class ModelRegistry(object):
         :param pretrained_dataset: The dataset to load for the model
         :return: the sparsezoo Model reference for the given model
         """
+
         if key not in ModelRegistry._CONSTRUCTORS:
             raise ValueError(
                 "key {} is not in the model registry; available: {}".format(
@@ -207,8 +219,11 @@ class ModelRegistry(object):
         if not isinstance(key, List):
             key = [key]
 
-        def decorator(const_func):
-            wrapped_constructor = ModelRegistry._registered_wrapper(key[0], const_func)
+        def decorator(constructor_func):
+            wrapped_constructor = ModelRegistry._registered_wrapper(
+                key[0],
+                constructor_func,
+            )
 
             ModelRegistry.register_wrapped_model_constructor(
                 wrapped_constructor,
@@ -293,10 +308,10 @@ class ModelRegistry(object):
     @staticmethod
     def _registered_wrapper(
         key: str,
-        const_func: Callable,
+        constructor_func: Callable,
     ):
-        @merge_args(const_func)
-        @wrapper_decorator(const_func)
+        @merge_args(constructor_func)
+        @wrapper_decorator(constructor_func)
         def wrapper(
             pretrained_path: str = None,
             pretrained: Union[bool, str] = False,
@@ -329,7 +344,7 @@ class ModelRegistry(object):
             if attributes.args and pretrained in attributes.args:
                 kwargs[attributes.args[pretrained][0]] = attributes.args[pretrained][1]
 
-            model = const_func(*args, **kwargs)
+            model = constructor_func(*args, **kwargs)
             ignore = []
 
             if ignore_error_tensors:

--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -242,12 +242,13 @@ class ModuleExporter(object):
 
     def export_pytorch(
         self,
-        optimizer: Optimizer = None,
-        epoch: int = None,
+        optimizer: Optional[Optimizer] = None,
+        epoch: Optional[int] = None,
         name: str = "model.pth",
         use_zipfile_serialization_if_available: bool = True,
         include_modifiers: bool = False,
         export_entire_model: bool = False,
+        arch_key: Optional[str] = None,
     ):
         """
         Export the pytorch state dicts into pth file within a
@@ -262,6 +263,8 @@ class ModuleExporter(object):
             as the optimizer, the associated ScheduledModifierManager and its
             Modifiers will be exported under the 'manager' key. Default is False
         :param export_entire_model: Exports entire file instead of state_dict
+        :param arch_key: if provided, the `arch_key` will be saved in the
+            checkpoint
         """
         pytorch_path = os.path.join(self._output_dir, "framework")
         pth_path = os.path.join(pytorch_path, name)
@@ -279,6 +282,7 @@ class ModuleExporter(object):
                     use_zipfile_serialization_if_available
                 ),
                 include_modifiers=include_modifiers,
+                arch_key=arch_key,
             )
 
     def export_samples(

--- a/src/sparseml/pytorch/utils/model.py
+++ b/src/sparseml/pytorch/utils/model.py
@@ -17,7 +17,7 @@ Code related to interacting with a trained model such as saving, loading, etc
 """
 
 from collections import OrderedDict
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from torch.nn import DataParallel, Module
@@ -180,9 +180,10 @@ def save_model(
     path: str,
     model: Module,
     optimizer: Optimizer = None,
-    epoch: Union[int, None] = None,
+    epoch: Optional[int] = None,
     use_zipfile_serialization_if_available: bool = True,
     include_modifiers: bool = False,
+    arch_key: Optional[str] = None,
 ):
     """
     Save a model's state dict into a file at the given path.
@@ -197,6 +198,8 @@ def save_model(
     :param include_modifiers: if True, and a ScheduledOptimizer is provided
         as the optimizer, the associated ScheduledModifierManager and its
         Modifiers will be exported under the 'manager' key. Default is False
+    :param arch_key: if provided, the `arch_key` will be saved in the
+        checkpoint
     """
     create_parent_dirs(path)
 
@@ -214,13 +217,16 @@ def save_model(
     if optimizer:
         save_dict["optimizer"] = optimizer.state_dict()
 
-    if epoch:
+    if epoch is not None:
         save_dict["epoch"] = epoch
 
     if include_modifiers and optimizer and hasattr(optimizer, "manager_state_dict"):
         save_dict["manager"] = optimizer.manager_state_dict()
     elif include_modifiers and optimizer and hasattr(optimizer, "wrapped_manager"):
         save_dict["manager"] = optimizer.wrapped_manager.state_dict()
+
+    if arch_key:
+        save_dict["arch_key"] = arch_key
 
     if torch.__version__ < "1.6":
         torch.save(save_dict, path)


### PR DESCRIPTION
The goal of this diff to create a new training wrapper for image classification models,
The training wrapper easily integrates into the training flow and provides a single utility function `run_one_epoch(....)` for running a train and/or validation epoch.

Note: The arch-key argument can be omitted if the model checkpoint contains the arch_key an example checkpoint could look it
```python
{
    "state_dict" : ...,
    "arch_key": "resnet50",
    .
    .
    .
}

# In this case the arch-key can be omitted
```


The tests performed on this PR are as follows:

- [x]  Checkpoint downloaded from `Zoo` with `local recipe`, `arch-key` provided

```bash
sparseml.image_classification.train \
--recipe-path ./integrations/pytorch/recipes/resnet50-pruned.md \
--arch-key resnet50 \
--dataset imagenette \
--train-batch-size 32 \
--test-batch-size 256 \
--dataset-path dataset
```

- [X] Local checkpoint and recipe with `arch-key` not passed as a command line argument. Note that the checkpoint must contain `arch_key`.

```bash
sparseml.image_classification.train \
--recipe-path ./integrations/pytorch/recipes/resnet50-pruned.md \
--checkpoint-path ./pytorch/image_classification/pytorch_vision/resnet50_imagenette/framework/checkpoint-best.pth \
--dataset imagenette \
--train-batch-size 32 \
--test-batch-size 256 \
--dataset-path dataset
```

- [X] Zoo stub with checkpoint-path zoo

```bash
sparseml.image_classification.train \
--recipe-path "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none?recipe_type=original" \
--checkpoint-path zoo \
--dataset imagenette \
--train-batch-size 32 \
--test-batch-size 256 \
--dataset-path dataset
```

Note: `--arch-key` argument must be provided when recipes are `SparseZoo` stubs and checkpoint-path is `zoo`; because currently hosted models do not have `arch_key` in their `state_dicts`
