### PR TITLE
[Add tests] To hotfix regarding the saving of `None` metadata

### DIFF
--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -399,7 +399,7 @@ class BaseManager(BaseObject):
             for mod in modifiers_list:
                 yield mod
 
-    def to_string_lines(self, include_metadata: bool = False) -> List[str]:
+    def to_string_lines(self, include_metadata: bool = True) -> List[str]:
         """
         :param include_metadata: boolean indicator whether metadata shall be
             appended to the yaml file before saving. Default is False.

--- a/tests/sparseml/pytorch/optim/test_manager.py
+++ b/tests/sparseml/pytorch/optim/test_manager.py
@@ -438,8 +438,6 @@ def test_lifecycle_manager_staged(
     raise_warning,
     raise_value_error,
 ):
-    temp_dir = tempfile.mkdtemp()
-    recipe_path = os.path.join(temp_dir, "recipy.yaml")
     if raise_warning:
         with pytest.warns(UserWarning):
             recipe_manager = ScheduledModifierManager.from_yaml(
@@ -461,10 +459,8 @@ def test_lifecycle_manager_staged(
                 base_recipe=checkpoint_recipe,
                 additional_recipe=recipe_manager,
             )
-    recipe_manager.save(recipe_path)
 
-    with open(recipe_path, "r") as file:
-        final_recipe = file.read()
+    final_recipe = str(recipe_manager)
     assert final_recipe == expected_recipe
 
 

--- a/tests/sparseml/pytorch/optim/test_manager.py
+++ b/tests/sparseml/pytorch/optim/test_manager.py
@@ -515,7 +515,7 @@ stage_1:
 )
 def test_lifecycle_manager_staged_no_metadata(recipe):
     temp_dir = tempfile.mkdtemp()
-    recipe_path = os.path.join(temp_dir, "recipy.yaml")
+    recipe_path = os.path.join(temp_dir, "recipe.yaml")
 
     recipe_manager = ScheduledModifierManager.from_yaml(file_path=recipe)
     recipe_manager.save(recipe_path)

--- a/tests/sparseml/pytorch/optim/test_manager.py
+++ b/tests/sparseml/pytorch/optim/test_manager.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import tempfile
 from collections import OrderedDict
 from typing import Callable
 
@@ -510,18 +509,11 @@ stage_1:
     ],
 )
 def test_lifecycle_manager_staged_no_metadata(recipe):
-    temp_dir = tempfile.mkdtemp()
-    recipe_path = os.path.join(temp_dir, "recipe.yaml")
-
     recipe_manager = ScheduledModifierManager.from_yaml(file_path=recipe)
-    recipe_manager.save(recipe_path)
-    with open(recipe_path, "r") as file:
-        recipe_old = file.read()
+    recipe_old = str(recipe_manager)
 
     recipe_manager = ScheduledModifierManager.from_yaml(file_path=recipe_old)
-    recipe_manager.save(recipe_path)
-    with open(recipe_path, "r") as file:
-        recipe = file.read()
+    recipe = str(recipe_manager)
 
     assert recipe_old == recipe
 


### PR DESCRIPTION
Tests related to https://github.com/neuralmagic/sparseml/pull/660.

Asserting that:

1. While Rahul's fix corrects the behavior of function `metadata_to_string_lines` in `optim/manager.py` for an unstaged recipe, I am making sure that the logic is foolproof for staged recipes.
2. Once we take a recipe without metadata (staged or non-staged) and save it using `manager.save()`, the resulting YAML file can be once again correctly digestible when reused. I was mostly concerned about what happens if we consume a recipe with `__metadata__:   <empty> `. Fortunately, it is being parsed correctly.

- [x] use str(manager) instead of saving recipes across all metadata tests