### PR TITLE
ACDC: Passing `epoch = float('inf)` when applying recipe to a model.

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_acdc.py
@@ -164,6 +164,9 @@ class ACDCPruningModifier(BasePruningModifier):
             should be set to different sparsities, should return a list of those values
             in the order the parameters appear in the mask manager for this object
         """
+        if epoch == float("inf"):
+            return self._compression_sparsity
+
         self._num_phase = math.floor((epoch - self.start_epoch) / self.update_frequency)
         if self._num_phase % 2 == 0:
             # entering decompression phase


### PR DESCRIPTION
When applying a checkpoint recipe containing ACDCPruningModifier to a model, the modifier's `get_applied_sparsity_for_epoch` method receives `epoch=float('inf')`. This breaks the modifier (`cannot convert float infinity to integer`).
This diff is my best and quickest way how to mitigate this problem, but I am open for suggestions.