### PR TITLE
[Staged Recipes Integration] `ScheduledModifierManager` adds "framework metadata" to new metadata.

### DIFF
--- a/src/sparseml/keras/optim/manager.py
+++ b/src/sparseml/keras/optim/manager.py
@@ -18,7 +18,7 @@ grouping modifiers and running them together.
 Also handles loading modifiers from yaml files
 """
 
-import logging
+
 from typing import Any, Dict, List, Optional, Union
 
 from tensorflow import Tensor
@@ -33,7 +33,6 @@ from sparseml.optim import (
     parse_recipe_variables,
     validate_metadata,
 )
-from sparseml.utils import FRAMEWORK_METADATA_KEY
 from sparsezoo.objects import Recipe
 
 
@@ -79,12 +78,6 @@ class ScheduledModifierManager(BaseManager, Modifier):
         validated_metadata = validate_metadata(metadata, yaml_str)
 
         if metadata is not None:
-            logging.info(
-                "The new `metadata` has been passed to the manager. "
-                f"This will change the metadata in the recipe {file_path}"
-                f"including updating the metadata key {FRAMEWORK_METADATA_KEY} "
-                "to reflect your current setup."
-            )
             validated_metadata = add_framework_metadata(
                 validated_metadata, keras_version=keras.__version__
             )

--- a/src/sparseml/keras/optim/manager.py
+++ b/src/sparseml/keras/optim/manager.py
@@ -27,6 +27,7 @@ from sparseml.keras.utils.compat import keras
 from sparseml.keras.utils.logger import KerasLogger
 from sparseml.optim import (
     BaseManager,
+    add_framework_metadata,
     load_recipe_yaml_str,
     parse_recipe_variables,
     validate_metadata,
@@ -74,6 +75,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
             modifiers.extend(add_modifiers)
 
         metadata = validate_metadata(metadata, yaml_str)
+        metadata = add_framework_metadata(metadata)
 
         manager = ScheduledModifierManager(modifiers=modifiers, metadata=metadata)
 

--- a/src/sparseml/keras/optim/manager.py
+++ b/src/sparseml/keras/optim/manager.py
@@ -76,6 +76,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
 
         metadata = validate_metadata(metadata, yaml_str)
         metadata = add_framework_metadata(metadata)
+        # TODO: implement proper logic for adding framework metadata
 
         manager = ScheduledModifierManager(modifiers=modifiers, metadata=metadata)
 

--- a/src/sparseml/keras/optim/manager.py
+++ b/src/sparseml/keras/optim/manager.py
@@ -78,7 +78,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
 
         validated_metadata = validate_metadata(metadata, yaml_str)
 
-        if metadata:
+        if metadata is not None:
             logging.info(
                 "The new `metadata` has been passed to the manager. "
                 f"This will change the metadata in the recipe {file_path}"

--- a/src/sparseml/optim/helpers.py
+++ b/src/sparseml/optim/helpers.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 import torch
 import yaml
 
+from sparseml import version as sparseml_version
 from sparseml.utils import (
     RECIPE_METADATA_KEY,
     UnknownVariableException,
@@ -33,13 +34,6 @@ from sparseml.utils import (
 )
 from sparsezoo import Zoo
 from sparsezoo.objects import Recipe
-
-
-# from src.sparseml import version_base
-
-# having circular dependency problem with the
-# line above, hack for now
-version_base = "0.12.0"
 
 
 __all__ = [
@@ -601,7 +595,7 @@ def _add_framework_metadata(metadata, is_metadata_staged):
     framework_metadata = {
         "python_version": platform.python_version(),
         "torch_version": torch.__version__,
-        "sparseml_version": version_base,
+        "sparseml_version": sparseml_version,
     }
     if is_metadata_staged:
         for stage_name, stage_value in metadata.items():

--- a/src/sparseml/optim/helpers.py
+++ b/src/sparseml/optim/helpers.py
@@ -16,6 +16,7 @@
 Helper functions for base Modifier and Manger utilities
 """
 import json
+import logging
 import platform
 import re
 import warnings
@@ -23,11 +24,11 @@ from contextlib import suppress
 from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple, Union
 
