### PR TITLE
[Logging] File delay + None loggers support

### DIFF
--- a/src/sparseml/pytorch/optim/modifier.py
+++ b/src/sparseml/pytorch/optim/modifier.py
@@ -662,7 +662,7 @@ class ScheduledModifier(Modifier, BaseScheduled):
         if not self._enabled:
             raise RuntimeError("modifier must be enabled")
 
-        if self.loggers.log_ready(epoch, self._last_log_epoch):
+        if self.loggers and self.loggers.log_ready(epoch, self._last_log_epoch):
             self._last_log_epoch = epoch
             self._scheduled_log_called = True
             self.log_update(module, optimizer, epoch, steps_per_epoch)

--- a/src/sparseml/pytorch/utils/logger.py
+++ b/src/sparseml/pytorch/utils/logger.py
@@ -323,7 +323,8 @@ class PythonLogger(LambdaLogger):
             dt_string = now.strftime("%d-%m-%Y_%H.%M.%S")
             os.makedirs("sparse_logs", exist_ok=True)
             handler = logging.FileHandler(
-                os.path.join("sparse_logs", f"{dt_string}.log")
+                os.path.join("sparse_logs", f"{dt_string}.log"),
+                delay=True,
             )
             self._logger.addHandler(handler)
             self._logger.propagate = False


### PR DESCRIPTION
Two lines for 2 simple changes to logging:
- Add check for whether loggers are set to None. Allows integrations to handle logging in DDP by initializing loggers for only the main process
- Create debug log file only when logs are actually written