### PR TITLE
Integration Testing for Quantized ONNX export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ PYTEST_ARGS ?= ""
 ifneq ($(findstring deepsparse,$(TARGETS)),deepsparse)
     PYTEST_ARGS := $(PYTEST_ARGS) --ignore tests/sparseml/deepsparse
 endif
+ifneq ($(findstring transformers,$(TARGETS)),transformers)
+    PYTEST_ARGS := $(PYTEST_ARGS) --ignore tests/sparseml/transformers
+endif
 ifneq ($(findstring keras,$(TARGETS)),keras)
     PYTEST_ARGS := $(PYTEST_ARGS) --ignore tests/sparseml/keras
 endif

--- a/src/sparseml/transformers/export.py
+++ b/src/sparseml/transformers/export.py
@@ -71,13 +71,13 @@ from sparseml.transformers.sparsification import Trainer
 from sparseml.transformers.utils import SparseAutoModel
 
 
-__all__ = ["export_transformer_to_onnx"]
+__all__ = ["export_transformer_to_onnx", "load_task_model"]
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def _load_task_model(task: str, model_path: str, config: Any) -> Module:
+def load_task_model(task: str, model_path: str, config: Any) -> Module:
     if task == "masked-language-modeling" or task == "mlm":
         return SparseAutoModel.masked_language_modeling_from_pretrained(
             model_name_or_path=model_path,
@@ -156,7 +156,7 @@ def export_transformer_to_onnx(
     tokenizer = AutoTokenizer.from_pretrained(
         model_path, model_max_length=sequence_length
     )
-    model = _load_task_model(task, model_path, config)
+    model = load_task_model(task, model_path, config)
     _LOGGER.info(f"loaded model, config, and tokenizer from {model_path}")
 
     trainer = Trainer(

--- a/tests/sparseml/transformers/__init__.py
+++ b/tests/sparseml/transformers/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sparseml.transformers as _transformers  # noqa: F401

--- a/tests/sparseml/transformers/test_transformers.py
+++ b/tests/sparseml/transformers/test_transformers.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#import sparseml.transformers as __transformers  # noqa: F401
 
 import glob
 import math
@@ -21,9 +22,8 @@ from collections import Counter, OrderedDict
 import onnx
 import onnxruntime as ort
 import pytest
-from transformers import AutoConfig
-
 from sparseml.transformers.sparsification import Trainer
+from transformers import AutoConfig
 from sparsezoo import Zoo
 from sparsezoo.utils import load_numpy_list
 from src.sparseml.transformers import export_transformer_to_onnx, load_task_model

--- a/tests/sparseml/transformers/test_transformers.py
+++ b/tests/sparseml/transformers/test_transformers.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import glob
+import math
+import os
+import shutil
+import tarfile
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import pytest
+from transformers import AutoConfig
+
+from sparseml.transformers.sparsification import Trainer
+from sparsezoo import Zoo
+from src.sparseml.transformers import export_transformer_to_onnx, load_task_model
+
+
+def _is_yaml_recipe_present(model_path):
+    return any(
+        [
+            file
+            for file in glob.glob(os.path.join(model_path, "*"))
+            if (file.endswith(".yaml") or ("recipe" in file))
+        ]
+    )
+
+
+def _run_inference_onnx(path_onnx, input):
+    ort_sess = ort.InferenceSession(path_onnx)
+    with np.load(input) as data:
+        input_0, input_1, input_2 = (
+            data["input_0"].reshape(1, -1),
+            data["input_1"].reshape(1, -1),
+            data["input_2"].reshape(1, -1),
+        )
+    output = ort_sess.run(
+        None,
+        {"input_ids": input_0, "attention_mask": input_1, "token_type_ids": input_2},
+    )
+    return output
+
+
+def _compare_onnx_models(model1, model2):
+    optional_nodes_model1 = [
+        "If",
+        "Equal",
+        "Gather",
+        "Shape",
+        # ops above are those which are used in the
+        # original graph to create logits and softmax heads
+        "Constant",
+        "Cast",
+    ]  # ops above are the remaining optional nodes
+    optional_nodes_model2 = [
+        "Constant",
+        "Squeeze",
+    ]  # ops above are
+    # used in the original graph to create
+    # logits and softmax heads
+
+    nodes1 = model1.graph.node
+    nodes1_names = [node.name for node in nodes1]
+
+    nodes2 = model2.graph.node
+    nodes2_names = [node.name for node in nodes2]
+
+    # Extract ops which are in nodes1 but not in nodes2
+    nodes1_names_diff = [
+        node_name for node_name in nodes1_names if node_name not in nodes2_names
+    ]
+
+    # Extract ops which are in nodes2 but not in nodes1
+    nodes2_names_diff = [
+        node_name for node_name in nodes2_names if node_name not in nodes1_names
+    ]
+    # Assert that there are no important ops names in
+    # nodes1_names_diff or nodes2_names_diff
+    assert not [
+        x for x in nodes1_names_diff if x.split("_")[0] not in optional_nodes_model1
+    ]
+    assert not [
+        x for x in nodes2_names_diff if x.split("_")[0] not in optional_nodes_model2
+    ]
+
+    # Compare the structure of nodes which share names across m1 and m2
+    for node1 in nodes1:
+        if node1.name in set(nodes1_names).intersection(set(nodes2_names)):
+            for node2 in nodes2:
+                if node1.name == node2.name:
+                    _compare_onnx_nodes(node1, node2)
+
+
+def _compare_onnx_nodes(n1, n2):
+    # checking for consistent lengths seems like a sufficient test for now.
+    # due to internal structure, the naming of graph nodes
+    # may vary, even thought the semantics remain unchanged.
+    assert len(n1.input) == len(n2.input)
+    assert len(n1.output) == len(n2.output)
+    assert len(n1.op_type) == len(n2.op_type)
+    assert len(n1.attribute) == len(n2.attribute)
+
+
+@pytest.mark.parametrize(
+    "model_stub, recipe_present, task",
+    [
+        (
+            "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned-conservative",  # noqa: E501
+            False,
+            "question-answering",
+        )
+    ],
+    scope="function",
+)
+class TestModelFromZoo:
+    @pytest.fixture()
+    def setup(self, model_stub, recipe_present, task):
+        # setup
+        model = Zoo.load_model_from_stub(model_stub)
+        model.download()
+
+        path_onnx = model.onnx_file.downloaded_path()
+        model_path = os.path.join(os.path.dirname(path_onnx), "pytorch")
+
+        yield path_onnx, model_path, recipe_present, task
+
+        # teardown
+        shutil.rmtree(os.path.dirname(model_path))
+
+    def test_load_weights_apply_recipe(self, setup):
+        path_onnx, model_path, recipe_present, task = setup
+        config = AutoConfig.from_pretrained(model_path)
+        model = load_task_model(task, model_path, config)
+
+        assert model
+        assert recipe_present == _is_yaml_recipe_present(model_path)
+        if recipe_present:
+
+            trainer = Trainer(
+                model=model,
+                model_state_path=model_path,
+                recipe=None,
+                recipe_args=None,
+                teacher=None,
+            )
+            applied = trainer.apply_manager(epoch=math.inf, checkpoint=None)
+
+            assert applied
+
+    def test_outputs(self, setup):
+        path_onnx, model_path, recipe_present, task = setup
+        path_retrieved_onnx = export_transformer_to_onnx(
+            task=task,
+            model_path=model_path,
+            onnx_file_name="retrieved_model.onnx",
+        )
+
+        inputs_tar_path = os.path.join(
+            os.path.dirname(path_onnx), "sample-inputs.tar.gz"
+        )
+        my_tar = tarfile.open(inputs_tar_path)
+        my_tar.extractall(model_path)
+        my_tar.close()
+
+        inputs = glob.glob(os.path.join(model_path, "sample-inputs/*"))
+        for input in inputs:
+            out1 = _run_inference_onnx(path_onnx, input)
+            out2 = _run_inference_onnx(path_retrieved_onnx, input)
+            for o1, o2 in zip(out1, out2):
+                pytest.approx(o1, abs=1e-5) == o2
+
+    def test_export_to_onnx(self, setup):
+        path_onnx, model_path, recipe_present, task = setup
+        path_retrieved_onnx = export_transformer_to_onnx(
+            task=task,
+            model_path=model_path,
+            onnx_file_name="retrieved_model.onnx",
+        )
+
+        m1 = onnx.load(path_onnx)
+        m2 = onnx.load(os.path.join(model_path, path_retrieved_onnx))
+
+        assert m2
+
+        _compare_onnx_models(m1, m2)

--- a/tests/sparseml/transformers/test_transformers.py
+++ b/tests/sparseml/transformers/test_transformers.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#import sparseml.transformers as __transformers  # noqa: F401
 
 import glob
 import math
@@ -22,8 +21,9 @@ from collections import Counter, OrderedDict
 import onnx
 import onnxruntime as ort
 import pytest
-from sparseml.transformers.sparsification import Trainer
 from transformers import AutoConfig
+
+from sparseml.transformers.sparsification import Trainer
 from sparsezoo import Zoo
 from sparsezoo.utils import load_numpy_list
 from src.sparseml.transformers import export_transformer_to_onnx, load_task_model


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1201735099598270/1201949554543506/f

There are some discrepancies that are probably harmless and expected. For instance, when comparing two pruned models, the sequences of last operations (before logits) differ slightly (this is probably due to how the newer PyTorch version handles the model-->onnx export pipeline).

The prediction head for the original onnx model ("before")
<img width="224" alt="image" src="https://user-images.githubusercontent.com/97082108/159311725-ab5908fa-b988-46a0-bbdf-38d5237abddc.png">

The prediction head for the retrieved onnx model ("after").
<img width="204" alt="image" src="https://user-images.githubusercontent.com/97082108/159311823-000edf9c-3b6f-46a7-805b-3e9c13ad7e1a.png">