-import torch
 import yaml
 
 from sparseml import version as sparseml_version
 from sparseml.utils import (
+    FRAMEWORK_METADATA_KEY,
     RECIPE_METADATA_KEY,
     UnknownVariableException,
     restricted_eval,
@@ -46,6 +47,7 @@ __all__ = [
     "check_if_staged_recipe",
     "validate_metadata",
     "add_framework_metadata",
+    "contains_framework_metadata",
 ]
 
 
@@ -574,28 +576,94 @@ def _check_warn_dict_difference(original_dict, new_dict):
     return new_dict
 
 
-def add_framework_metadata(metadata: Dict[str, Dict]) -> Dict[str, Dict]:
+def contains_framework_metadata(yaml_str: str) -> bool:
     """
-    Adds the information about the relevant frameworks used by the user to the metadata.
+    Checks whether the recipe contains framework metadata.
+    :param yaml_str: String representation of the recipe YAML file,
+        (may contain framework metadata)
+    :return: True if recipe contains framework metadata,
+        else False
+    """
+    container = load_recipe_yaml_str_no_classes(yaml_str)
+    is_container_staged = check_if_staged_recipe(container)
+
+    metadata = (
+        _extract_metadata_from_staged_recipe(container)
+        if is_container_staged
+        else _extract_metadata_from_recipe(container)
+    )
+    if not metadata:
+        return False
+
+    # returns a list of boolean values where every entry
+    # tells whether framework metadata is contained by the stage
+    is_stage_w_framework_metadata = [
+        FRAMEWORK_METADATA_KEY in stage_metadata.keys()
+        for stage_metadata in metadata.values()
+    ]
+
+    # checking for prohibitive scenario, when some stages
+    # contain metadata and some don't.
+    if (True in is_stage_w_framework_metadata) and (
+        False in is_stage_w_framework_metadata
+    ):
+        stages_w_framework_metadata = {
+            stage_name
+            for stage_name, is_framework_metadata in zip(
+                _get_recipe_stage_names(container), is_stage_w_framework_metadata
+            )
+            if is_framework_metadata
+        }
+        stages_w_o_framework_metadata = set(
+            _get_recipe_stage_names(container)
+        ).difference(stages_w_framework_metadata)
+
+        raise ValueError(
+            "Some stages in the recipe contain framework metadata, while some don't. "
+            "This is prohibited, your recipe may be potentially corrupted."
+            f"{FRAMEWORK_METADATA_KEY} is in stages: {stages_w_framework_metadata} "
+            f"while not in stages: {stages_w_o_framework_metadata} "
+        )
+    # if all stages contain metadata
+    elif all(is_stage_w_framework_metadata):
+        return True
+
+    else:
+        return False
+
+
+def add_framework_metadata(
+    metadata: Dict[str, Dict], **extra_metadata
+) -> Dict[str, Dict]:
+    """
+    Adds the information (in the form of a nested dictionary)
+    about the relevant frameworks used by the user to the metadata.
     :param metadata: Validated metadata
+    :param extra_metadata: Optional framework metadata, specific for the given framework
+        (e.g. for pytorch integration
+        'add_framework_metadata(metadata, pytorch_version = torch.__version__)')
     :return: Validated metadata with framework metadata
     """
 
     framework_metadata = {
         "python_version": platform.python_version(),
-        "torch_version": torch.__version__,
         "sparseml_version": sparseml_version,
     }
+
+    framework_metadata.update(extra_metadata)
+
     for stage_name, stage_value in metadata.items():
         if stage_value is None:
-            _stage_value = framework_metadata
+            stage_metadata = {FRAMEWORK_METADATA_KEY: framework_metadata}
         else:
-            shared_keys = set(stage_value.keys()).intersection(
-                set(framework_metadata.keys())
-            )
-            if shared_keys:
+            if (FRAMEWORK_METADATA_KEY in stage_value.keys()) and stage_value[
+                FRAMEWORK_METADATA_KEY
+            ]:
+                shared_keys = set(
+                    stage_value[FRAMEWORK_METADATA_KEY].keys()
+                ).intersection(set(framework_metadata.keys()))
                 warning_if_stage = (
-                    f"stage, stage name: {stage_name}"
+                    f"stage (stage name: {stage_name})"
                     if stage_name != RECIPE_METADATA_KEY
                     else ""
                 )
@@ -604,10 +672,10 @@ def add_framework_metadata(metadata: Dict[str, Dict]) -> Dict[str, Dict]:
                     f"{shared_keys} with new value(s) "
                     f"{ {k:v for k,v in framework_metadata.items() if k in shared_keys} }"  # noqa E501
                 )
-                warnings.warn(warning_msg)
-            _stage_value = deepcopy(stage_value)
-            _stage_value.update(framework_metadata)
-        metadata[stage_name] = _stage_value
+                logging.warning(warning_msg)
+            stage_metadata = deepcopy(stage_value)
+            stage_metadata[FRAMEWORK_METADATA_KEY] = framework_metadata
+        metadata[stage_name] = stage_metadata
 
     return metadata
 

