### PR TITLE
[Hotfix] Quality failures with `black==21.5b2` and `click 8.1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ _dev_deps = [
     "pytest-mock~=3.6.0",
     "flaky~=3.7.0",
     "sphinx-rtd-theme",
+    "click<8.1",
 ]
 
 


### PR DESCRIPTION
This PR addresses `make quality` failures with `black==21.5b2` and `click==8.1`, the make quality command would fail in GitHub actions, blocking subsequent PR merges

Note: `click` was not included in dev dependencies originally but was required by one of sparseml's dev dependency

Proposed Solution:
Pin: `click<8.1` in dev dependencies to prevent quality-failures with `black`


Tested locally with a fresh virtual environment:
```bash
pip install -e "./[dev]"
make style && make quality
```
The above test passes without issues
