### PR TITLE
[MFAC] cache previous GPUtil return

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -1466,6 +1466,7 @@ def cache_gpu_mem_return(func):
     prev_return = {}
     safety_scale = 0.8
 
+    @wraps(func)
     def cached_gpu_mem_func(device_idx=[], clear_cache=True):
         key = str(device_idx)
         try:
@@ -1502,6 +1503,7 @@ def _get_free_gpu_memory(
     reading, but comes at a (small) cost to pytorch tensor allocation speed. In the case
     of very high frequency calls, it may be better to turn clear_cache off.
     """
+
     if not device_idx:
         device_idx = list(range(torch.cuda.device_count()))
     if not device_idx:

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -1459,6 +1459,10 @@ def _get_num_grads_for_sparsity(
 
 
 def cache_return(func):
+    """
+    Cache previous return of GPUtil to be re-used in case future GPUtil call fails to
+    detect available devices.
+    """
     prev_return = {"rt": []}
     safety_scale = 0.8
 
@@ -1493,6 +1497,7 @@ def _get_free_gpu_memory(
     reading, but comes at a (small) cost to pytorch tensor allocation speed. In the case
     of very high frequency calls, it may be better to turn clear_cache off.
     """
+
     if not device_idx:
         device_idx = list(range(torch.cuda.device_count()))
     if not device_idx:

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -1482,7 +1482,6 @@ def cache_gpu_mem_return(func):
                 if key in prev_return
                 else []
             )
-
     return cached_gpu_mem_func
 
 

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -1482,6 +1482,7 @@ def cache_gpu_mem_return(func):
                 if key in prev_return
                 else []
             )
+
     return cached_gpu_mem_func
 
 

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -1467,9 +1467,9 @@ def cache_return(func):
     safety_scale = 0.8
 
     @wraps
-    def cached_func(*args):
+    def cached_func(*args, **kwargs):
         try:
-            prev_return["rt"] = func(*args)
+            prev_return["rt"] = func(*args, **kwargs)
             return prev_return["rt"]
         except Exception:
             _LOGGER.warning(

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -1458,7 +1458,7 @@ def _get_num_grads_for_sparsity(
     return num_grads[sparsity_thresholds[idx]]
 
 
-def cache_return(func):
+def cache_gpu_mem_return(func):
     """
     Cache previous return of GPUtil to be re-used in case future GPUtil call fails to
     detect available devices.
@@ -1467,7 +1467,7 @@ def cache_return(func):
     safety_scale = 0.8
 
     @wraps
-    def cached_func(*args, **kwargs):
+    def cached_gpu_mem_func(*args, **kwargs):
         try:
             prev_return["rt"] = func(*args, **kwargs)
             return prev_return["rt"]
@@ -1478,10 +1478,10 @@ def cache_return(func):
             )
             return [mem * safety_scale for mem in prev_return["rt"]]
 
-    return cached_func
+    return cached_gpu_mem_func
 
 
-@cache_return
+@cache_gpu_mem_return
 def _get_free_gpu_memory(
     device_idx: List[int] = [], clear_cache: bool = True
 ) -> List[float]:

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -1474,14 +1474,17 @@ def cache_gpu_mem_return(func):
             return prev_return[key]
         except Exception:
             _LOGGER.warning(
-                f"Failed to get GPU available memory. Using previous memory read, "
-                f"scaled down to {safety_scale*100:.2f}% for a safety margin"
+                f"[M-FAC] Failed to get GPU available memory. Using previous memory "
+                f" read scaled down to {safety_scale*100:.2f}% for a safety margin"
             )
-            return (
-                [mem * safety_scale for mem in prev_return[key]]
-                if key in prev_return
-                else []
-            )
+            if key not in prev_return:
+                _LOGGER.warning(
+                    "[M-FAC] No cached memory usage found for this set of GPUs. "
+                    "Defaulting to CPU for M-FAC calculations"
+                )
+                return []
+            else:
+                return [mem * safety_scale for mem in prev_return[key]]
 
     return cached_gpu_mem_func
 

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -1466,7 +1466,8 @@ def cache_return(func):
     prev_return = {"rt": []}
     safety_scale = 0.8
 
-    def wrapper(*args):
+    @wraps
+    def cached_func(*args):
         try:
             prev_return["rt"] = func(*args)
             return prev_return["rt"]
@@ -1477,7 +1478,7 @@ def cache_return(func):
             )
             return [mem * safety_scale for mem in prev_return["rt"]]
 
-    return wrapper
+    return cached_func
 
 
 @cache_return


### PR DESCRIPTION
Potential fix for #645. The fix caches returns from `_get_free_gpu_memory()` and uses them when the function fails to execute