--- a/src/sparseml/optim/helpers.py
+++ b/src/sparseml/optim/helpers.py
@@ -16,17 +16,13 @@
 Helper functions for base Modifier and Manger utilities
 """
 import json
-import platform
 import re
 import warnings
 from contextlib import suppress
-from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple, Union
 
-import torch
 import yaml
 
-from sparseml import version as sparseml_version
 from sparseml.utils import (
     RECIPE_METADATA_KEY,
     UnknownVariableException,
@@ -45,7 +41,6 @@ __all__ = [
     "parse_recipe_variables",
     "check_if_staged_recipe",
     "validate_metadata",
-    "add_framework_metadata",
 ]
 
 
@@ -572,44 +567,6 @@ def _check_warn_dict_difference(original_dict, new_dict):
             "change in metadata is expected."
         )
     return new_dict
-
-
-def add_framework_metadata(metadata: Dict[str, Dict]) -> Dict[str, Dict]:
-    """
-    Adds the information about the relevant frameworks used by the user to the metadata.
-    :param metadata: Validated metadata
-    :return: Validated metadata with framework metadata
-    """
-
-    framework_metadata = {
-        "python_version": platform.python_version(),
-        "torch_version": torch.__version__,
-        "sparseml_version": sparseml_version,
-    }
-    for stage_name, stage_value in metadata.items():
-        if stage_value is None:
-            _stage_value = framework_metadata
-        else:
-            shared_keys = set(stage_value.keys()).intersection(
-                set(framework_metadata.keys())
-            )
-            if shared_keys:
-                warning_if_stage = (
-                    f"stage, stage name: {stage_name}"
-                    if stage_name != RECIPE_METADATA_KEY
-                    else ""
-                )
-                warning_msg = (
-                    f"Overwriting metadata {warning_if_stage} key(s) "
-                    f"{shared_keys} with new value(s) "
-                    f"{ {k:v for k,v in framework_metadata.items() if k in shared_keys} }"  # noqa E501
-                )
-                warnings.warn(warning_msg)
-            _stage_value = deepcopy(stage_value)
-            _stage_value.update(framework_metadata)
-        metadata[stage_name] = _stage_value
-
-    return metadata
 
 
 def validate_metadata(metadata: dict, yaml_str: str) -> dict:

--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -528,19 +528,19 @@ def _sort_modifiers_list(modifiers: List[BaseModifier]) -> List[BaseModifier]:
     return sorted(modifiers, key=cmp_to_key(BaseModifier.comparator))
 
 
-# Not sure whether this is the best way to avoid boilerplate code,
-# but definitely helps with the heavy lifting, especially after introducing
-# nested metadata.
 def _nested_dict_to_lines(
     dict1: dict, yaml_str_lines: List[str], nesting_depth: int = 1
 ) -> List[str]:
     indentation = "  "
     for key, value in dict1.items():
         if isinstance(value, dict):
+            # add data for the current nesting level and
+            # move deeper to the next nesting level
             yaml_str_lines.append(indentation * nesting_depth + f"{key}:")
             yaml_str_lines = _nested_dict_to_lines(
                 value, yaml_str_lines, nesting_depth + 1
             )
         else:
+            # reached maximum nesting level.
             yaml_str_lines.append(indentation * nesting_depth + f"{key}: {value}")
     return yaml_str_lines

--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -18,6 +18,8 @@ Managers control groups of modifiers to allow modifying the training process of 
 ex to perform model pruning.
 """
 
+import json
+import logging
 import math
 from collections import OrderedDict
 from copy import deepcopy
@@ -51,6 +53,8 @@ class BaseManager(BaseObject):
         super().__init__(**kwargs)
 
         self._metadata = metadata if metadata else None
+        if self._metadata is not None:
+            self._info_log_metadata()
 
         if isinstance(modifiers, List):
             # sort modifiers by when they start and end so that later modifiers
@@ -522,6 +526,13 @@ class BaseManager(BaseObject):
             if quant_modifiers
             else False
         )
+
+    def _info_log_metadata(self):
+        logging.info(
+            "The new `metadata` has been passed to the manager. "
+            "Metadata supplied to the recipe:\t"
+        )
+        logging.info(json.dumps(self._metadata, indent=1))
 
 
 def _sort_modifiers_list(modifiers: List[BaseModifier]) -> List[BaseModifier]:

