### PR TITLE
[Hotfix] recipe save failure when metadata is `None` 

### DIFF
--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -441,7 +441,7 @@ class BaseManager(BaseObject):
             yaml_str_lines.append(f"{RECIPE_METADATA_KEY}:")
             if not isinstance(self._metadata, dict):
                 yaml_str_lines[-1] += f" {self._metadata}"
-            else:
+            elif self._metadata[RECIPE_METADATA_KEY] is not None:
                 for key, value in self._metadata[RECIPE_METADATA_KEY].items():
                     yaml_str_lines.append(f"  {key}: {value}")
 


### PR DESCRIPTION
Fix: A small bug when the recipe metadata is `None`

This PR fixes a bug that causes recipe_manager.save(...) to fail when the recipe metadata is `None`

Example of a failing recipe

```yaml
version: 1.1.0

__metadata__:

modifiers:
    - !LearningRateFunctionModifier
        cycle_epochs: 1.0
        end_epoch: 5
        final_lr: 0.256
        init_lr: 0.0512
        lr_func: linear
        start_epoch: 0
        update_frequency: -1.0

    - !ACDCPruningModifier
        compression_sparsity: 0.95
        end_epoch: 190
        leave_enabled: True
        mask_type: unstructured
        momentum_buffer_reset: True
        params: ['sections.0.0.conv1.weight', 'sections.0.0.conv3.weight', 'sections.0>
        start_epoch: 5
        update_frequency: 5

    - !EpochRangeModifier
        end_epoch: 200
        start_epoch: 0

    - !LearningRateFunctionModifier
        cycle_epochs: 1.0
        end_epoch: 200
        final_lr: 0.0
        init_lr: 0.256
        lr_func: cosine
        start_epoch: 5
        update_frequency: -1.0
```

Steps to Reproduce:
```python
In [1]: from sparseml.pytorch.optim import ScheduledModifierManager

In [2]: manager = ScheduledModifierManager.from_yaml("recipe.yaml")

In [3]: manager.save("recipe-copy.yaml")
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Input In [3], in <module>
----> 1 manager.save("recipe-copy.yaml")

File ~/projects/sparseml/src/sparseml/optim/manager.py:360, in BaseManager.save(self, file_path, include_metadata)
    357 create_parent_dirs(file_path)
    359 with open(file_path, "w") as yaml_file:
--> 360     yaml_file.write("\n".join(self.to_string_lines(include_metadata)))

File ~/projects/sparseml/src/sparseml/optim/manager.py:412, in BaseManager.to_string_lines(self, include_metadata)
    410 if isinstance(self.modifiers, List):
    411     if include_metadata and self._metadata:
--> 412         yaml_str_lines.extend(self.metadata_to_string_lines())
    413     yaml_str_lines.append("modifiers:")
    414     yaml_str_lines.extend(self.modifiers_list_to_string_lines(self.modifiers))

File ~/projects/sparseml/src/sparseml/optim/manager.py:445, in BaseManager.metadata_to_string_lines(self, stage)
    443         yaml_str_lines[-1] += f" {self._metadata}"
    444     else:
--> 445         for key, value in self._metadata[RECIPE_METADATA_KEY].items():
    446             yaml_str_lines.append(f"  {key}: {value}")
    448 yaml_str_lines.append("")

AttributeError: 'NoneType' object has no attribute 'items'
```