### PR TITLE
ConvInteger quantization conversion for quant refactor

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -673,6 +673,12 @@ class QuantizationModifier(ScheduledModifier):
         self._qat_enabled = True
         self._calibrate_if_possible(module)
 
+        # mark export mode for module Conv layers
+        module.export_with_qlinearconv = self._quantize_conv_activations
+        if hasattr(module, "module"):
+            # for DP/DDP unwrapping
+            module.module.export_with_qlinearconv = self._quantize_conv_activations
+
     def _calibrate_if_possible(self, module):
         if self.num_calibration_steps == 0 and self._calibration_dataloader:
             warnings.warn(

--- a/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
@@ -166,7 +166,10 @@ def _fold_conv_bn_bias(model: ModelProto, conv_node: NodeProto, bn_node: NodePro
     folded_bias = folded_bias.astype(numpy.float32)
 
     bias_name = conv_node.name + ".bias"
-    conv_node.input.append(bias_name)
+    if len(conv_node.input) > 2:
+        conv_node.input[2] = bias_name
+    else:
+        conv_node.input.append(bias_name)
     update_model_param(model, bias_name, folded_bias)
 
     # forward conv output to bn children

--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -498,7 +498,15 @@ def export_onnx(
             quantize_torch_qat_export,
         )
 
-        quantize_torch_qat_export(model=file_path, output_file_path=file_path)
+        use_qlinearconv = hasattr(module, "export_with_qlinearconv") and (
+            module.export_with_qlinearconv
+        )
+
+        quantize_torch_qat_export(
+            model=file_path,
+            output_file_path=file_path,
+            use_qlinearconv=use_qlinearconv,
+        )
 
     if skip_input_quantize:
         try:


### PR DESCRIPTION
To land after the quantization-refactor branch lands (Will remove DRAFT tag after). This PR adds support for changing the main pathway of converting quantizable convs to `ConvInteger`. The advantage of this update is that activation ranges of Convs no longer need to be observed during training under the `ConvInteger` spec which will help reduce quantization loss while not sacrificing inference performance.

Additionally, a check was added to not remove QDQ blocks immediately preceding `Add` nodes. This is to give the deepsparse engine the option of representing parts of a quantizable `Add` operation as INT8.

Expected quantizable conv block prior conversion:
<img width="236" alt="Screen Shot 2022-03-25 at 4 23 33 PM" src="https://user-images.githubusercontent.com/11316925/160195808-72de6cb4-a229-4442-aa13-2f070fbaffbc.png">

Result after conversion:
<img width="245" alt="Screen Shot 2022-03-25 at 4 23 50 PM" src="https://user-images.githubusercontent.com/11316925/160195843-18973e6b-e373-427b-9cc1-15a7d3b7fd40.png">

Residual add with 1 QDQ input:
<img width="347" alt="Screen Shot 2022-03-25 at 4 24 10 PM" src="https://user-images.githubusercontent.com/11316925/160195889-dace9fa3-c4e7-402a-a0f8-e189230d45c5.png">



Tested against sample RN50 models from research team against ONNX checker and tested accuracy against imagenet subset