--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -33,6 +33,8 @@ from sparseml.utils import RECIPE_METADATA_KEY, clean_path, create_parent_dirs
 
 __all__ = ["BaseManager"]
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class BaseManager(BaseObject):
     """
@@ -528,11 +530,8 @@ class BaseManager(BaseObject):
         )
 
     def _info_log_metadata(self):
-        logging.info(
-            "The new `metadata` has been passed to the manager. "
-            "Metadata supplied to the recipe:\t"
-        )
-        logging.info(json.dumps(self._metadata, indent=1))
+        metadata_str = json.dumps(self._metadata, indent=1)
+        _LOGGER.info(f"Created recipe manager with metadata: {metadata_str}")
 
 
 def _sort_modifiers_list(modifiers: List[BaseModifier]) -> List[BaseModifier]:

--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -550,6 +550,10 @@ def _nested_dict_to_lines(
     dict1: dict, yaml_str_lines: List[str], nesting_depth: int = 1
 ) -> List[str]:
     indentation = "  "
+
+    if dict1 is None:
+        return yaml_str_lines
+
     for key, value in dict1.items():
         if isinstance(value, dict):
             # add data for the current nesting level and

--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -35,7 +35,6 @@ from sparseml.optim import (
 )
 from sparseml.pytorch.optim.modifier import Modifier, ScheduledModifier
 from sparseml.pytorch.utils import BaseLogger, LoggerManager, is_parallel_model
-from sparseml.utils import FRAMEWORK_METADATA_KEY
 from sparsezoo.objects import Recipe
 
 
@@ -290,12 +289,6 @@ class ScheduledModifierManager(BaseManager, Modifier):
         validated_metadata = validate_metadata(metadata, yaml_str)
 
         if metadata is not None:
-            logging.info(
-                "The new `metadata` has been passed to the manager. "
-                f"This will change the metadata in the recipe {file_path}"
-                f"including updating the metadata key {FRAMEWORK_METADATA_KEY} "
-                "to reflect your current setup."
-            )
             validated_metadata = add_framework_metadata(
                 validated_metadata, torch_version=torch.__version__
             )

--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -26,7 +26,7 @@ from torch import Tensor
 from torch.nn import Module
 from torch.optim.optimizer import Optimizer
 
-from sparseml.optim import (  # for now
+from sparseml.optim import (
     BaseManager,
     add_framework_metadata,
     load_recipe_yaml_str,

--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -21,11 +21,13 @@ Also handles loading modifiers from yaml files
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+import torch
 from torch import Tensor
 from torch.nn import Module
 from torch.optim.optimizer import Optimizer
 
-from sparseml.optim import (
+from sparseml.optim import contains_framework_metadata  # noqa F401
+from sparseml.optim import (  # for now
     BaseManager,
     add_framework_metadata,
     load_recipe_yaml_str,
@@ -286,10 +288,35 @@ class ScheduledModifierManager(BaseManager, Modifier):
         if add_modifiers:
             modifiers.extend(add_modifiers)
 
-        metadata = validate_metadata(metadata, yaml_str)
-        metadata = add_framework_metadata(metadata)
+        validated_metadata = validate_metadata(metadata, yaml_str)
+        """
+        Proposal of implementation:
 
-        manager = ScheduledModifierManager(modifiers=modifiers, metadata=metadata)
+        We don't want to add framework metadata (risk of overwriting previous, valid
+        framework metadata) if:
+        - `yaml_str` already contains framework metadata (condition A)
+        AND
+        - metadata is None (condition B)
+
+        This means that we do want to add framework metadata if
+        ! (A AND B) -> !A OR !B
+
+        So:
+
+        if metadata is not None or not contains_framework_metadata(yaml_str):
+            validated_metadata = add_framework_metadata(
+                    validated_metadata, torch_version=torch.__version__
+                )
+
+        """
+
+        validated_metadata = add_framework_metadata(
+            validated_metadata, torch_version=torch.__version__
+        )
+
+        manager = ScheduledModifierManager(
+            modifiers=modifiers, metadata=validated_metadata
+        )
 
         return manager
 

--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -27,17 +27,13 @@ from torch.optim.optimizer import Optimizer
 
 from sparseml.optim import (
     BaseManager,
+    add_framework_metadata,
     load_recipe_yaml_str,
     parse_recipe_variables,
     validate_metadata,
 )
 from sparseml.pytorch.optim.modifier import Modifier, ScheduledModifier
-from sparseml.pytorch.utils import (
-    BaseLogger,
-    LoggerManager,
-    add_framework_metadata,
-    is_parallel_model,
-)
+from sparseml.pytorch.utils import BaseLogger, LoggerManager, is_parallel_model
 from sparsezoo.objects import Recipe
 
 

--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -289,7 +289,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
 
         validated_metadata = validate_metadata(metadata, yaml_str)
 
-        if metadata:
+        if metadata is not None:
             logging.info(
                 "The new `metadata` has been passed to the manager. "
                 f"This will change the metadata in the recipe {file_path}"

--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -27,13 +27,17 @@ from torch.optim.optimizer import Optimizer
 
 from sparseml.optim import (
     BaseManager,
-    add_framework_metadata,
     load_recipe_yaml_str,
     parse_recipe_variables,
     validate_metadata,
 )
 from sparseml.pytorch.optim.modifier import Modifier, ScheduledModifier
-from sparseml.pytorch.utils import BaseLogger, LoggerManager, is_parallel_model
+from sparseml.pytorch.utils import (
+    BaseLogger,
+    LoggerManager,
+    add_framework_metadata,
+    is_parallel_model,
+)
 from sparsezoo.objects import Recipe
 
 

--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -27,6 +27,7 @@ from torch.optim.optimizer import Optimizer
 
 from sparseml.optim import (
     BaseManager,
+    add_framework_metadata,
     load_recipe_yaml_str,
     parse_recipe_variables,
     validate_metadata,
@@ -286,6 +287,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
             modifiers.extend(add_modifiers)
 
         metadata = validate_metadata(metadata, yaml_str)
+        metadata = add_framework_metadata(metadata)
 
         manager = ScheduledModifierManager(modifiers=modifiers, metadata=metadata)
 

--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -15,7 +15,7 @@
 """
 Utility / helper functions
 """
-
+import platform
 import random
 import re
 import warnings
@@ -31,6 +31,9 @@ from torch.nn import Linear, Module, Parameter
 from torch.nn.modules.conv import Conv2d, Conv3d, _ConvNd
 from torch.optim.optimizer import Optimizer
 from torch.utils.data import DataLoader
+
+from sparseml import version as sparseml_version
+from sparseml.utils import RECIPE_METADATA_KEY
 
 
 try:
@@ -84,6 +87,7 @@ __all__ = [
     "get_layer_param",
     "set_deterministic_seeds",
     "torch_distributed_zero_first",
+    "add_framework_metadata",
 ]
 
 
@@ -957,3 +961,41 @@ def torch_distributed_zero_first(local_rank: int):
     yield
     if local_rank == 0:
         torch.distributed.barrier()
+
+
+def add_framework_metadata(metadata: Dict[str, Dict]) -> Dict[str, Dict]:
+    """
+    Adds the information about the relevant frameworks used by the user to the metadata.
+    :param metadata: Validated metadata
+    :return: Validated metadata with framework metadata
+    """
+
+    framework_metadata = {
+        "python_version": platform.python_version(),
+        "torch_version": torch.__version__,
+        "sparseml_version": sparseml_version,
+    }
+    for stage_name, stage_value in metadata.items():
+        if stage_value is None:
+            _stage_value = framework_metadata
+        else:
+            shared_keys = set(stage_value.keys()).intersection(
+                set(framework_metadata.keys())
+            )
+            if shared_keys:
+                warning_if_stage = (
+                    f"stage, stage name: {stage_name}"
+                    if stage_name != RECIPE_METADATA_KEY
+                    else ""
+                )
+                warning_msg = (
+                    f"Overwriting metadata {warning_if_stage} key(s) "
+                    f"{shared_keys} with new value(s) "
+                    f"{ {k:v for k,v in framework_metadata.items() if k in shared_keys} }"  # noqa E501
+                )
+                warnings.warn(warning_msg)
+            _stage_value = deepcopy(stage_value)
+            _stage_value.update(framework_metadata)
+        metadata[stage_name] = _stage_value
+
+    return metadata

--- a/src/sparseml/tensorflow_v1/optim/manager.py
+++ b/src/sparseml/tensorflow_v1/optim/manager.py
@@ -113,6 +113,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
 
         metadata = validate_metadata(metadata, yaml_str)
         metadata = add_framework_metadata(metadata)
+        # TODO: implement proper logic for adding framework metadata
 
         manager = ScheduledModifierManager(modifiers=modifiers, metadata=metadata)
 

--- a/src/sparseml/tensorflow_v1/optim/manager.py
+++ b/src/sparseml/tensorflow_v1/optim/manager.py
@@ -117,7 +117,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
 
         validated_metadata = validate_metadata(metadata, yaml_str)
 
-        if metadata:
+        if metadata is not None:
             logging.info(
                 "The new `metadata` has been passed to the manager. "
                 f"This will change the metadata in the recipe {file_path}"

--- a/src/sparseml/tensorflow_v1/optim/manager.py
+++ b/src/sparseml/tensorflow_v1/optim/manager.py
@@ -19,7 +19,6 @@ Also handles loading modifiers from yaml files
 """
 
 import itertools
-import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import tensorflow as tf
@@ -34,7 +33,6 @@ from sparseml.optim import (
 )
 from sparseml.tensorflow_v1.optim.modifier import NM_RECAL, Modifier, ScheduledModifier
 from sparseml.tensorflow_v1.utils import tf_compat
-from sparseml.utils import FRAMEWORK_METADATA_KEY
 from sparsezoo.objects import Recipe
 
 
@@ -118,12 +116,6 @@ class ScheduledModifierManager(BaseManager, Modifier):
         validated_metadata = validate_metadata(metadata, yaml_str)
 
         if metadata is not None:
-            logging.info(
-                "The new `metadata` has been passed to the manager. "
-                f"This will change the metadata in the recipe {file_path}"
-                f"including updating the metadata key {FRAMEWORK_METADATA_KEY} "
-                "to reflect your current setup."
-            )
             validated_metadata = add_framework_metadata(
                 validated_metadata, tensorflow_version=tf.__version__
             )

--- a/src/sparseml/tensorflow_v1/optim/manager.py
+++ b/src/sparseml/tensorflow_v1/optim/manager.py
@@ -24,6 +24,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from sparseml.optim import (
     BaseManager,
     BaseScheduled,
+    add_framework_metadata,
     load_recipe_yaml_str,
     parse_recipe_variables,
     validate_metadata,
@@ -111,6 +112,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
             modifiers.extend(add_modifiers)
 
         metadata = validate_metadata(metadata, yaml_str)
+        metadata = add_framework_metadata(metadata)
 
         manager = ScheduledModifierManager(modifiers=modifiers, metadata=metadata)
 

--- a/src/sparseml/utils/helpers.py
+++ b/src/sparseml/utils/helpers.py
@@ -37,6 +37,7 @@ __all__ = [
     "ALL_PRUNABLE_TOKEN",
     "FROM_PARAM_TOKEN",
     "RECIPE_METADATA_KEY",
+    "FRAMEWORK_METADATA_KEY",
     "flatten_iterable",
     "convert_to_bool",
     "validate_str_iterable",
@@ -68,6 +69,7 @@ ALL_TOKEN = "__ALL__"
 ALL_PRUNABLE_TOKEN = "__ALL_PRUNABLE__"
 FROM_PARAM_TOKEN = "__FROM_PARAM__"
 RECIPE_METADATA_KEY = "__metadata__"
+FRAMEWORK_METADATA_KEY = "framework_metadata"
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/sparseml/optim/test_helpers.py
+++ b/tests/sparseml/optim/test_helpers.py
@@ -17,6 +17,7 @@ import platform
 import pytest
 import torch
 
+from sparseml import version as sparseml_version
 from sparseml.optim import (
     check_if_staged_recipe,
     evaluate_recipe_yaml_str_equations,
@@ -26,7 +27,6 @@ from sparseml.optim import (
     validate_metadata,
 )
 from sparseml.utils import RECIPE_METADATA_KEY
-from src.sparseml.version import version_base
 
 
 STAGED_RECIPE_COMPLEX = """
@@ -429,7 +429,7 @@ def _generate_fake_metadata(
     framework_metadata = {
         "python_version": platform.python_version(),
         "torch_version": torch.__version__,
-        "sparseml_version": version_base,
+        "sparseml_version": sparseml_version,
     }
     metadata = {k: v for (k, v) in (item1, item2)}
     if include_framework_metadata:

--- a/tests/sparseml/optim/test_helpers.py
+++ b/tests/sparseml/optim/test_helpers.py
@@ -15,7 +15,7 @@
 import platform
 
 import pytest
-import torch
+from sparseml.pytorch import torch
 
 from sparseml import version as sparseml_version
 from sparseml.optim import (

--- a/tests/sparseml/optim/test_helpers.py
+++ b/tests/sparseml/optim/test_helpers.py
@@ -15,11 +15,10 @@
 import platform
 
 import pytest
-from sparseml.pytorch import torch
+import torch
 
 from sparseml import version as sparseml_version
 from sparseml.optim import (
-    add_framework_metadata,
     check_if_staged_recipe,
     evaluate_recipe_yaml_str_equations,
     load_recipe_yaml_str,
@@ -27,6 +26,7 @@ from sparseml.optim import (
     update_recipe_variables,
     validate_metadata,
 )
+from sparseml.pytorch.utils import add_framework_metadata
 from sparseml.utils import RECIPE_METADATA_KEY
 
 

--- a/tests/sparseml/optim/test_helpers.py
+++ b/tests/sparseml/optim/test_helpers.py
@@ -15,10 +15,11 @@
 import platform
 
 import pytest
-import torch
+from sparseml.pytorch import torch
 
 from sparseml import version as sparseml_version
 from sparseml.optim import (
+    add_framework_metadata,
     check_if_staged_recipe,
     evaluate_recipe_yaml_str_equations,
     load_recipe_yaml_str,
@@ -26,7 +27,6 @@ from sparseml.optim import (
     update_recipe_variables,
     validate_metadata,
 )
-from sparseml.pytorch.utils import add_framework_metadata
 from sparseml.utils import RECIPE_METADATA_KEY
 
 

--- a/tests/sparseml/optim/test_helpers.py
+++ b/tests/sparseml/optim/test_helpers.py
@@ -12,9 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import platform
+from copy import deepcopy
+
 import pytest
 
+from sparseml import version as sparseml_version
 from sparseml.optim import (
+    add_framework_metadata,
     check_if_staged_recipe,
     evaluate_recipe_yaml_str_equations,
     load_recipe_yaml_str,
@@ -22,7 +28,7 @@ from sparseml.optim import (
     update_recipe_variables,
     validate_metadata,
 )
-from sparseml.utils import RECIPE_METADATA_KEY
+from sparseml.utils import FRAMEWORK_METADATA_KEY, RECIPE_METADATA_KEY
 
 
 STAGED_RECIPE_COMPLEX = """
@@ -524,12 +530,61 @@ def _generate_fake_metadata(item1=("this", "is"), item2=("metadata", 100)):
         ),
     ],
 )
-def test_validate_metadata(metadata, yaml_str, expected_metadata, raise_warning):
-    if raise_warning:
-        with pytest.warns(UserWarning):
-            metadata = validate_metadata(metadata, yaml_str)
-    else:
+def test_validate_metadata(
+    metadata, yaml_str, expected_metadata, raise_warning, caplog
+):
+    with caplog.at_level(logging.WARNING):
         metadata = validate_metadata(metadata, yaml_str)
+        assert raise_warning == bool(caplog.text)
+    assert metadata == expected_metadata
+
+
+metadata_w_framework_1 = _generate_fake_metadata()
+metadata_w_framework_1[FRAMEWORK_METADATA_KEY] = {
+    "python_version": platform.python_version(),
+    "sparseml_version": sparseml_version,
+}
+metadata_w_framework_2 = deepcopy(metadata_w_framework_1)
+metadata_w_framework_2[FRAMEWORK_METADATA_KEY]["python_version"] = "placeholder"
+
+
+@pytest.mark.parametrize(
+    "metadata, expected_metadata, raise_warning",
+    [
+        # pass unstaged metadata without framework metadata
+        (
+            {RECIPE_METADATA_KEY: _generate_fake_metadata()},
+            {RECIPE_METADATA_KEY: metadata_w_framework_1},
+            False,
+        ),
+        # pass staged metadata without framework metadata
+        (
+            {
+                "stage_0": _generate_fake_metadata(),
+                "stage_1": _generate_fake_metadata(),
+            },
+            {"stage_0": metadata_w_framework_1, "stage_1": metadata_w_framework_1},
+            False,
+        ),
+        # pass unstaged metadata with framework metadata
+        (
+            {RECIPE_METADATA_KEY: metadata_w_framework_2},
+            {RECIPE_METADATA_KEY: metadata_w_framework_1},
+            True,
+        ),
+        # pass staged metadata with framework metadata
+        (
+            {"stage_0": metadata_w_framework_2, "stage_1": metadata_w_framework_2},
+            {"stage_0": metadata_w_framework_1, "stage_1": metadata_w_framework_1},
+            True,
+        ),
+    ],
+)
+def test_add_framework_metadata(metadata, expected_metadata, raise_warning, caplog):
+    with caplog.at_level(logging.WARNING):
+        metadata = add_framework_metadata(metadata)
+        assert raise_warning == bool(caplog.text)
+
     assert metadata == expected_metadata
 
 
@@ -631,8 +686,3 @@ def test_update_recipe_variables(
         updated_yaml = load_recipe_yaml_str_no_classes(updated_recipe)
         target_yaml = load_recipe_yaml_str_no_classes(target_recipe)
         _test_nested_equality(updated_yaml, target_yaml)
-
-
-def test_contains_framework_metadata():
-    # TODO: To implement once we agree on the proposed logic
-    pass

--- a/tests/sparseml/pytorch/optim/test_manager.py
+++ b/tests/sparseml/pytorch/optim/test_manager.py
@@ -26,9 +26,7 @@ from torch.optim.optimizer import Optimizer
 
 from sparseml import version as sparseml_version
 from sparseml.optim import BaseModifier
-from sparseml.optim.helpers import add_framework_metadata
 from sparseml.pytorch.optim import Modifier, ScheduledModifierManager
-from sparseml.utils import FRAMEWORK_METADATA_KEY, RECIPE_METADATA_KEY
 from tests.sparseml.pytorch.helpers import (
     SAMPLE_STAGED_RECIPE,
     LinearNet,
@@ -569,18 +567,16 @@ def test_lifecycle_manager_staged(
     expected_recipe,
     raise_warning,
     raise_value_error,
+    caplog,
 ):
     temp_dir = tempfile.mkdtemp()
     recipe_path = os.path.join(temp_dir, "recipy.yaml")
-    if raise_warning:
-        with pytest.warns(UserWarning):
-            recipe_manager = ScheduledModifierManager.from_yaml(
-                file_path=recipe, metadata=metadata
-            )
-    else:
+    with caplog.at_level(logging.WARNING):
         recipe_manager = ScheduledModifierManager.from_yaml(
             file_path=recipe, metadata=metadata
         )
+        assert raise_warning == bool(caplog.text)
+
     if checkpoint_recipe:
         if raise_value_error:
             with pytest.raises(ValueError):
@@ -598,68 +594,6 @@ def test_lifecycle_manager_staged(
     with open(recipe_path, "r") as file:
         final_recipe = file.read()
     assert final_recipe == expected_recipe
-
-
-def _generate_fake_validated_metadata(include_framework_metadata, is_staged=False):
-    framework_metadata = {
-        "python_version": platform.python_version(),
-        "torch_version": torch.__version__,
-        "sparseml_version": sparseml_version,
-    }
-    stage_metadata = {"batch_size": 16, "learning_rate": 0.005}
-    if include_framework_metadata:
-        stage_metadata[FRAMEWORK_METADATA_KEY] = framework_metadata
-    metadata = (
-        {"stage_0": stage_metadata, "stage_1": stage_metadata}
-        if is_staged
-        else {RECIPE_METADATA_KEY: stage_metadata}
-    )
-    return metadata
-
-
-@pytest.mark.parametrize(
-    "metadata,expected_metadata, raise_warning",
-    [
-        # Unstaged metadata without previous framework_metadata
-        (
-            _generate_fake_validated_metadata(include_framework_metadata=False),
-            _generate_fake_validated_metadata(include_framework_metadata=True),
-            False,
-        ),
-        # Unstaged metadata with previous framework_metadata
-        (
-            _generate_fake_validated_metadata(include_framework_metadata=True),
-            _generate_fake_validated_metadata(include_framework_metadata=True),
-            True,
-        ),
-        # Staged metadata without previous framework_metadata
-        (
-            _generate_fake_validated_metadata(
-                include_framework_metadata=False, is_staged=True
-            ),
-            _generate_fake_validated_metadata(
-                include_framework_metadata=True, is_staged=True
-            ),
-            False,
-        ),
-        # Staged metadata with previous framework_metadata
-        (
-            _generate_fake_validated_metadata(
-                include_framework_metadata=True, is_staged=True
-            ),
-            _generate_fake_validated_metadata(
-                include_framework_metadata=True, is_staged=True
-            ),
-            True,
-        ),
-    ],
-)
-def test_add_framework_metadata(metadata, expected_metadata, raise_warning, caplog):
-    with caplog.at_level(logging.WARNING):
-        metadata = add_framework_metadata(metadata, torch_version=torch.__version__)
-        assert raise_warning == bool(caplog.text)
-
-    assert metadata == expected_metadata
 
 
 @pytest.mark.skipif(

--- a/tests/sparseml/pytorch/optim/test_manager.py
+++ b/tests/sparseml/pytorch/optim/test_manager.py
@@ -23,6 +23,7 @@ import torch
 from torch.nn import Module
 from torch.optim.optimizer import Optimizer
 
+from sparseml import version as sparseml_version
 from sparseml.optim import BaseModifier
 from sparseml.pytorch.optim import Modifier, ScheduledModifierManager
 from tests.sparseml.pytorch.helpers import (
@@ -42,12 +43,6 @@ from tests.sparseml.pytorch.helpers import (  # noqa isort:skip
     test_loss,
     test_steps_per_epoch,
 )
-
-# from src.sparseml import version_base
-
-# having circular dependency problem with the
-# line above, hack for now
-version_base = "0.12.0"
 
 
 STANDARD_RECIPE_1 = """
@@ -415,7 +410,6 @@ def _generate_fake_metadata(item1=("metadata", None), item2=("level", 1)):
 
 python_version = platform.python_version()
 torch_version = torch.__version__
-sparse_ml_version = version_base
 
 
 @pytest.mark.parametrize(
@@ -429,7 +423,7 @@ sparse_ml_version = version_base
             _generate_fake_metadata(item2=("level", 0)),
             STANDARD_RECIPE_1_EVAL.format(
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             False,
@@ -441,7 +435,7 @@ sparse_ml_version = version_base
             STANDARD_RECIPE_2,
             STANDARD_RECIPE_1_EVAL.format(
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             _generate_fake_metadata(),
@@ -449,7 +443,7 @@ sparse_ml_version = version_base
                 stage_0_name="stage_0",
                 stage_1_name="stage_1",
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             False,
@@ -463,13 +457,13 @@ sparse_ml_version = version_base
                 stage_0_name="stage_0",
                 stage_1_name="stage_1",
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             _generate_fake_metadata(item2=("level", 3)),
             THREE_STAGES_RECIPE_1.format(
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             False,
@@ -482,18 +476,18 @@ sparse_ml_version = version_base
                 stage_0_name="stage_0",
                 stage_1_name="stage_1",
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             STANDARD_RECIPE_1_EVAL.format(
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             _generate_fake_metadata(),
             THREE_STAGES_RECIPE_2.format(
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             True,
@@ -505,20 +499,20 @@ sparse_ml_version = version_base
                 stage_0_name="stage_3",
                 stage_1_name="stage_4",
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             TWO_STAGES_RECIPE.format(
                 stage_0_name="stage_0",
                 stage_1_name="stage_1",
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             _generate_fake_metadata(),
             FOUR_STAGES_RECIPE.format(
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             True,
@@ -531,20 +525,20 @@ sparse_ml_version = version_base
                 stage_0_name="stage_0",
                 stage_1_name="stage_1",
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             TWO_STAGES_RECIPE.format(
                 stage_0_name="stage_0",
                 stage_1_name="stage_1",
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             None,
             FOUR_STAGES_RECIPE.format(
                 python_version=python_version,
-                sparseml_version=sparse_ml_version,
+                sparseml_version=sparseml_version,
                 torch_version=torch_version,
             ),
             False,


### PR DESCRIPTION
This diff grants the `ScheduledModifierManager` the ability to insert "framework metadata" to incoming metadata.
The logic is as follows:
If new metadata is `None`, no framework metadata is added to it.
If new metadata is not `None` and there is no previous framework metadata: we add metadata.
If new metadata is not `None` and there is previous framework metadata: we overwrite previous framework metadata while raising a warning that we have done so.

Open questions:
- experiencing a bug regarding circular imports when fetching sparse ml version `from src.sparseml import version_base`. Did not spend too much time investigating, we can fix it before the merge or during our tri-weekly meeting.
- I am still not sure whether metadata=None should be equivalent to ignoring framework metadata insertion. Let's discuss that.