### PR TITLE
Quantization refactor

### DIFF
--- a/sandbox/quantization_recipe.yaml
+++ b/sandbox/quantization_recipe.yaml
@@ -1,0 +1,7 @@
+quantization_modifiers:
+  - !QuantizationModifier
+    start_epoch: -1.0
+    model_fuse_fn_name: no_fuse
+    submodules:
+      - input
+      - sections

--- a/sandbox/quantization_test.py
+++ b/sandbox/quantization_test.py
@@ -1,0 +1,23 @@
+import torch
+from sparseml.pytorch.utils import ModuleExporter
+from sparseml.pytorch.models import ModelRegistry
+from sparseml.pytorch.optim import ScheduledModifierManager
+
+model = ModelRegistry.create(
+    key='resnet50',
+    pretrained=False,
+    pretrained_dataset="imagenet",
+    num_classes=1000
+)
+
+
+ScheduledModifierManager.from_yaml("quantization_recipe.yaml").apply(model, epoch=float("inf"))
+
+print(model)
+
+exporter = ModuleExporter(model, ".")
+exporter.export_onnx(
+    torch.randn(1, 3, 224, 224),
+    "quantized_test.onnx",
+    convert_qat=False,
+)

--- a/src/sparseml/pytorch/models/classification/resnet.py
+++ b/src/sparseml/pytorch/models/classification/resnet.py
@@ -140,14 +140,14 @@ class _IdentityModifier(Module):
 
 
 class _AddReLU(Module):
-    def __init__(self, num_channels):
+    def __init__(self):
         super().__init__()
         if FloatFunctional:
             self.functional = FloatFunctional()
             self.wrap_qat = True
             self.qat_wrapper_kwargs = {'num_inputs': 1, 'num_outputs': 0}
         else:
-            self.functional = ReLU(num_channels=num_channels, inplace=True)
+            self.functional = ReLU(num_channels=out_channels, inplace=True)
 
     def forward(self, x, y):
         if isinstance(self.functional, FloatFunctional):
@@ -179,7 +179,7 @@ class _BasicBlock(Module):
             else None
         )
 
-        self.add_relu = _AddReLU(out_channels)
+        self.add_relu = _AddReLU()
 
         self.initialize()
 
@@ -236,7 +236,7 @@ class _BottleneckBlock(Module):
             else None
         )
 
-        self.add_relu = _AddReLU(out_channels)
+        self.add_relu = _AddReLU()
 
         self.initialize()
 

--- a/src/sparseml/pytorch/models/classification/resnet.py
+++ b/src/sparseml/pytorch/models/classification/resnet.py
@@ -41,7 +41,6 @@ from torch.nn import (
 from sparseml.pytorch.models.registry import ModelRegistry
 from sparseml.pytorch.nn import ReLU
 
-
 try:
     from torch.nn.quantized import FloatFunctional
 except Exception:
@@ -146,7 +145,7 @@ class _AddReLU(Module):
         if FloatFunctional:
             self.functional = FloatFunctional()
             self.wrap_qat = True
-            self.qat_wrapper_kwargs = {"num_inputs": 1, "num_outputs": 0}
+            self.qat_wrapper_kwargs = {'num_inputs': 1, 'num_outputs': 0}
         else:
             self.functional = ReLU(num_channels=num_channels, inplace=True)
 
@@ -206,12 +205,12 @@ class _BasicBlock(Module):
 
 class _BottleneckBlock(Module):
     def __init__(
-        self,
-        in_channels: int,
-        out_channels: int,
-        proj_channels: int,
-        stride: int = 1,
-        groups: int = 1,
+            self,
+            in_channels: int,
+            out_channels: int,
+            proj_channels: int,
+            stride: int = 1,
+            groups: int = 1,
     ):
         super().__init__()
 
@@ -322,12 +321,12 @@ class _BasicBlockV2(Module):
 
 class _BottleneckBlockV2(Module):
     def __init__(
-        self,
-        in_channels: int,
-        out_channels: int,
-        proj_channels: int,
-        stride: int = 1,
-        groups: int = 1,
+            self,
+            in_channels: int,
+            out_channels: int,
+            proj_channels: int,
+            stride: int = 1,
+            groups: int = 1,
     ):
         super().__init__()
 
@@ -438,15 +437,15 @@ class ResNetSectionSettings(object):
     """
 
     def __init__(
-        self,
-        num_blocks: int,
-        in_channels: int,
-        out_channels: int,
-        downsample: bool,
-        proj_channels: int = -1,
-        groups: int = 1,
-        use_se: bool = False,
-        version: int = 1,
+            self,
+            num_blocks: int,
+            in_channels: int,
+            out_channels: int,
+            downsample: bool,
+            proj_channels: int = -1,
+            groups: int = 1,
+            use_se: bool = False,
+            version: int = 1,
     ):
         if use_se:
             # TODO: add support for squeeze excite
@@ -480,10 +479,10 @@ class ResNet(Module):
     """
 
     def __init__(
-        self,
-        sec_settings: List[ResNetSectionSettings],
-        num_classes: int,
-        class_type: str,
+            self,
+            sec_settings: List[ResNetSectionSettings],
+            num_classes: int,
+            class_type: str,
     ):
         super().__init__()
         self.input = _Input()

--- a/src/sparseml/pytorch/models/classification/resnet.py
+++ b/src/sparseml/pytorch/models/classification/resnet.py
@@ -41,6 +41,7 @@ from torch.nn import (
 from sparseml.pytorch.models.registry import ModelRegistry
 from sparseml.pytorch.nn import ReLU
 
+
 try:
     from torch.nn.quantized import FloatFunctional
 except Exception:
@@ -144,12 +145,13 @@ class _AddReLU(Module):
     Wrapper for the FloatFunctional class that enables QATWrapper used to
     quantize the first input to the Add operation
     """
+
     def __init__(self, num_channels):
         super().__init__()
         if FloatFunctional:
             self.functional = FloatFunctional()
             self.wrap_qat = True
-            self.qat_wrapper_kwargs = {'num_inputs': 1, 'num_outputs': 0}
+            self.qat_wrapper_kwargs = {"num_inputs": 1, "num_outputs": 0}
         else:
             self.functional = ReLU(num_channels=num_channels, inplace=True)
 
@@ -209,12 +211,12 @@ class _BasicBlock(Module):
 
 class _BottleneckBlock(Module):
     def __init__(
-            self,
-            in_channels: int,
-            out_channels: int,
-            proj_channels: int,
-            stride: int = 1,
-            groups: int = 1,
+        self,
+        in_channels: int,
+        out_channels: int,
+        proj_channels: int,
+        stride: int = 1,
+        groups: int = 1,
     ):
         super().__init__()
 
@@ -325,12 +327,12 @@ class _BasicBlockV2(Module):
 
 class _BottleneckBlockV2(Module):
     def __init__(
-            self,
-            in_channels: int,
-            out_channels: int,
-            proj_channels: int,
-            stride: int = 1,
-            groups: int = 1,
+        self,
+        in_channels: int,
+        out_channels: int,
+        proj_channels: int,
+        stride: int = 1,
+        groups: int = 1,
     ):
         super().__init__()
 
@@ -441,15 +443,15 @@ class ResNetSectionSettings(object):
     """
 
     def __init__(
-            self,
-            num_blocks: int,
-            in_channels: int,
-            out_channels: int,
-            downsample: bool,
-            proj_channels: int = -1,
-            groups: int = 1,
-            use_se: bool = False,
-            version: int = 1,
+        self,
+        num_blocks: int,
+        in_channels: int,
+        out_channels: int,
+        downsample: bool,
+        proj_channels: int = -1,
+        groups: int = 1,
+        use_se: bool = False,
+        version: int = 1,
     ):
         if use_se:
             # TODO: add support for squeeze excite
@@ -483,10 +485,10 @@ class ResNet(Module):
     """
 
     def __init__(
-            self,
-            sec_settings: List[ResNetSectionSettings],
-            num_classes: int,
-            class_type: str,
+        self,
+        sec_settings: List[ResNetSectionSettings],
+        num_classes: int,
+        class_type: str,
     ):
         super().__init__()
         self.input = _Input()

--- a/src/sparseml/pytorch/models/classification/resnet.py
+++ b/src/sparseml/pytorch/models/classification/resnet.py
@@ -140,6 +140,10 @@ class _IdentityModifier(Module):
 
 
 class _AddReLU(Module):
+    """
+    Wrapper for the FloatFunctional class that enables QATWrapper used to
+    quantize the first input to the Add operation
+    """
     def __init__(self, num_channels):
         super().__init__()
         if FloatFunctional:

--- a/src/sparseml/pytorch/models/classification/resnet.py
+++ b/src/sparseml/pytorch/models/classification/resnet.py
@@ -41,7 +41,6 @@ from torch.nn import (
 from sparseml.pytorch.models.registry import ModelRegistry
 from sparseml.pytorch.nn import ReLU
 
-
 try:
     from torch.nn.quantized import FloatFunctional
 except Exception:
@@ -141,19 +140,14 @@ class _IdentityModifier(Module):
 
 
 class _AddReLU(Module):
-    """
-    Wrapper for the FloatFunctional class that enables QATWrapper used to
-    quantize the first input to the Add operation
-    """
-
-    def __init__(self, num_channels):
+    def __init__(self):
         super().__init__()
         if FloatFunctional:
             self.functional = FloatFunctional()
             self.wrap_qat = True
-            self.qat_wrapper_kwargs = {"num_inputs": 1, "num_outputs": 0}
+            self.qat_wrapper_kwargs = {'num_inputs': 1, 'num_outputs': 0}
         else:
-            self.functional = ReLU(num_channels=num_channels, inplace=True)
+            self.functional = ReLU(num_channels=out_channels, inplace=True)
 
     def forward(self, x, y):
         if isinstance(self.functional, FloatFunctional):
@@ -185,7 +179,7 @@ class _BasicBlock(Module):
             else None
         )
 
-        self.add_relu = _AddReLU(out_channels)
+        self.add_relu = _AddReLU()
 
         self.initialize()
 
@@ -211,12 +205,12 @@ class _BasicBlock(Module):
 
 class _BottleneckBlock(Module):
     def __init__(
-        self,
-        in_channels: int,
-        out_channels: int,
-        proj_channels: int,
-        stride: int = 1,
-        groups: int = 1,
+            self,
+            in_channels: int,
+            out_channels: int,
+            proj_channels: int,
+            stride: int = 1,
+            groups: int = 1,
     ):
         super().__init__()
 
@@ -242,7 +236,7 @@ class _BottleneckBlock(Module):
             else None
         )
 
-        self.add_relu = _AddReLU(out_channels)
+        self.add_relu = _AddReLU()
 
         self.initialize()
 
@@ -327,12 +321,12 @@ class _BasicBlockV2(Module):
 
 class _BottleneckBlockV2(Module):
     def __init__(
-        self,
-        in_channels: int,
-        out_channels: int,
-        proj_channels: int,
-        stride: int = 1,
-        groups: int = 1,
+            self,
+            in_channels: int,
+            out_channels: int,
+            proj_channels: int,
+            stride: int = 1,
+            groups: int = 1,
     ):
         super().__init__()
 
@@ -443,15 +437,15 @@ class ResNetSectionSettings(object):
     """
 
     def __init__(
-        self,
-        num_blocks: int,
-        in_channels: int,
-        out_channels: int,
-        downsample: bool,
-        proj_channels: int = -1,
-        groups: int = 1,
-        use_se: bool = False,
-        version: int = 1,
+            self,
+            num_blocks: int,
+            in_channels: int,
+            out_channels: int,
+            downsample: bool,
+            proj_channels: int = -1,
+            groups: int = 1,
+            use_se: bool = False,
+            version: int = 1,
     ):
         if use_se:
             # TODO: add support for squeeze excite
@@ -485,10 +479,10 @@ class ResNet(Module):
     """
 
     def __init__(
-        self,
-        sec_settings: List[ResNetSectionSettings],
-        num_classes: int,
-        class_type: str,
+            self,
+            sec_settings: List[ResNetSectionSettings],
+            num_classes: int,
+            class_type: str,
     ):
         super().__init__()
         self.input = _Input()

--- a/src/sparseml/pytorch/models/classification/resnet.py
+++ b/src/sparseml/pytorch/models/classification/resnet.py
@@ -41,6 +41,7 @@ from torch.nn import (
 from sparseml.pytorch.models.registry import ModelRegistry
 from sparseml.pytorch.nn import ReLU
 
+
 try:
     from torch.nn.quantized import FloatFunctional
 except Exception:
@@ -140,14 +141,14 @@ class _IdentityModifier(Module):
 
 
 class _AddReLU(Module):
-    def __init__(self):
+    def __init__(self, num_channels):
         super().__init__()
         if FloatFunctional:
             self.functional = FloatFunctional()
             self.wrap_qat = True
-            self.qat_wrapper_kwargs = {'num_inputs': 1, 'num_outputs': 0}
+            self.qat_wrapper_kwargs = {"num_inputs": 1, "num_outputs": 0}
         else:
-            self.functional = ReLU(num_channels=out_channels, inplace=True)
+            self.functional = ReLU(num_channels=num_channels, inplace=True)
 
     def forward(self, x, y):
         if isinstance(self.functional, FloatFunctional):
@@ -179,7 +180,7 @@ class _BasicBlock(Module):
             else None
         )
 
-        self.add_relu = _AddReLU()
+        self.add_relu = _AddReLU(out_channels)
 
         self.initialize()
 
@@ -205,12 +206,12 @@ class _BasicBlock(Module):
 
 class _BottleneckBlock(Module):
     def __init__(
-            self,
-            in_channels: int,
-            out_channels: int,
-            proj_channels: int,
-            stride: int = 1,
-            groups: int = 1,
+        self,
+        in_channels: int,
+        out_channels: int,
+        proj_channels: int,
+        stride: int = 1,
+        groups: int = 1,
     ):
         super().__init__()
 
@@ -236,7 +237,7 @@ class _BottleneckBlock(Module):
             else None
         )
 
-        self.add_relu = _AddReLU()
+        self.add_relu = _AddReLU(out_channels)
 
         self.initialize()
 
@@ -321,12 +322,12 @@ class _BasicBlockV2(Module):
 
 class _BottleneckBlockV2(Module):
     def __init__(
-            self,
-            in_channels: int,
-            out_channels: int,
-            proj_channels: int,
-            stride: int = 1,
-            groups: int = 1,
+        self,
+        in_channels: int,
+        out_channels: int,
+        proj_channels: int,
+        stride: int = 1,
+        groups: int = 1,
     ):
         super().__init__()
 
@@ -437,15 +438,15 @@ class ResNetSectionSettings(object):
     """
 
     def __init__(
-            self,
-            num_blocks: int,
-            in_channels: int,
-            out_channels: int,
-            downsample: bool,
-            proj_channels: int = -1,
-            groups: int = 1,
-            use_se: bool = False,
-            version: int = 1,
+        self,
+        num_blocks: int,
+        in_channels: int,
+        out_channels: int,
+        downsample: bool,
+        proj_channels: int = -1,
+        groups: int = 1,
+        use_se: bool = False,
+        version: int = 1,
     ):
         if use_se:
             # TODO: add support for squeeze excite
@@ -479,10 +480,10 @@ class ResNet(Module):
     """
 
     def __init__(
-            self,
-            sec_settings: List[ResNetSectionSettings],
-            num_classes: int,
-            class_type: str,
+        self,
+        sec_settings: List[ResNetSectionSettings],
+        num_classes: int,
+        class_type: str,
     ):
         super().__init__()
         self.input = _Input()

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -106,7 +106,7 @@ class BNWrapper(Module):
 
     def train(self, mode=True):
         if not self.freeze_bn:
-            self.bn.train()
+            self.bn.train(mode)
         return self
 
     def update_bn_stats(self):

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Embedding, Module, ReLU
 
+
 try:
     import torch.nn.intrinsic as nni
     from torch import quantization as torch_quantization
@@ -30,6 +31,7 @@ except Exception:
     torch_quantization = None
 
 from sparseml.pytorch.nn import ReLU as ReLU_nm
+
 
 __all__ = [
     "QATWrapper",
@@ -69,7 +71,7 @@ _QUANTIZABLE_MODULE_TYPES = (
     else None
 )
 
-#
+
 class BNWrapper(Module):
     """
     Wraps BatchNormalization module to expose methods needed to enable
@@ -77,6 +79,7 @@ class BNWrapper(Module):
 
     :param module: BatchNormalization module to be wrapped
     """
+
     def __init__(self, module: Module):
         super().__init__()
         self.bn = module
@@ -213,16 +216,16 @@ class QATWrapper(Module):
 
     @staticmethod
     def from_module(
-            module: Module,
-            symmetric_activations: Optional[bool] = None,
-            symmetric_weights: Optional[bool] = None,
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
-            activation_dtype: Optional[torch.dtype] = None,
-            weight_dtype: Optional[torch.dtype] = None,
-            activation_bits: Optional[int] = None,
-            weight_bits: Optional[int] = None,
+        module: Module,
+        symmetric_activations: Optional[bool] = None,
+        symmetric_weights: Optional[bool] = None,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
+        activation_dtype: Optional[torch.dtype] = None,
+        weight_dtype: Optional[torch.dtype] = None,
+        activation_bits: Optional[int] = None,
+        weight_bits: Optional[int] = None,
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for
@@ -241,8 +244,10 @@ class QATWrapper(Module):
             activations.
         :param weight_qconfig_kwargs: Additional kwargs for quantization of
             weights.
-        :param activation_dtype: quantized activation data type. Default is torch.quint8.
-        :param weight_dtype: quantized weights data type. Default is torch.qint8.
+        :param activation_dtype: quantized activation data type.
+            Default is torch.quint8.
+        :param weight_dtype: quantized weights data type.
+            Default is torch.qint8.
         :param activation_bits: number of bits for activations. Default is 8.
         :param weight_bits: number of bits for weights. Default is 8.
         :return: QATWrapper object created using the given Module as the forward
@@ -277,7 +282,7 @@ class QATWrapper(Module):
             activation_qconfig_kwargs
             if "activation_qconfig_kwargs" not in qat_wrapper_kwargs
             else activation_qconfig_kwargs
-                 or qat_wrapper_kwargs["activation_qconfig_kwargs"]
+            or qat_wrapper_kwargs["activation_qconfig_kwargs"]
         )
 
         qat_wrapper_kwargs["weight_qconfig_kwargs"] = (
@@ -315,26 +320,26 @@ class QATWrapper(Module):
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
     def __init__(
-            self,
-            forward_fn: Callable[[Any], Any],
-            num_inputs: int = 1,
-            kwarg_input_names: List[str] = None,
-            num_outputs: int = 1,
-            input_qconfigs: Union[
-                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-            ] = "asymmetric",
-            output_qconfigs: Union[
-                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-            ] = "asymmetric",
-            symmetric_activations: Optional[bool] = None,
-            symmetric_weights: Optional[bool] = None,
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
-            activation_dtype: Optional[torch.dtype] = None,
-            weight_dtype: Optional[torch.dtype] = None,
-            activation_bits: Optional[int] = None,
-            weight_bits: Optional[int] = None,
+        self,
+        forward_fn: Callable[[Any], Any],
+        num_inputs: int = 1,
+        kwarg_input_names: List[str] = None,
+        num_outputs: int = 1,
+        input_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        output_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        symmetric_activations: Optional[bool] = None,
+        symmetric_weights: Optional[bool] = None,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
+        activation_dtype: Optional[torch.dtype] = None,
+        weight_dtype: Optional[torch.dtype] = None,
+        activation_bits: Optional[int] = None,
+        weight_bits: Optional[int] = None,
     ):
         super().__init__()
 
@@ -471,18 +476,18 @@ class QATWrapper(Module):
 
     @staticmethod
     def _load_qconfigs(
-            name: str,
-            expected_len: int,
-            qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
-            symmetric_activations: Optional[bool] = None,
-            symmetric_weights: Optional[bool] = None,
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
-            activation_dtype: Optional[torch.dtype] = None,
-            weight_dtype: Optional[torch.dtype] = None,
-            activation_bits: Optional[int] = None,
-            weight_bits: Optional[int] = None,
+        name: str,
+        expected_len: int,
+        qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
+        symmetric_activations: Optional[bool] = None,
+        symmetric_weights: Optional[bool] = None,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
+        activation_dtype: Optional[torch.dtype] = None,
+        weight_dtype: Optional[torch.dtype] = None,
+        activation_bits: Optional[int] = None,
+        weight_bits: Optional[int] = None,
     ):
         if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
             raise ValueError(
@@ -540,29 +545,29 @@ def configure_module_bn_wrappers(module: Module):
     :param module: module to potentially wrap the submodules of
     """
     # wrap any children of the given module as a QATWrapper if required
-    if not hasattr(module, 'freeze_bn_stats'):
+    if not hasattr(module, "freeze_bn_stats"):
         for child_name, child_module in module.named_children():
-            if type(child_module) in [torch.nn.BatchNorm1d, torch.nn.BatchNorm2d, torch.nn.BatchNorm3d]:
-                setattr(
-                    module,
-                    child_name,
-                    BNWrapper(child_module)
-                )
+            if type(child_module) in [
+                torch.nn.BatchNorm1d,
+                torch.nn.BatchNorm2d,
+                torch.nn.BatchNorm3d,
+            ]:
+                setattr(module, child_name, BNWrapper(child_module))
             # recurse on child module
             configure_module_bn_wrappers(child_module)
 
 
 def configure_module_qat_wrappers(
-        module: Module,
-        symmetric_activations: Optional[bool] = None,
-        symmetric_weights: Optional[bool] = None,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
-        activation_dtype: Optional[torch.dtype] = None,
-        weight_dtype: Optional[torch.dtype] = None,
-        activation_bits: Optional[int] = None,
-        weight_bits: Optional[int] = None,
+    module: Module,
+    symmetric_activations: Optional[bool] = None,
+    symmetric_weights: Optional[bool] = None,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Dict[str, Any] = {},
+    weight_qconfig_kwargs: Dict[str, Any] = {},
+    activation_dtype: Optional[torch.dtype] = None,
+    weight_dtype: Optional[torch.dtype] = None,
+    activation_bits: Optional[int] = None,
+    weight_bits: Optional[int] = None,
 ):
     """
     if any submodule of the given module has the attribute wrap_qat == True,
@@ -589,7 +594,7 @@ def configure_module_qat_wrappers(
     :param activation_dtype: quantized activation data type. Default is torch.quint8.
     :param weight_dtype: quantized weights data type. Default is torch.qint8.
     :param activation_bits: number of bits for activations. Default is 8.
-    :param weight_bits: number of bits for weights. Default is 8.    """
+    :param weight_bits: number of bits for weights. Default is 8."""
     # wrap any children of the given module as a QATWrapper if required
     for child_name, child_module in module.named_children():
         if hasattr(child_module, "wrap_qat") and child_module.wrap_qat:
@@ -654,7 +659,7 @@ def configure_module_default_qconfigs(module: Module):
     """
     for submodule in module.modules():
         if hasattr(submodule, "configure_qconfig") and callable(
-                getattr(submodule, "configure_qconfig")
+            getattr(submodule, "configure_qconfig")
         ):
             submodule.configure_qconfig()
 
@@ -669,9 +674,9 @@ def add_quant_dequant(module, name=None, parent_module=None):
     """
     named_children = module.named_children()
     if (
-            type(module) in _QUANTIZABLE_MODULE_TYPES
-            and hasattr(module, "qconfig")
-            and module.qconfig
+        type(module) in _QUANTIZABLE_MODULE_TYPES
+        and hasattr(module, "qconfig")
+        and module.qconfig
     ):
         if parent_module is not None and len(list(named_children)) <= 0:
             module = torch_quantization.QuantWrapper(module)
@@ -695,7 +700,7 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
     """
     for submodule in module.modules():
         if submodule.__class__.__name__ in layer_class_names and hasattr(
-                submodule, "qconfig"
+            submodule, "qconfig"
         ):
             submodule.qconfig = torch_quantization.QConfig(
                 activation=torch.nn.Identity,
@@ -704,15 +709,15 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
 
 
 def get_qat_qconfig(
-        symmetric_activations: Optional[bool] = None,
-        symmetric_weights: Optional[bool] = None,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-        weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-        activation_dtype: Optional[torch.dtype] = None,
-        weight_dtype: Optional[torch.dtype] = None,
-        activation_bits: Optional[int] = None,
-        weight_bits: Optional[int] = None,
+    symmetric_activations: Optional[bool] = None,
+    symmetric_weights: Optional[bool] = None,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    activation_dtype: Optional[torch.dtype] = None,
+    weight_dtype: Optional[torch.dtype] = None,
+    activation_bits: Optional[int] = None,
+    weight_bits: Optional[int] = None,
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
@@ -739,8 +744,13 @@ def get_qat_qconfig(
         torch.quantization.default_qat_qconfig is that the activation observer
         will not have reduce_range enabled.
     """
-    activation_observer = get_observer(symmetric_activations, activation_dtype, activation_bits, reduce_range,
-                                       activation_qconfig_kwargs)
+    activation_observer = get_observer(
+        symmetric_activations,
+        activation_dtype,
+        activation_bits,
+        reduce_range,
+        activation_qconfig_kwargs,
+    )
     if symmetric_weights is None:
         _symmetric_weights = True
     else:
@@ -751,17 +761,23 @@ def get_qat_qconfig(
     else:
         _weight_dtype = weight_dtype
 
-    weight_observer = get_observer(_symmetric_weights, _weight_dtype, weight_bits, False, weight_qconfig_kwargs)
+    weight_observer = get_observer(
+        _symmetric_weights, _weight_dtype, weight_bits, False, weight_qconfig_kwargs
+    )
     return torch_quantization.QConfig(
         activation=activation_observer,
         weight=weight_observer,
     )
 
 
-def get_observer(symmetric: Optional[bool], dtype: Optional[torch.dtype], bits: Optional[int], reduce_range: bool, qconfig_kwargs: Dict[str, Any]):
-    qscheme = (
-        torch.per_tensor_symmetric if symmetric else torch.per_tensor_affine
-    )
+def get_observer(
+    symmetric: Optional[bool],
+    dtype: Optional[torch.dtype],
+    bits: Optional[int],
+    reduce_range: bool,
+    qconfig_kwargs: Dict[str, Any],
+):
+    qscheme = torch.per_tensor_symmetric if symmetric else torch.per_tensor_affine
     quant_min, quant_max, dtype = compute_range(dtype, bits)
     observer_kwargs = dict(
         observer=torch_quantization.MovingAverageMinMaxObserver,
@@ -793,7 +809,7 @@ def fix_observer_quant_range(module: Module):
         if isinstance(submodule, torch_quantization.FakeQuantize):
             fake_quantize = submodule
         elif hasattr(submodule, "activation_post_process") and isinstance(
-                submodule.activation_post_process, torch_quantization.FakeQuantize
+            submodule.activation_post_process, torch_quantization.FakeQuantize
         ):
             fake_quantize = submodule.activation_post_process
         else:
@@ -813,14 +829,14 @@ def fix_observer_quant_range(module: Module):
 
 
 def freeze_bn_stats(module: Module):
-    if hasattr(module, 'freeze_bn_stats'):
+    if hasattr(module, "freeze_bn_stats"):
         module.freeze_bn_stats()
 
 
 def fuse_module_conv_bn_relus(
-        module: Module,
-        inplace: bool = True,
-        override_bn_subclasses_forward: Union[bool, str] = True,
+    module: Module,
+    inplace: bool = True,
+    override_bn_subclasses_forward: Union[bool, str] = True,
 ) -> Module:
     """
     Performs fusion of Conv2d, BatchNorm2d, and ReLU layers found in the
@@ -855,14 +871,14 @@ def fuse_module_conv_bn_relus(
     for name, layer in module.named_modules():
         submodule_name = ".".join(name.split(".")[:-1])
         if (
-                len(current_block) == 1  # [Conv2d]
-                and isinstance(layer, BatchNorm2d)
-                and submodule_name == current_block_submodule_name
+            len(current_block) == 1  # [Conv2d]
+            and isinstance(layer, BatchNorm2d)
+            and submodule_name == current_block_submodule_name
         ) or (
-                len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
-                and isinstance(layer, ReLU)
-                and not isinstance(current_block[-1], ReLU)
-                and submodule_name == current_block_submodule_name
+            len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
+            and isinstance(layer, ReLU)
+            and not isinstance(current_block[-1], ReLU)
+            and submodule_name == current_block_submodule_name
         ):
             if isinstance(layer, ReLU_nm):
                 _set_submodule(module, name, ReLU(inplace=layer.inplace))
@@ -899,17 +915,17 @@ def fuse_module_conv_bn_relus(
 
 
 def prepare_embeddings_qat(
-        module: Module,
-        qconfig: "torch.quantization.QConfig" = None,
-        symmetric_activations: Optional[bool] = None,
-        symmetric_weights: Optional[bool] = None,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-        weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-        activation_dtype: Optional[torch.dtype] = None,
-        weight_dtype: Optional[torch.dtype] = None,
-        activation_bits: Optional[int] = None,
-        weight_bits: Optional[int] = None,
+    module: Module,
+    qconfig: "torch.quantization.QConfig" = None,
+    symmetric_activations: Optional[bool] = None,
+    symmetric_weights: Optional[bool] = None,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    activation_dtype: Optional[torch.dtype] = None,
+    weight_dtype: Optional[torch.dtype] = None,
+    activation_bits: Optional[int] = None,
+    weight_bits: Optional[int] = None,
 ):
     """
     adds a fake quantize call to the weights of any Embedding modules in the given
@@ -936,7 +952,7 @@ def prepare_embeddings_qat(
     :param activation_dtype: quantized activation data type. Default is torch.quint8.
     :param weight_dtype: quantized weights data type. Default is torch.qint8.
     :param activation_bits: number of bits for activations. Default is 8.
-    :param weight_bits: number of bits for weights. Default is 8.    """
+    :param weight_bits: number of bits for weights. Default is 8."""
     if qconfig is None:
         if symmetric_weights is None:
             _symmetric_weights = False
@@ -960,24 +976,17 @@ def prepare_embeddings_qat(
 
 
 def get_updated_qconfig_kwargs(qconfig_kwargs, bits, mode):
-    qconfig_kwargs = (
-        qconfig_kwargs.copy()
-        if qconfig_kwargs
-        else {}
-    )
+    qconfig_kwargs = qconfig_kwargs.copy() if qconfig_kwargs else {}
 
     # update qconfig_kwargs for bits
-    if bits and (
-            qconfig_kwargs.get("quant_min")
-            or qconfig_kwargs.get("quant_max")
-    ):
+    if bits and (qconfig_kwargs.get("quant_min") or qconfig_kwargs.get("quant_max")):
         raise ValueError(
             "Cannot override quant_max and quant_min when number of bits is set"
         )
 
     if bits:
         if mode == "symmetric":
-            quant_min = -2 ** (bits - 1)
+            quant_min = -(2 ** (bits - 1))
             quant_max = 2 ** (bits - 1) - 1
             dtype = torch.qint8
         else:

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -22,7 +22,6 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Embedding, Module, ReLU
 
-
 try:
     import torch.nn.intrinsic as nni
     from torch import quantization as torch_quantization
@@ -32,16 +31,17 @@ except Exception:
 
 from sparseml.pytorch.nn import ReLU as ReLU_nm
 
-
 __all__ = [
     "QATWrapper",
-    "configure_module_qat_wrappers",
+    "configure_module_bn_wrappers",
     "configure_module_default_qconfigs",
+    "configure_module_qat_wrappers",
     "add_quant_dequant",
     "remove_activation_qat_by_layer_name",
     "get_qat_qconfig",
     "get_updated_qconfig_kwargs",
     "fix_observer_quant_range",
+    "freeze_bn_stats",
     "fuse_module_conv_bn_relus",
     "prepare_embeddings_qat",
 ]
@@ -68,6 +68,54 @@ _QUANTIZABLE_MODULE_TYPES = (
     if nni  # nni will always import if torch.quantization is available
     else None
 )
+
+_BN_MODULE_TYPES = (
+    {
+        # Conv based layers
+        nni.ConvBn1d,
+        nni.ConvBn2d,
+        nni.ConvBn3d,
+        nni.ConvReLU1d,
+        nni.ConvReLU2d,
+        nni.ConvReLU3d,
+        nni.ConvBnReLU1d,
+        nni.ConvBnReLU2d,
+        nni.ConvBnReLU3d,
+    }
+    if nni  # nni will always import if torch.quantization is available
+    else {}
+)
+
+
+class BNWrapper(Module):
+    def __init__(self, module: Module):
+        super().__init__()
+        self.bn = module
+        self.freeze_bn = False
+
+    def forward(self, x):
+        return self.bn(x)
+
+    def freeze_bn_stats(self):
+        self.freeze_bn = True
+        self.bn.training = False
+        return self
+
+    def reset_running_stats(self):
+        self.bn.reset_running_stats()
+
+    def train(self, mode=True):
+        if not self.freeze_bn:
+            self.bn.train()
+        return self
+
+    def update_bn_stats(self):
+        self.freeze_bn = False
+        self.bn.training = True
+        return self
+
+
+_BN_MODULE_TYPES.add(BNWrapper)
 
 
 class QATWrapper(Module):
@@ -107,10 +155,10 @@ class QATWrapper(Module):
 
     @staticmethod
     def from_module(
-        module: Module,
-        reduce_range: bool = None,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+            module: Module,
+            reduce_range: bool = None,
+            activation_qconfig_kwargs: Dict[str, Any] = {},
+            weight_qconfig_kwargs: Dict[str, Any] = {},
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for
@@ -142,7 +190,7 @@ class QATWrapper(Module):
             activation_qconfig_kwargs
             if "activation_qconfig_kwargs" not in qat_wrapper_kwargs
             else activation_qconfig_kwargs
-            or qat_wrapper_kwargs["activation_qconfig_kwargs"]
+                 or qat_wrapper_kwargs["activation_qconfig_kwargs"]
         )
 
         qat_wrapper_kwargs["weight_qconfig_kwargs"] = (
@@ -155,20 +203,20 @@ class QATWrapper(Module):
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
     def __init__(
-        self,
-        forward_fn: Callable[[Any], Any],
-        num_inputs: int = 1,
-        kwarg_input_names: List[str] = None,
-        num_outputs: int = 1,
-        input_qconfigs: Union[
-            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-        ] = "asymmetric",
-        output_qconfigs: Union[
-            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-        ] = "asymmetric",
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+            self,
+            forward_fn: Callable[[Any], Any],
+            num_inputs: int = 1,
+            kwarg_input_names: List[str] = None,
+            num_outputs: int = 1,
+            input_qconfigs: Union[
+                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+            ] = "asymmetric",
+            output_qconfigs: Union[
+                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+            ] = "asymmetric",
+            reduce_range: bool = False,
+            activation_qconfig_kwargs: Dict[str, Any] = {},
+            weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         super().__init__()
 
@@ -287,12 +335,12 @@ class QATWrapper(Module):
 
     @staticmethod
     def _load_qconfigs(
-        name: str,
-        expected_len: int,
-        qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+            name: str,
+            expected_len: int,
+            qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
+            reduce_range: bool = False,
+            activation_qconfig_kwargs: Dict[str, Any] = {},
+            weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
             raise ValueError(
@@ -332,11 +380,40 @@ class QATWrapper(Module):
         return qconfigs
 
 
+def configure_module_bn_wrappers(module: Module):
+    """
+    if any submodule of the given module has the attribute wrap_qat == True,
+    then it will be replaced by a QATWrapper of it created by QATWrapper.from_module.
+    Other named kwargs to the QATWrapper constructor must be contained in a dictionary
+    under an attributed named `qat_wrapper_kwargs`
+
+    :param module: module to potentially wrap the submodules of
+    :param reduce_range: if True, the quantization range will be reduced by one bit.
+        This may prevent overflow issues with model execution on certain hardware
+        Default is False
+    :param activation_qconfig_kwargs: Additional kwargs for quantization of
+            activations. Default is {}
+    :param weight_qconfig_kwargs: Additional kwargs for quantization of
+            weights. Default is {}
+    """
+    # wrap any children of the given module as a QATWrapper if required
+    if type(module) != BNWrapper:
+        for child_name, child_module in module.named_children():
+            if type(child_module) in [torch.nn.BatchNorm1d, torch.nn.BatchNorm2d, torch.nn.BatchNorm3d]:
+                setattr(
+                    module,
+                    child_name,
+                    BNWrapper(child_module)
+                )
+            # recurse on child module
+            configure_module_bn_wrappers(child_module)
+
+
 def configure_module_qat_wrappers(
-    module: Module,
-    reduce_range: bool = False,
-    activation_qconfig_kwargs: Dict[str, Any] = {},
-    weight_qconfig_kwargs: Dict[str, Any] = {},
+        module: Module,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     if any submodule of the given module has the attribute wrap_qat == True,
@@ -385,7 +462,7 @@ def configure_module_default_qconfigs(module: Module):
     """
     for submodule in module.modules():
         if hasattr(submodule, "configure_qconfig") and callable(
-            getattr(submodule, "configure_qconfig")
+                getattr(submodule, "configure_qconfig")
         ):
             submodule.configure_qconfig()
 
@@ -400,9 +477,9 @@ def add_quant_dequant(module, name=None, parent_module=None):
     """
     named_children = module.named_children()
     if (
-        type(module) in _QUANTIZABLE_MODULE_TYPES
-        and hasattr(module, "qconfig")
-        and module.qconfig
+            type(module) in _QUANTIZABLE_MODULE_TYPES
+            and hasattr(module, "qconfig")
+            and module.qconfig
     ):
         if parent_module is not None and len(list(named_children)) <= 0:
             module = torch_quantization.QuantWrapper(module)
@@ -426,7 +503,7 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
     """
     for submodule in module.modules():
         if submodule.__class__.__name__ in layer_class_names and hasattr(
-            submodule, "qconfig"
+                submodule, "qconfig"
         ):
             submodule.qconfig = torch_quantization.QConfig(
                 activation=torch.nn.Identity,
@@ -435,11 +512,11 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
 
 
 def get_qat_qconfig(
-    symmetric_activations: bool = False,
-    symmetric_weights: bool = True,
-    reduce_range: bool = False,
-    activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-    weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+        symmetric_activations: bool = False,
+        symmetric_weights: bool = True,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+        weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
@@ -511,7 +588,7 @@ def fix_observer_quant_range(module: Module):
         if isinstance(submodule, torch_quantization.FakeQuantize):
             fake_quantize = submodule
         elif hasattr(submodule, "activation_post_process") and isinstance(
-            submodule.activation_post_process, torch_quantization.FakeQuantize
+                submodule.activation_post_process, torch_quantization.FakeQuantize
         ):
             fake_quantize = submodule.activation_post_process
         else:
@@ -520,9 +597,9 @@ def fix_observer_quant_range(module: Module):
         # continue if fake_quantize quant range not set, or observer quant range is set
         observer = fake_quantize.activation_post_process
         if (
-            fake_quantize.quant_min is None
-            or fake_quantize.quant_max is None
-            or (observer.quant_min is not None or observer.quant_max is not None)
+                fake_quantize.quant_min is None
+                or fake_quantize.quant_max is None
+                or (observer.quant_min is not None or observer.quant_max is not None)
         ):
             continue
         observer.quant_min = fake_quantize.quant_min
@@ -530,10 +607,15 @@ def fix_observer_quant_range(module: Module):
         observer.has_customized_qrange = True
 
 
+def freeze_bn_stats(module: Module):
+    if type(module) in _BN_MODULE_TYPES:
+        module.freeze_bn_stats()
+
+
 def fuse_module_conv_bn_relus(
-    module: Module,
-    inplace: bool = True,
-    override_bn_subclasses_forward: Union[bool, str] = True,
+        module: Module,
+        inplace: bool = True,
+        override_bn_subclasses_forward: Union[bool, str] = True,
 ) -> Module:
     """
     Performs fusion of Conv2d, BatchNorm2d, and ReLU layers found in the
@@ -568,14 +650,14 @@ def fuse_module_conv_bn_relus(
     for name, layer in module.named_modules():
         submodule_name = ".".join(name.split(".")[:-1])
         if (
-            len(current_block) == 1  # [Conv2d]
-            and isinstance(layer, BatchNorm2d)
-            and submodule_name == current_block_submodule_name
+                len(current_block) == 1  # [Conv2d]
+                and isinstance(layer, BatchNorm2d)
+                and submodule_name == current_block_submodule_name
         ) or (
-            len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
-            and isinstance(layer, ReLU)
-            and not isinstance(current_block[-1], ReLU)
-            and submodule_name == current_block_submodule_name
+                len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
+                and isinstance(layer, ReLU)
+                and not isinstance(current_block[-1], ReLU)
+                and submodule_name == current_block_submodule_name
         ):
             if isinstance(layer, ReLU_nm):
                 _set_submodule(module, name, ReLU(inplace=layer.inplace))
@@ -612,11 +694,11 @@ def fuse_module_conv_bn_relus(
 
 
 def prepare_embeddings_qat(
-    module: Module,
-    qconfig: "torch.quantization.QConfig" = None,
-    reduce_range: bool = False,
-    activation_qconfig_kwargs: Dict[str, Any] = {},
-    weight_qconfig_kwargs: Dict[str, Any] = {},
+        module: Module,
+        qconfig: "torch.quantization.QConfig" = None,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     adds a fake quantize call to the weights of any Embedding modules in the given
@@ -646,10 +728,17 @@ def prepare_embeddings_qat(
 
 
 def get_updated_qconfig_kwargs(qconfig_kwargs, bits):
-    qconfig_kwargs = qconfig_kwargs.copy() if qconfig_kwargs else {}
+    qconfig_kwargs = (
+        qconfig_kwargs.copy()
+        if qconfig_kwargs
+        else {}
+    )
 
     # update qconfig_kwargs for bits
-    if bits and (qconfig_kwargs.get("quant_min") or qconfig_kwargs.get("quant_max")):
+    if bits and (
+            qconfig_kwargs.get("quant_min")
+            or qconfig_kwargs.get("quant_max")
+    ):
         raise ValueError(
             "Cannot override quant_max and quant_min when number of bits is set"
         )

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -32,7 +32,6 @@ except Exception:
 from sparseml.pytorch.nn import ReLU as ReLU_nm
 
 __all__ = [
-    "QUANTIZABLE_MODULE_TYPES",
     "QATWrapper",
     "configure_module_qat_wrappers",
     "configure_module_default_qconfigs",
@@ -45,7 +44,7 @@ __all__ = [
     "prepare_embeddings_qat",
 ]
 
-QUANTIZABLE_MODULE_TYPES = (
+_QUANTIZABLE_MODULE_TYPES = (
     {
         # Conv based layers
         torch.nn.Conv1d,
@@ -150,6 +149,7 @@ class QATWrapper(Module):
             else weight_qconfig_kwargs or qat_wrapper_kwargs["weight_qconfig_kwargs"]
         )
 
+        module.qconfig = None
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
     def __init__(
@@ -398,7 +398,7 @@ def add_quant_dequant(module, name=None, parent_module=None):
     """
     named_children = module.named_children()
     if (
-            type(module) in QUANTIZABLE_MODULE_TYPES
+            type(module) in _QUANTIZABLE_MODULE_TYPES
             and hasattr(module, "qconfig")
             and module.qconfig
     ):

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Embedding, Module, ReLU
 
+
 try:
     import torch.nn.intrinsic as nni
     from torch import quantization as torch_quantization
@@ -30,6 +31,7 @@ except Exception:
     torch_quantization = None
 
 from sparseml.pytorch.nn import ReLU as ReLU_nm
+
 
 __all__ = [
     "QATWrapper",
@@ -105,10 +107,10 @@ class QATWrapper(Module):
 
     @staticmethod
     def from_module(
-            module: Module,
-            reduce_range: bool = None,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        module: Module,
+        reduce_range: bool = None,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for
@@ -140,7 +142,7 @@ class QATWrapper(Module):
             activation_qconfig_kwargs
             if "activation_qconfig_kwargs" not in qat_wrapper_kwargs
             else activation_qconfig_kwargs
-                 or qat_wrapper_kwargs["activation_qconfig_kwargs"]
+            or qat_wrapper_kwargs["activation_qconfig_kwargs"]
         )
 
         qat_wrapper_kwargs["weight_qconfig_kwargs"] = (
@@ -153,20 +155,20 @@ class QATWrapper(Module):
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
     def __init__(
-            self,
-            forward_fn: Callable[[Any], Any],
-            num_inputs: int = 1,
-            kwarg_input_names: List[str] = None,
-            num_outputs: int = 1,
-            input_qconfigs: Union[
-                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-            ] = "asymmetric",
-            output_qconfigs: Union[
-                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-            ] = "asymmetric",
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        self,
+        forward_fn: Callable[[Any], Any],
+        num_inputs: int = 1,
+        kwarg_input_names: List[str] = None,
+        num_outputs: int = 1,
+        input_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        output_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         super().__init__()
 
@@ -285,12 +287,12 @@ class QATWrapper(Module):
 
     @staticmethod
     def _load_qconfigs(
-            name: str,
-            expected_len: int,
-            qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        name: str,
+        expected_len: int,
+        qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
             raise ValueError(
@@ -331,10 +333,10 @@ class QATWrapper(Module):
 
 
 def configure_module_qat_wrappers(
-        module: Module,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+    module: Module,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Dict[str, Any] = {},
+    weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     if any submodule of the given module has the attribute wrap_qat == True,
@@ -383,7 +385,7 @@ def configure_module_default_qconfigs(module: Module):
     """
     for submodule in module.modules():
         if hasattr(submodule, "configure_qconfig") and callable(
-                getattr(submodule, "configure_qconfig")
+            getattr(submodule, "configure_qconfig")
         ):
             submodule.configure_qconfig()
 
@@ -398,9 +400,9 @@ def add_quant_dequant(module, name=None, parent_module=None):
     """
     named_children = module.named_children()
     if (
-            type(module) in _QUANTIZABLE_MODULE_TYPES
-            and hasattr(module, "qconfig")
-            and module.qconfig
+        type(module) in _QUANTIZABLE_MODULE_TYPES
+        and hasattr(module, "qconfig")
+        and module.qconfig
     ):
         if parent_module is not None and len(list(named_children)) <= 0:
             module = torch_quantization.QuantWrapper(module)
@@ -424,7 +426,7 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
     """
     for submodule in module.modules():
         if submodule.__class__.__name__ in layer_class_names and hasattr(
-                submodule, "qconfig"
+            submodule, "qconfig"
         ):
             submodule.qconfig = torch_quantization.QConfig(
                 activation=torch.nn.Identity,
@@ -433,11 +435,11 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
 
 
 def get_qat_qconfig(
-        symmetric_activations: bool = False,
-        symmetric_weights: bool = True,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-        weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    symmetric_activations: bool = False,
+    symmetric_weights: bool = True,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
@@ -509,7 +511,7 @@ def fix_observer_quant_range(module: Module):
         if isinstance(submodule, torch_quantization.FakeQuantize):
             fake_quantize = submodule
         elif hasattr(submodule, "activation_post_process") and isinstance(
-                submodule.activation_post_process, torch_quantization.FakeQuantize
+            submodule.activation_post_process, torch_quantization.FakeQuantize
         ):
             fake_quantize = submodule.activation_post_process
         else:
@@ -518,9 +520,9 @@ def fix_observer_quant_range(module: Module):
         # continue if fake_quantize quant range not set, or observer quant range is set
         observer = fake_quantize.activation_post_process
         if (
-                fake_quantize.quant_min is None
-                or fake_quantize.quant_max is None
-                or (observer.quant_min is not None or observer.quant_max is not None)
+            fake_quantize.quant_min is None
+            or fake_quantize.quant_max is None
+            or (observer.quant_min is not None or observer.quant_max is not None)
         ):
             continue
         observer.quant_min = fake_quantize.quant_min
@@ -529,9 +531,9 @@ def fix_observer_quant_range(module: Module):
 
 
 def fuse_module_conv_bn_relus(
-        module: Module,
-        inplace: bool = True,
-        override_bn_subclasses_forward: Union[bool, str] = True,
+    module: Module,
+    inplace: bool = True,
+    override_bn_subclasses_forward: Union[bool, str] = True,
 ) -> Module:
     """
     Performs fusion of Conv2d, BatchNorm2d, and ReLU layers found in the
@@ -566,14 +568,14 @@ def fuse_module_conv_bn_relus(
     for name, layer in module.named_modules():
         submodule_name = ".".join(name.split(".")[:-1])
         if (
-                len(current_block) == 1  # [Conv2d]
-                and isinstance(layer, BatchNorm2d)
-                and submodule_name == current_block_submodule_name
+            len(current_block) == 1  # [Conv2d]
+            and isinstance(layer, BatchNorm2d)
+            and submodule_name == current_block_submodule_name
         ) or (
-                len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
-                and isinstance(layer, ReLU)
-                and not isinstance(current_block[-1], ReLU)
-                and submodule_name == current_block_submodule_name
+            len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
+            and isinstance(layer, ReLU)
+            and not isinstance(current_block[-1], ReLU)
+            and submodule_name == current_block_submodule_name
         ):
             if isinstance(layer, ReLU_nm):
                 _set_submodule(module, name, ReLU(inplace=layer.inplace))
@@ -610,11 +612,11 @@ def fuse_module_conv_bn_relus(
 
 
 def prepare_embeddings_qat(
-        module: Module,
-        qconfig: "torch.quantization.QConfig" = None,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+    module: Module,
+    qconfig: "torch.quantization.QConfig" = None,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Dict[str, Any] = {},
+    weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     adds a fake quantize call to the weights of any Embedding modules in the given
@@ -644,17 +646,10 @@ def prepare_embeddings_qat(
 
 
 def get_updated_qconfig_kwargs(qconfig_kwargs, bits):
-    qconfig_kwargs = (
-        qconfig_kwargs.copy()
-        if qconfig_kwargs
-        else {}
-    )
+    qconfig_kwargs = qconfig_kwargs.copy() if qconfig_kwargs else {}
 
     # update qconfig_kwargs for bits
-    if bits and (
-            qconfig_kwargs.get("quant_min")
-            or qconfig_kwargs.get("quant_max")
-    ):
+    if bits and (qconfig_kwargs.get("quant_min") or qconfig_kwargs.get("quant_max")):
         raise ValueError(
             "Cannot override quant_max and quant_min when number of bits is set"
         )

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Embedding, Module, ReLU
 
+
 try:
     import torch.nn.intrinsic as nni
     from torch import quantization as torch_quantization
@@ -30,6 +31,7 @@ except Exception:
     torch_quantization = None
 
 from sparseml.pytorch.nn import ReLU as ReLU_nm
+
 
 __all__ = [
     "QATWrapper",
@@ -69,29 +71,84 @@ _QUANTIZABLE_MODULE_TYPES = (
     else None
 )
 
-_BN_MODULE_TYPES = (
-    {
-        # Conv based layers
-        nni.ConvBn1d,
-        nni.ConvBn2d,
-        nni.ConvBn3d,
-        nni.ConvReLU1d,
-        nni.ConvReLU2d,
-        nni.ConvReLU3d,
-        nni.ConvBnReLU1d,
-        nni.ConvBnReLU2d,
-        nni.ConvBnReLU3d,
-    }
-    if nni  # nni will always import if torch.quantization is available
-    else {}
-)
-
 
 class BNWrapper(Module):
     def __init__(self, module: Module):
         super().__init__()
         self.bn = module
         self.freeze_bn = False
+
+    @property
+    def running_mean(self):
+        return self.bn.running_mean
+
+    @running_mean.setter
+    def running_mean(self, value):
+        self.bn.running_mean = value
+
+    @property
+    def running_var(self):
+        return self.bn.running_var
+
+    @running_var.setter
+    def running_var(self, value):
+        self.bn.running_var = value
+
+    @property
+    def weight(self):
+        return self.bn.weight
+
+    @weight.setter
+    def weight(self, value):
+        self.bn.weight = value
+
+    @property
+    def bias(self):
+        return self.bn.bias
+
+    @bias.setter
+    def bias(self, value):
+        self.bn.bias = value
+
+    @property
+    def gamma(self):
+        return self.bn.gamma
+
+    @gamma.setter
+    def gamma(self, value):
+        self.bn.gamma = value
+
+    @property
+    def beta(self):
+        return self.bn.beta
+
+    @beta.setter
+    def beta(self, value):
+        self.bn.beta = value
+
+    @property
+    def num_batches_tracked(self):
+        return self.bn.num_batches_tracked
+
+    @num_batches_tracked.setter
+    def num_batches_tracked(self, value):
+        self.bn.num_batches_tracked = value
+
+    @property
+    def eps(self):
+        return self.bn.eps
+
+    @eps.setter
+    def eps(self, value):
+        self.bn.eps = value
+
+    @property
+    def momentum(self):
+        return self.bn.momentum
+
+    @momentum.setter
+    def momentum(self, value):
+        self.bn.momentum = value
 
     def forward(self, x):
         return self.bn(x)
@@ -113,9 +170,6 @@ class BNWrapper(Module):
         self.freeze_bn = False
         self.bn.training = True
         return self
-
-
-_BN_MODULE_TYPES.add(BNWrapper)
 
 
 class QATWrapper(Module):
@@ -155,10 +209,10 @@ class QATWrapper(Module):
 
     @staticmethod
     def from_module(
-            module: Module,
-            reduce_range: bool = None,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        module: Module,
+        reduce_range: bool = None,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for
@@ -190,7 +244,7 @@ class QATWrapper(Module):
             activation_qconfig_kwargs
             if "activation_qconfig_kwargs" not in qat_wrapper_kwargs
             else activation_qconfig_kwargs
-                 or qat_wrapper_kwargs["activation_qconfig_kwargs"]
+            or qat_wrapper_kwargs["activation_qconfig_kwargs"]
         )
 
         qat_wrapper_kwargs["weight_qconfig_kwargs"] = (
@@ -203,20 +257,20 @@ class QATWrapper(Module):
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
     def __init__(
-            self,
-            forward_fn: Callable[[Any], Any],
-            num_inputs: int = 1,
-            kwarg_input_names: List[str] = None,
-            num_outputs: int = 1,
-            input_qconfigs: Union[
-                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-            ] = "asymmetric",
-            output_qconfigs: Union[
-                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-            ] = "asymmetric",
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        self,
+        forward_fn: Callable[[Any], Any],
+        num_inputs: int = 1,
+        kwarg_input_names: List[str] = None,
+        num_outputs: int = 1,
+        input_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        output_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         super().__init__()
 
@@ -335,12 +389,12 @@ class QATWrapper(Module):
 
     @staticmethod
     def _load_qconfigs(
-            name: str,
-            expected_len: int,
-            qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        name: str,
+        expected_len: int,
+        qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
             raise ValueError(
@@ -397,23 +451,23 @@ def configure_module_bn_wrappers(module: Module):
             weights. Default is {}
     """
     # wrap any children of the given module as a QATWrapper if required
-    if type(module) not in _BN_MODULE_TYPES:
+    if not hasattr(module, "freeze_bn_stats"):
         for child_name, child_module in module.named_children():
-            if type(child_module) in [torch.nn.BatchNorm1d, torch.nn.BatchNorm2d, torch.nn.BatchNorm3d]:
-                setattr(
-                    module,
-                    child_name,
-                    BNWrapper(child_module)
-                )
+            if type(child_module) in [
+                torch.nn.BatchNorm1d,
+                torch.nn.BatchNorm2d,
+                torch.nn.BatchNorm3d,
+            ]:
+                setattr(module, child_name, BNWrapper(child_module))
             # recurse on child module
             configure_module_bn_wrappers(child_module)
 
 
 def configure_module_qat_wrappers(
-        module: Module,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+    module: Module,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Dict[str, Any] = {},
+    weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     if any submodule of the given module has the attribute wrap_qat == True,
@@ -462,7 +516,7 @@ def configure_module_default_qconfigs(module: Module):
     """
     for submodule in module.modules():
         if hasattr(submodule, "configure_qconfig") and callable(
-                getattr(submodule, "configure_qconfig")
+            getattr(submodule, "configure_qconfig")
         ):
             submodule.configure_qconfig()
 
@@ -477,9 +531,9 @@ def add_quant_dequant(module, name=None, parent_module=None):
     """
     named_children = module.named_children()
     if (
-            type(module) in _QUANTIZABLE_MODULE_TYPES
-            and hasattr(module, "qconfig")
-            and module.qconfig
+        type(module) in _QUANTIZABLE_MODULE_TYPES
+        and hasattr(module, "qconfig")
+        and module.qconfig
     ):
         if parent_module is not None and len(list(named_children)) <= 0:
             module = torch_quantization.QuantWrapper(module)
@@ -503,7 +557,7 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
     """
     for submodule in module.modules():
         if submodule.__class__.__name__ in layer_class_names and hasattr(
-                submodule, "qconfig"
+            submodule, "qconfig"
         ):
             submodule.qconfig = torch_quantization.QConfig(
                 activation=torch.nn.Identity,
@@ -512,11 +566,11 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
 
 
 def get_qat_qconfig(
-        symmetric_activations: bool = False,
-        symmetric_weights: bool = True,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-        weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    symmetric_activations: bool = False,
+    symmetric_weights: bool = True,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
@@ -588,7 +642,7 @@ def fix_observer_quant_range(module: Module):
         if isinstance(submodule, torch_quantization.FakeQuantize):
             fake_quantize = submodule
         elif hasattr(submodule, "activation_post_process") and isinstance(
-                submodule.activation_post_process, torch_quantization.FakeQuantize
+            submodule.activation_post_process, torch_quantization.FakeQuantize
         ):
             fake_quantize = submodule.activation_post_process
         else:
@@ -597,9 +651,9 @@ def fix_observer_quant_range(module: Module):
         # continue if fake_quantize quant range not set, or observer quant range is set
         observer = fake_quantize.activation_post_process
         if (
-                fake_quantize.quant_min is None
-                or fake_quantize.quant_max is None
-                or (observer.quant_min is not None or observer.quant_max is not None)
+            fake_quantize.quant_min is None
+            or fake_quantize.quant_max is None
+            or (observer.quant_min is not None or observer.quant_max is not None)
         ):
             continue
         observer.quant_min = fake_quantize.quant_min
@@ -608,14 +662,14 @@ def fix_observer_quant_range(module: Module):
 
 
 def freeze_bn_stats(module: Module):
-    if type(module) in _BN_MODULE_TYPES:
+    if hasattr(module, "freeze_bn_stats"):
         module.freeze_bn_stats()
 
 
 def fuse_module_conv_bn_relus(
-        module: Module,
-        inplace: bool = True,
-        override_bn_subclasses_forward: Union[bool, str] = True,
+    module: Module,
+    inplace: bool = True,
+    override_bn_subclasses_forward: Union[bool, str] = True,
 ) -> Module:
     """
     Performs fusion of Conv2d, BatchNorm2d, and ReLU layers found in the
@@ -650,14 +704,14 @@ def fuse_module_conv_bn_relus(
     for name, layer in module.named_modules():
         submodule_name = ".".join(name.split(".")[:-1])
         if (
-                len(current_block) == 1  # [Conv2d]
-                and isinstance(layer, BatchNorm2d)
-                and submodule_name == current_block_submodule_name
+            len(current_block) == 1  # [Conv2d]
+            and isinstance(layer, BatchNorm2d)
+            and submodule_name == current_block_submodule_name
         ) or (
-                len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
-                and isinstance(layer, ReLU)
-                and not isinstance(current_block[-1], ReLU)
-                and submodule_name == current_block_submodule_name
+            len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
+            and isinstance(layer, ReLU)
+            and not isinstance(current_block[-1], ReLU)
+            and submodule_name == current_block_submodule_name
         ):
             if isinstance(layer, ReLU_nm):
                 _set_submodule(module, name, ReLU(inplace=layer.inplace))
@@ -694,11 +748,11 @@ def fuse_module_conv_bn_relus(
 
 
 def prepare_embeddings_qat(
-        module: Module,
-        qconfig: "torch.quantization.QConfig" = None,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+    module: Module,
+    qconfig: "torch.quantization.QConfig" = None,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Dict[str, Any] = {},
+    weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     adds a fake quantize call to the weights of any Embedding modules in the given
@@ -727,26 +781,25 @@ def prepare_embeddings_qat(
             _prepare_qat_embedding(submodule, qconfig)
 
 
-def get_updated_qconfig_kwargs(qconfig_kwargs, bits):
-    qconfig_kwargs = (
-        qconfig_kwargs.copy()
-        if qconfig_kwargs
-        else {}
-    )
+def get_updated_qconfig_kwargs(qconfig_kwargs, bits, mode):
+    qconfig_kwargs = qconfig_kwargs.copy() if qconfig_kwargs else {}
 
     # update qconfig_kwargs for bits
-    if bits and (
-            qconfig_kwargs.get("quant_min")
-            or qconfig_kwargs.get("quant_max")
-    ):
+    if bits and (qconfig_kwargs.get("quant_min") or qconfig_kwargs.get("quant_max")):
         raise ValueError(
             "Cannot override quant_max and quant_min when number of bits is set"
         )
 
     if bits:
-        quant_min = 0
-        quant_max = 2 ** bits - 1
-        dtype = torch.quint8
+        if mode == "symmetric":
+            quant_min = -(2 ** (bits - 1))
+            quant_max = 2 ** (bits - 1) - 1
+            dtype = torch.qint8
+        else:
+            quant_min = 0
+            quant_max = 2 ** bits - 1
+            dtype = torch.quint8
+
         qconfig_kwargs.update(
             dict(
                 quant_min=quant_min,

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -22,7 +22,6 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Embedding, Module, ReLU
 
-
 try:
     import torch.nn.intrinsic as nni
     from torch import quantization as torch_quantization
@@ -32,16 +31,17 @@ except Exception:
 
 from sparseml.pytorch.nn import ReLU as ReLU_nm
 
-
 __all__ = [
     "QATWrapper",
-    "configure_module_qat_wrappers",
+    "configure_module_bn_wrappers",
     "configure_module_default_qconfigs",
+    "configure_module_qat_wrappers",
     "add_quant_dequant",
     "remove_activation_qat_by_layer_name",
     "get_qat_qconfig",
     "get_updated_qconfig_kwargs",
     "fix_observer_quant_range",
+    "freeze_bn_stats",
     "fuse_module_conv_bn_relus",
     "prepare_embeddings_qat",
 ]
@@ -68,6 +68,54 @@ _QUANTIZABLE_MODULE_TYPES = (
     if nni  # nni will always import if torch.quantization is available
     else None
 )
+
+_BN_MODULE_TYPES = (
+    {
+        # Conv based layers
+        nni.ConvBn1d,
+        nni.ConvBn2d,
+        nni.ConvBn3d,
+        nni.ConvReLU1d,
+        nni.ConvReLU2d,
+        nni.ConvReLU3d,
+        nni.ConvBnReLU1d,
+        nni.ConvBnReLU2d,
+        nni.ConvBnReLU3d,
+    }
+    if nni  # nni will always import if torch.quantization is available
+    else {}
+)
+
+
+class BNWrapper(Module):
+    def __init__(self, module: Module):
+        super().__init__()
+        self.bn = module
+        self.freeze_bn = False
+
+    def forward(self, x):
+        return self.bn(x)
+
+    def freeze_bn_stats(self):
+        self.freeze_bn = True
+        self.bn.training = False
+        return self
+
+    def reset_running_stats(self):
+        self.bn.reset_running_stats()
+
+    def train(self, mode=True):
+        if not self.freeze_bn:
+            self.bn.train()
+        return self
+
+    def update_bn_stats(self):
+        self.freeze_bn = False
+        self.bn.training = True
+        return self
+
+
+_BN_MODULE_TYPES.add(BNWrapper)
 
 
 class QATWrapper(Module):
@@ -107,10 +155,10 @@ class QATWrapper(Module):
 
     @staticmethod
     def from_module(
-        module: Module,
-        reduce_range: bool = None,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+            module: Module,
+            reduce_range: bool = None,
+            activation_qconfig_kwargs: Dict[str, Any] = {},
+            weight_qconfig_kwargs: Dict[str, Any] = {},
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for
@@ -142,7 +190,7 @@ class QATWrapper(Module):
             activation_qconfig_kwargs
             if "activation_qconfig_kwargs" not in qat_wrapper_kwargs
             else activation_qconfig_kwargs
-            or qat_wrapper_kwargs["activation_qconfig_kwargs"]
+                 or qat_wrapper_kwargs["activation_qconfig_kwargs"]
         )
 
         qat_wrapper_kwargs["weight_qconfig_kwargs"] = (
@@ -155,20 +203,20 @@ class QATWrapper(Module):
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
     def __init__(
-        self,
-        forward_fn: Callable[[Any], Any],
-        num_inputs: int = 1,
-        kwarg_input_names: List[str] = None,
-        num_outputs: int = 1,
-        input_qconfigs: Union[
-            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-        ] = "asymmetric",
-        output_qconfigs: Union[
-            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-        ] = "asymmetric",
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+            self,
+            forward_fn: Callable[[Any], Any],
+            num_inputs: int = 1,
+            kwarg_input_names: List[str] = None,
+            num_outputs: int = 1,
+            input_qconfigs: Union[
+                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+            ] = "asymmetric",
+            output_qconfigs: Union[
+                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+            ] = "asymmetric",
+            reduce_range: bool = False,
+            activation_qconfig_kwargs: Dict[str, Any] = {},
+            weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         super().__init__()
 
@@ -287,12 +335,12 @@ class QATWrapper(Module):
 
     @staticmethod
     def _load_qconfigs(
-        name: str,
-        expected_len: int,
-        qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+            name: str,
+            expected_len: int,
+            qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
+            reduce_range: bool = False,
+            activation_qconfig_kwargs: Dict[str, Any] = {},
+            weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
             raise ValueError(
@@ -332,11 +380,40 @@ class QATWrapper(Module):
         return qconfigs
 
 
+def configure_module_bn_wrappers(module: Module):
+    """
+    if any submodule of the given module has the attribute wrap_qat == True,
+    then it will be replaced by a QATWrapper of it created by QATWrapper.from_module.
+    Other named kwargs to the QATWrapper constructor must be contained in a dictionary
+    under an attributed named `qat_wrapper_kwargs`
+
+    :param module: module to potentially wrap the submodules of
+    :param reduce_range: if True, the quantization range will be reduced by one bit.
+        This may prevent overflow issues with model execution on certain hardware
+        Default is False
+    :param activation_qconfig_kwargs: Additional kwargs for quantization of
+            activations. Default is {}
+    :param weight_qconfig_kwargs: Additional kwargs for quantization of
+            weights. Default is {}
+    """
+    # wrap any children of the given module as a QATWrapper if required
+    if type(module) != BNWrapper:
+        for child_name, child_module in module.named_children():
+            if type(child_module) in [torch.nn.BatchNorm1d, torch.nn.BatchNorm2d, torch.nn.BatchNorm3d]:
+                setattr(
+                    module,
+                    child_name,
+                    BNWrapper(child_module)
+                )
+            # recurse on child module
+            configure_module_bn_wrappers(child_module)
+
+
 def configure_module_qat_wrappers(
-    module: Module,
-    reduce_range: bool = False,
-    activation_qconfig_kwargs: Dict[str, Any] = {},
-    weight_qconfig_kwargs: Dict[str, Any] = {},
+        module: Module,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     if any submodule of the given module has the attribute wrap_qat == True,
@@ -385,7 +462,7 @@ def configure_module_default_qconfigs(module: Module):
     """
     for submodule in module.modules():
         if hasattr(submodule, "configure_qconfig") and callable(
-            getattr(submodule, "configure_qconfig")
+                getattr(submodule, "configure_qconfig")
         ):
             submodule.configure_qconfig()
 
@@ -400,9 +477,9 @@ def add_quant_dequant(module, name=None, parent_module=None):
     """
     named_children = module.named_children()
     if (
-        type(module) in _QUANTIZABLE_MODULE_TYPES
-        and hasattr(module, "qconfig")
-        and module.qconfig
+            type(module) in _QUANTIZABLE_MODULE_TYPES
+            and hasattr(module, "qconfig")
+            and module.qconfig
     ):
         if parent_module is not None and len(list(named_children)) <= 0:
             module = torch_quantization.QuantWrapper(module)
@@ -426,7 +503,7 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
     """
     for submodule in module.modules():
         if submodule.__class__.__name__ in layer_class_names and hasattr(
-            submodule, "qconfig"
+                submodule, "qconfig"
         ):
             submodule.qconfig = torch_quantization.QConfig(
                 activation=torch.nn.Identity,
@@ -435,11 +512,11 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
 
 
 def get_qat_qconfig(
-    symmetric_activations: bool = False,
-    symmetric_weights: bool = True,
-    reduce_range: bool = False,
-    activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-    weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+        symmetric_activations: bool = False,
+        symmetric_weights: bool = True,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+        weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
@@ -511,7 +588,7 @@ def fix_observer_quant_range(module: Module):
         if isinstance(submodule, torch_quantization.FakeQuantize):
             fake_quantize = submodule
         elif hasattr(submodule, "activation_post_process") and isinstance(
-            submodule.activation_post_process, torch_quantization.FakeQuantize
+                submodule.activation_post_process, torch_quantization.FakeQuantize
         ):
             fake_quantize = submodule.activation_post_process
         else:
@@ -535,10 +612,15 @@ def fix_observer_quant_range(module: Module):
         observer.has_customized_qrange = True
 
 
+def freeze_bn_stats(module: Module):
+    if type(module) in _BN_MODULE_TYPES:
+        module.freeze_bn_stats()
+
+
 def fuse_module_conv_bn_relus(
-    module: Module,
-    inplace: bool = True,
-    override_bn_subclasses_forward: Union[bool, str] = True,
+        module: Module,
+        inplace: bool = True,
+        override_bn_subclasses_forward: Union[bool, str] = True,
 ) -> Module:
     """
     Performs fusion of Conv2d, BatchNorm2d, and ReLU layers found in the
@@ -573,14 +655,14 @@ def fuse_module_conv_bn_relus(
     for name, layer in module.named_modules():
         submodule_name = ".".join(name.split(".")[:-1])
         if (
-            len(current_block) == 1  # [Conv2d]
-            and isinstance(layer, BatchNorm2d)
-            and submodule_name == current_block_submodule_name
+                len(current_block) == 1  # [Conv2d]
+                and isinstance(layer, BatchNorm2d)
+                and submodule_name == current_block_submodule_name
         ) or (
-            len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
-            and isinstance(layer, ReLU)
-            and not isinstance(current_block[-1], ReLU)
-            and submodule_name == current_block_submodule_name
+                len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
+                and isinstance(layer, ReLU)
+                and not isinstance(current_block[-1], ReLU)
+                and submodule_name == current_block_submodule_name
         ):
             if isinstance(layer, ReLU_nm):
                 _set_submodule(module, name, ReLU(inplace=layer.inplace))
@@ -617,11 +699,11 @@ def fuse_module_conv_bn_relus(
 
 
 def prepare_embeddings_qat(
-    module: Module,
-    qconfig: "torch.quantization.QConfig" = None,
-    reduce_range: bool = False,
-    activation_qconfig_kwargs: Dict[str, Any] = {},
-    weight_qconfig_kwargs: Dict[str, Any] = {},
+        module: Module,
+        qconfig: "torch.quantization.QConfig" = None,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     adds a fake quantize call to the weights of any Embedding modules in the given
@@ -651,10 +733,17 @@ def prepare_embeddings_qat(
 
 
 def get_updated_qconfig_kwargs(qconfig_kwargs, bits):
-    qconfig_kwargs = qconfig_kwargs.copy() if qconfig_kwargs else {}
+    qconfig_kwargs = (
+        qconfig_kwargs.copy()
+        if qconfig_kwargs
+        else {}
+    )
 
     # update qconfig_kwargs for bits
-    if bits and (qconfig_kwargs.get("quant_min") or qconfig_kwargs.get("quant_max")):
+    if bits and (
+            qconfig_kwargs.get("quant_min")
+            or qconfig_kwargs.get("quant_max")
+    ):
         raise ValueError(
             "Cannot override quant_max and quant_min when number of bits is set"
         )

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -397,7 +397,7 @@ def configure_module_bn_wrappers(module: Module):
             weights. Default is {}
     """
     # wrap any children of the given module as a QATWrapper if required
-    if type(module) != BNWrapper:
+    if type(module) not in _BN_MODULE_TYPES:
         for child_name, child_module in module.named_children():
             if type(child_module) in [torch.nn.BatchNorm1d, torch.nn.BatchNorm2d, torch.nn.BatchNorm3d]:
                 setattr(

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -751,7 +751,7 @@ def get_qat_qconfig(
     else:
         _weight_dtype = weight_dtype
 
-    weight_observer = get_observer(_symmetric_weights, weight_dtype, weight_bits, False, weight_qconfig_kwargs)
+    weight_observer = get_observer(_symmetric_weights, _weight_dtype, weight_bits, False, weight_qconfig_kwargs)
     return torch_quantization.QConfig(
         activation=activation_observer,
         weight=weight_observer,

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -41,7 +41,6 @@ __all__ = [
     "add_quant_dequant",
     "remove_activation_qat_by_layer_name",
     "get_qat_qconfig",
-    "get_updated_qconfig_kwargs",
     "fix_observer_quant_range",
     "freeze_bn_stats",
     "fuse_module_conv_bn_relus",
@@ -973,36 +972,6 @@ def prepare_embeddings_qat(
     for submodule in module.modules():
         if type(submodule) is Embedding:
             _prepare_qat_embedding(submodule, qconfig)
-
-
-def get_updated_qconfig_kwargs(qconfig_kwargs, bits, mode):
-    qconfig_kwargs = qconfig_kwargs.copy() if qconfig_kwargs else {}
-
-    # update qconfig_kwargs for bits
-    if bits and (qconfig_kwargs.get("quant_min") or qconfig_kwargs.get("quant_max")):
-        raise ValueError(
-            "Cannot override quant_max and quant_min when number of bits is set"
-        )
-
-    if bits:
-        if mode == "symmetric":
-            quant_min = -(2 ** (bits - 1))
-            quant_max = 2 ** (bits - 1) - 1
-            dtype = torch.qint8
-        else:
-            quant_min = 0
-            quant_max = 2 ** bits - 1
-            dtype = torch.quint8
-
-        qconfig_kwargs.update(
-            dict(
-                quant_min=quant_min,
-                quant_max=quant_max,
-                dtype=dtype,
-            )
-        )
-
-    return qconfig_kwargs
 
 
 def _prepare_qat_embedding(embedding: Module, qconfig: "torch.quantization.QConfig"):

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -69,8 +69,14 @@ _QUANTIZABLE_MODULE_TYPES = (
     else None
 )
 
-
+#
 class BNWrapper(Module):
+    """
+    Wraps BatchNormalization module to expose methods needed to enable
+    freezing/unfreezing of statistics
+
+    :param module: BatchNormalization module to be wrapped
+    """
     def __init__(self, module: Module):
         super().__init__()
         self.bn = module
@@ -220,14 +226,25 @@ class QATWrapper(Module):
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for
-        :param reduce_range: if True, the quantization range will be reduced by one
-            bit. This may prevent overflow issues with model execution on certain
-            hardware. Default is None, will only override qat_wrapper_kwargs if set
-            to a bool value
+        :param symmetric_activations: if True, activations will have a symmetric
+            quantization range with a pre-specified zero point
+            (0 if activation_dtype=torch.qint8, 128 if activation_dtype=torch.quint8).
+            Default is False.
+        :param symmetric_weights: if True, weights will have a symmetric
+            quantization range with a pre-specified zero point
+            (0 if weight_dtype=torch.qint8, 128 if weight_dtype=torch.quint8).
+            Default is True.
+        :param reduce_range: if True, the quantization range will be reduced by one bit.
+            This may prevent overflow issues with model execution on certain hardware.
+            Default is False.
         :param activation_qconfig_kwargs: Additional kwargs for quantization of
-            activations. Default is {}
+            activations.
         :param weight_qconfig_kwargs: Additional kwargs for quantization of
-            weights. Default is {}
+            weights.
+        :param activation_dtype: quantized activation data type. Default is torch.quint8.
+        :param weight_dtype: quantized weights data type. Default is torch.qint8.
+        :param activation_bits: number of bits for activations. Default is 8.
+        :param weight_bits: number of bits for weights. Default is 8.
         :return: QATWrapper object created using the given Module as the forward
             function. Will attempt to find any other named parameter of the QATWrapper
             constructor from the attributes of the given Module
@@ -293,6 +310,7 @@ class QATWrapper(Module):
             else weight_bits or qat_wrapper_kwargs["weight_bits"]
         )
 
+        # Remove qconfig from wrapped layer to avoid duplicate quantization
         module.qconfig = None
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
@@ -516,19 +534,10 @@ class QATWrapper(Module):
 
 def configure_module_bn_wrappers(module: Module):
     """
-    if any submodule of the given module has the attribute wrap_qat == True,
-    then it will be replaced by a QATWrapper of it created by QATWrapper.from_module.
-    Other named kwargs to the QATWrapper constructor must be contained in a dictionary
-    under an attributed named `qat_wrapper_kwargs`
+    Wrap any BatchNormalization modules that are not fused with convolutions
+    with BNWrapper to enable freezing/unfreezing of BN statistics
 
     :param module: module to potentially wrap the submodules of
-    :param reduce_range: if True, the quantization range will be reduced by one bit.
-        This may prevent overflow issues with model execution on certain hardware
-        Default is False
-    :param activation_qconfig_kwargs: Additional kwargs for quantization of
-            activations. Default is {}
-    :param weight_qconfig_kwargs: Additional kwargs for quantization of
-            weights. Default is {}
     """
     # wrap any children of the given module as a QATWrapper if required
     if not hasattr(module, 'freeze_bn_stats'):
@@ -562,14 +571,25 @@ def configure_module_qat_wrappers(
     under an attributed named `qat_wrapper_kwargs`
 
     :param module: module to potentially wrap the submodules of
+    :param symmetric_activations: if True, activations will have a symmetric
+        quantization range with a pre-specified zero point
+        (0 if activation_dtype=torch.qint8, 128 if activation_dtype=torch.quint8).
+        Default is False.
+    :param symmetric_weights: if True, weights will have a symmetric
+        quantization range with a pre-specified zero point
+        (0 if weight_dtype=torch.qint8, 128 if weight_dtype=torch.quint8).
+        Default is True.
     :param reduce_range: if True, the quantization range will be reduced by one bit.
-        This may prevent overflow issues with model execution on certain hardware
-        Default is False
+        This may prevent overflow issues with model execution on certain hardware.
+        Default is False.
     :param activation_qconfig_kwargs: Additional kwargs for quantization of
-            activations. Default is {}
+        activations.
     :param weight_qconfig_kwargs: Additional kwargs for quantization of
-            weights. Default is {}
-    """
+        weights.
+    :param activation_dtype: quantized activation data type. Default is torch.quint8.
+    :param weight_dtype: quantized weights data type. Default is torch.qint8.
+    :param activation_bits: number of bits for activations. Default is 8.
+    :param weight_bits: number of bits for weights. Default is 8.    """
     # wrap any children of the given module as a QATWrapper if required
     for child_name, child_module in module.named_children():
         if hasattr(child_module, "wrap_qat") and child_module.wrap_qat:
@@ -605,6 +625,13 @@ def configure_module_qat_wrappers(
 
 
 def compute_range(dtype: Optional[torch.dtype], bits: Optional[int]):
+    """
+    compute quantization limits depending on data type and number of bits
+
+    :param dtype: data type. If None dtype is set to torch.quint8.
+    :param bits: number of bits. If None is set to 8.
+    :return: minimum limit, maximum limit, data type
+    """
     dtype = dtype if dtype else torch.quint8
     bits = bits if bits else 8
     if dtype == torch.qint8:
@@ -689,18 +716,24 @@ def get_qat_qconfig(
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
-        UINT8 quantization range with zero point set to 128. Otherwise activations
-        will use asymmetric quantization with any zero point. Default is False
+        quantization range with a pre-specified zero point
+        (0 if activation_dtype=torch.qint8, 128 if activation_dtype=torch.quint8).
+        Default is False.
     :param symmetric_weights: if True, weights will have a symmetric
-        INT8 quantization range with zero point set to 0. Otherwise activations
-        will use asymmetric quantization with any zero point. Default is True
+        quantization range with a pre-specified zero point
+        (0 if weight_dtype=torch.qint8, 128 if weight_dtype=torch.quint8).
+        Default is True.
     :param reduce_range: if True, the quantization range will be reduced by one bit.
-        This may prevent overflow issues with model execution on certain hardware
-        Default is False
+        This may prevent overflow issues with model execution on certain hardware.
+        Default is False.
     :param activation_qconfig_kwargs: Additional kwargs for quantization of
-            activations.
+        activations.
     :param weight_qconfig_kwargs: Additional kwargs for quantization of
-            weights.
+        weights.
+    :param activation_dtype: quantized activation data type. Default is torch.quint8.
+    :param weight_dtype: quantized weights data type. Default is torch.qint8.
+    :param activation_bits: number of bits for activations. Default is 8.
+    :param weight_bits: number of bits for weights. Default is 8.
     :return: A QAT fake quantization config for symmetric weight quantization and
         asymmetric activation quantization.  The difference between this and
         torch.quantization.default_qat_qconfig is that the activation observer
@@ -885,14 +918,25 @@ def prepare_embeddings_qat(
     :param module: module to run QAT for the embeddings of
     :param qconfig: qconfig to generate the fake quantize ops from. Default uses INT8
         asymmetric range
-    :param activation_qconfig_kwargs: additional kwargs for quantizing activations.
-        Default is {}.
-    :param weight_qconfig_kwargs: additional kwargs for quantizing the weights.
-        Default is {}.
+    :param symmetric_activations: if True, activations will have a symmetric
+        quantization range with a pre-specified zero point
+        (0 if activation_dtype=torch.qint8, 128 if activation_dtype=torch.quint8).
+        Default is False.
+    :param symmetric_weights: if True, weights will have a symmetric
+        quantization range with a pre-specified zero point
+        (0 if weight_dtype=torch.qint8, 128 if weight_dtype=torch.quint8).
+        Default is True.
     :param reduce_range: if True, the quantization range will be reduced by one bit.
         This may prevent overflow issues with model execution on certain hardware.
-        Default is False
-    """
+        Default is False.
+    :param activation_qconfig_kwargs: Additional kwargs for quantization of
+        activations.
+    :param weight_qconfig_kwargs: Additional kwargs for quantization of
+        weights.
+    :param activation_dtype: quantized activation data type. Default is torch.quint8.
+    :param weight_dtype: quantized weights data type. Default is torch.qint8.
+    :param activation_bits: number of bits for activations. Default is 8.
+    :param weight_bits: number of bits for weights. Default is 8.    """
     if qconfig is None:
         if symmetric_weights is None:
             _symmetric_weights = False

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Embedding, Module, ReLU
 
+
 try:
     import torch.nn.intrinsic as nni
     from torch import quantization as torch_quantization
@@ -30,6 +31,7 @@ except Exception:
     torch_quantization = None
 
 from sparseml.pytorch.nn import ReLU as ReLU_nm
+
 
 __all__ = [
     "QATWrapper",
@@ -105,10 +107,10 @@ class QATWrapper(Module):
 
     @staticmethod
     def from_module(
-            module: Module,
-            reduce_range: bool = None,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        module: Module,
+        reduce_range: bool = None,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for
@@ -140,7 +142,7 @@ class QATWrapper(Module):
             activation_qconfig_kwargs
             if "activation_qconfig_kwargs" not in qat_wrapper_kwargs
             else activation_qconfig_kwargs
-                 or qat_wrapper_kwargs["activation_qconfig_kwargs"]
+            or qat_wrapper_kwargs["activation_qconfig_kwargs"]
         )
 
         qat_wrapper_kwargs["weight_qconfig_kwargs"] = (
@@ -153,20 +155,20 @@ class QATWrapper(Module):
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
     def __init__(
-            self,
-            forward_fn: Callable[[Any], Any],
-            num_inputs: int = 1,
-            kwarg_input_names: List[str] = None,
-            num_outputs: int = 1,
-            input_qconfigs: Union[
-                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-            ] = "asymmetric",
-            output_qconfigs: Union[
-                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-            ] = "asymmetric",
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        self,
+        forward_fn: Callable[[Any], Any],
+        num_inputs: int = 1,
+        kwarg_input_names: List[str] = None,
+        num_outputs: int = 1,
+        input_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        output_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         super().__init__()
 
@@ -285,12 +287,12 @@ class QATWrapper(Module):
 
     @staticmethod
     def _load_qconfigs(
-            name: str,
-            expected_len: int,
-            qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        name: str,
+        expected_len: int,
+        qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
             raise ValueError(
@@ -331,10 +333,10 @@ class QATWrapper(Module):
 
 
 def configure_module_qat_wrappers(
-        module: Module,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+    module: Module,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Dict[str, Any] = {},
+    weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     if any submodule of the given module has the attribute wrap_qat == True,
@@ -383,7 +385,7 @@ def configure_module_default_qconfigs(module: Module):
     """
     for submodule in module.modules():
         if hasattr(submodule, "configure_qconfig") and callable(
-                getattr(submodule, "configure_qconfig")
+            getattr(submodule, "configure_qconfig")
         ):
             submodule.configure_qconfig()
 
@@ -398,9 +400,9 @@ def add_quant_dequant(module, name=None, parent_module=None):
     """
     named_children = module.named_children()
     if (
-            type(module) in _QUANTIZABLE_MODULE_TYPES
-            and hasattr(module, "qconfig")
-            and module.qconfig
+        type(module) in _QUANTIZABLE_MODULE_TYPES
+        and hasattr(module, "qconfig")
+        and module.qconfig
     ):
         if parent_module is not None and len(list(named_children)) <= 0:
             module = torch_quantization.QuantWrapper(module)
@@ -424,7 +426,7 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
     """
     for submodule in module.modules():
         if submodule.__class__.__name__ in layer_class_names and hasattr(
-                submodule, "qconfig"
+            submodule, "qconfig"
         ):
             submodule.qconfig = torch_quantization.QConfig(
                 activation=torch.nn.Identity,
@@ -433,11 +435,11 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
 
 
 def get_qat_qconfig(
-        symmetric_activations: bool = False,
-        symmetric_weights: bool = True,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-        weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    symmetric_activations: bool = False,
+    symmetric_weights: bool = True,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
@@ -509,7 +511,7 @@ def fix_observer_quant_range(module: Module):
         if isinstance(submodule, torch_quantization.FakeQuantize):
             fake_quantize = submodule
         elif hasattr(submodule, "activation_post_process") and isinstance(
-                submodule.activation_post_process, torch_quantization.FakeQuantize
+            submodule.activation_post_process, torch_quantization.FakeQuantize
         ):
             fake_quantize = submodule.activation_post_process
         else:
@@ -534,9 +536,9 @@ def fix_observer_quant_range(module: Module):
 
 
 def fuse_module_conv_bn_relus(
-        module: Module,
-        inplace: bool = True,
-        override_bn_subclasses_forward: Union[bool, str] = True,
+    module: Module,
+    inplace: bool = True,
+    override_bn_subclasses_forward: Union[bool, str] = True,
 ) -> Module:
     """
     Performs fusion of Conv2d, BatchNorm2d, and ReLU layers found in the
@@ -571,14 +573,14 @@ def fuse_module_conv_bn_relus(
     for name, layer in module.named_modules():
         submodule_name = ".".join(name.split(".")[:-1])
         if (
-                len(current_block) == 1  # [Conv2d]
-                and isinstance(layer, BatchNorm2d)
-                and submodule_name == current_block_submodule_name
+            len(current_block) == 1  # [Conv2d]
+            and isinstance(layer, BatchNorm2d)
+            and submodule_name == current_block_submodule_name
         ) or (
-                len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
-                and isinstance(layer, ReLU)
-                and not isinstance(current_block[-1], ReLU)
-                and submodule_name == current_block_submodule_name
+            len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
+            and isinstance(layer, ReLU)
+            and not isinstance(current_block[-1], ReLU)
+            and submodule_name == current_block_submodule_name
         ):
             if isinstance(layer, ReLU_nm):
                 _set_submodule(module, name, ReLU(inplace=layer.inplace))
@@ -615,11 +617,11 @@ def fuse_module_conv_bn_relus(
 
 
 def prepare_embeddings_qat(
-        module: Module,
-        qconfig: "torch.quantization.QConfig" = None,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+    module: Module,
+    qconfig: "torch.quantization.QConfig" = None,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Dict[str, Any] = {},
+    weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     adds a fake quantize call to the weights of any Embedding modules in the given
@@ -649,17 +651,10 @@ def prepare_embeddings_qat(
 
 
 def get_updated_qconfig_kwargs(qconfig_kwargs, bits):
-    qconfig_kwargs = (
-        qconfig_kwargs.copy()
-        if qconfig_kwargs
-        else {}
-    )
+    qconfig_kwargs = qconfig_kwargs.copy() if qconfig_kwargs else {}
 
     # update qconfig_kwargs for bits
-    if bits and (
-            qconfig_kwargs.get("quant_min")
-            or qconfig_kwargs.get("quant_max")
-    ):
+    if bits and (qconfig_kwargs.get("quant_min") or qconfig_kwargs.get("quant_max")):
         raise ValueError(
             "Cannot override quant_max and quant_min when number of bits is set"
         )

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Embedding, Module, ReLU
 
+
 try:
     import torch.nn.intrinsic as nni
     from torch import quantization as torch_quantization
@@ -30,6 +31,7 @@ except Exception:
     torch_quantization = None
 
 from sparseml.pytorch.nn import ReLU as ReLU_nm
+
 
 __all__ = [
     "QATWrapper",
@@ -69,29 +71,84 @@ _QUANTIZABLE_MODULE_TYPES = (
     else None
 )
 
-_BN_MODULE_TYPES = (
-    {
-        # Conv based layers
-        nni.ConvBn1d,
-        nni.ConvBn2d,
-        nni.ConvBn3d,
-        nni.ConvReLU1d,
-        nni.ConvReLU2d,
-        nni.ConvReLU3d,
-        nni.ConvBnReLU1d,
-        nni.ConvBnReLU2d,
-        nni.ConvBnReLU3d,
-    }
-    if nni  # nni will always import if torch.quantization is available
-    else {}
-)
-
 
 class BNWrapper(Module):
     def __init__(self, module: Module):
         super().__init__()
         self.bn = module
         self.freeze_bn = False
+
+    @property
+    def running_mean(self):
+        return self.bn.running_mean
+
+    @running_mean.setter
+    def running_mean(self, value):
+        self.bn.running_mean = value
+
+    @property
+    def running_var(self):
+        return self.bn.running_var
+
+    @running_var.setter
+    def running_var(self, value):
+        self.bn.running_var = value
+
+    @property
+    def weight(self):
+        return self.bn.weight
+
+    @weight.setter
+    def weight(self, value):
+        self.bn.weight = value
+
+    @property
+    def bias(self):
+        return self.bn.bias
+
+    @bias.setter
+    def bias(self, value):
+        self.bn.bias = value
+
+    @property
+    def gamma(self):
+        return self.bn.gamma
+
+    @gamma.setter
+    def gamma(self, value):
+        self.bn.gamma = value
+
+    @property
+    def beta(self):
+        return self.bn.beta
+
+    @beta.setter
+    def beta(self, value):
+        self.bn.beta = value
+
+    @property
+    def num_batches_tracked(self):
+        return self.bn.num_batches_tracked
+
+    @num_batches_tracked.setter
+    def num_batches_tracked(self, value):
+        self.bn.num_batches_tracked = value
+
+    @property
+    def eps(self):
+        return self.bn.eps
+
+    @eps.setter
+    def eps(self, value):
+        self.bn.eps = value
+
+    @property
+    def momentum(self):
+        return self.bn.momentum
+
+    @momentum.setter
+    def momentum(self, value):
+        self.bn.momentum = value
 
     def forward(self, x):
         return self.bn(x)
@@ -113,9 +170,6 @@ class BNWrapper(Module):
         self.freeze_bn = False
         self.bn.training = True
         return self
-
-
-_BN_MODULE_TYPES.add(BNWrapper)
 
 
 class QATWrapper(Module):
@@ -155,10 +209,10 @@ class QATWrapper(Module):
 
     @staticmethod
     def from_module(
-            module: Module,
-            reduce_range: bool = None,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        module: Module,
+        reduce_range: bool = None,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for
@@ -190,7 +244,7 @@ class QATWrapper(Module):
             activation_qconfig_kwargs
             if "activation_qconfig_kwargs" not in qat_wrapper_kwargs
             else activation_qconfig_kwargs
-                 or qat_wrapper_kwargs["activation_qconfig_kwargs"]
+            or qat_wrapper_kwargs["activation_qconfig_kwargs"]
         )
 
         qat_wrapper_kwargs["weight_qconfig_kwargs"] = (
@@ -203,20 +257,20 @@ class QATWrapper(Module):
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
     def __init__(
-            self,
-            forward_fn: Callable[[Any], Any],
-            num_inputs: int = 1,
-            kwarg_input_names: List[str] = None,
-            num_outputs: int = 1,
-            input_qconfigs: Union[
-                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-            ] = "asymmetric",
-            output_qconfigs: Union[
-                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-            ] = "asymmetric",
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        self,
+        forward_fn: Callable[[Any], Any],
+        num_inputs: int = 1,
+        kwarg_input_names: List[str] = None,
+        num_outputs: int = 1,
+        input_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        output_qconfigs: Union[
+            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+        ] = "asymmetric",
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         super().__init__()
 
@@ -335,12 +389,12 @@ class QATWrapper(Module):
 
     @staticmethod
     def _load_qconfigs(
-            name: str,
-            expected_len: int,
-            qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
-            reduce_range: bool = False,
-            activation_qconfig_kwargs: Dict[str, Any] = {},
-            weight_qconfig_kwargs: Dict[str, Any] = {},
+        name: str,
+        expected_len: int,
+        qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
             raise ValueError(
@@ -397,23 +451,23 @@ def configure_module_bn_wrappers(module: Module):
             weights. Default is {}
     """
     # wrap any children of the given module as a QATWrapper if required
-    if type(module) not in _BN_MODULE_TYPES:
+    if not hasattr(module, "freeze_bn_stats"):
         for child_name, child_module in module.named_children():
-            if type(child_module) in [torch.nn.BatchNorm1d, torch.nn.BatchNorm2d, torch.nn.BatchNorm3d]:
-                setattr(
-                    module,
-                    child_name,
-                    BNWrapper(child_module)
-                )
+            if type(child_module) in [
+                torch.nn.BatchNorm1d,
+                torch.nn.BatchNorm2d,
+                torch.nn.BatchNorm3d,
+            ]:
+                setattr(module, child_name, BNWrapper(child_module))
             # recurse on child module
             configure_module_bn_wrappers(child_module)
 
 
 def configure_module_qat_wrappers(
-        module: Module,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+    module: Module,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Dict[str, Any] = {},
+    weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     if any submodule of the given module has the attribute wrap_qat == True,
@@ -462,7 +516,7 @@ def configure_module_default_qconfigs(module: Module):
     """
     for submodule in module.modules():
         if hasattr(submodule, "configure_qconfig") and callable(
-                getattr(submodule, "configure_qconfig")
+            getattr(submodule, "configure_qconfig")
         ):
             submodule.configure_qconfig()
 
@@ -477,9 +531,9 @@ def add_quant_dequant(module, name=None, parent_module=None):
     """
     named_children = module.named_children()
     if (
-            type(module) in _QUANTIZABLE_MODULE_TYPES
-            and hasattr(module, "qconfig")
-            and module.qconfig
+        type(module) in _QUANTIZABLE_MODULE_TYPES
+        and hasattr(module, "qconfig")
+        and module.qconfig
     ):
         if parent_module is not None and len(list(named_children)) <= 0:
             module = torch_quantization.QuantWrapper(module)
@@ -503,7 +557,7 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
     """
     for submodule in module.modules():
         if submodule.__class__.__name__ in layer_class_names and hasattr(
-                submodule, "qconfig"
+            submodule, "qconfig"
         ):
             submodule.qconfig = torch_quantization.QConfig(
                 activation=torch.nn.Identity,
@@ -512,11 +566,11 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
 
 
 def get_qat_qconfig(
-        symmetric_activations: bool = False,
-        symmetric_weights: bool = True,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-        weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    symmetric_activations: bool = False,
+    symmetric_weights: bool = True,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+    weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
@@ -588,7 +642,7 @@ def fix_observer_quant_range(module: Module):
         if isinstance(submodule, torch_quantization.FakeQuantize):
             fake_quantize = submodule
         elif hasattr(submodule, "activation_post_process") and isinstance(
-                submodule.activation_post_process, torch_quantization.FakeQuantize
+            submodule.activation_post_process, torch_quantization.FakeQuantize
         ):
             fake_quantize = submodule.activation_post_process
         else:
@@ -613,14 +667,14 @@ def fix_observer_quant_range(module: Module):
 
 
 def freeze_bn_stats(module: Module):
-    if type(module) in _BN_MODULE_TYPES:
+    if hasattr(module, "freeze_bn_stats"):
         module.freeze_bn_stats()
 
 
 def fuse_module_conv_bn_relus(
-        module: Module,
-        inplace: bool = True,
-        override_bn_subclasses_forward: Union[bool, str] = True,
+    module: Module,
+    inplace: bool = True,
+    override_bn_subclasses_forward: Union[bool, str] = True,
 ) -> Module:
     """
     Performs fusion of Conv2d, BatchNorm2d, and ReLU layers found in the
@@ -655,14 +709,14 @@ def fuse_module_conv_bn_relus(
     for name, layer in module.named_modules():
         submodule_name = ".".join(name.split(".")[:-1])
         if (
-                len(current_block) == 1  # [Conv2d]
-                and isinstance(layer, BatchNorm2d)
-                and submodule_name == current_block_submodule_name
+            len(current_block) == 1  # [Conv2d]
+            and isinstance(layer, BatchNorm2d)
+            and submodule_name == current_block_submodule_name
         ) or (
-                len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
-                and isinstance(layer, ReLU)
-                and not isinstance(current_block[-1], ReLU)
-                and submodule_name == current_block_submodule_name
+            len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
+            and isinstance(layer, ReLU)
+            and not isinstance(current_block[-1], ReLU)
+            and submodule_name == current_block_submodule_name
         ):
             if isinstance(layer, ReLU_nm):
                 _set_submodule(module, name, ReLU(inplace=layer.inplace))
@@ -699,11 +753,11 @@ def fuse_module_conv_bn_relus(
 
 
 def prepare_embeddings_qat(
-        module: Module,
-        qconfig: "torch.quantization.QConfig" = None,
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+    module: Module,
+    qconfig: "torch.quantization.QConfig" = None,
+    reduce_range: bool = False,
+    activation_qconfig_kwargs: Dict[str, Any] = {},
+    weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     adds a fake quantize call to the weights of any Embedding modules in the given
@@ -732,26 +786,25 @@ def prepare_embeddings_qat(
             _prepare_qat_embedding(submodule, qconfig)
 
 
-def get_updated_qconfig_kwargs(qconfig_kwargs, bits):
-    qconfig_kwargs = (
-        qconfig_kwargs.copy()
-        if qconfig_kwargs
-        else {}
-    )
+def get_updated_qconfig_kwargs(qconfig_kwargs, bits, mode):
+    qconfig_kwargs = qconfig_kwargs.copy() if qconfig_kwargs else {}
 
     # update qconfig_kwargs for bits
-    if bits and (
-            qconfig_kwargs.get("quant_min")
-            or qconfig_kwargs.get("quant_max")
-    ):
+    if bits and (qconfig_kwargs.get("quant_min") or qconfig_kwargs.get("quant_max")):
         raise ValueError(
             "Cannot override quant_max and quant_min when number of bits is set"
         )
 
     if bits:
-        quant_min = 0
-        quant_max = 2 ** bits - 1
-        dtype = torch.quint8
+        if mode == "symmetric":
+            quant_min = -(2 ** (bits - 1))
+            quant_max = 2 ** (bits - 1) - 1
+            dtype = torch.qint8
+        else:
+            quant_min = 0
+            quant_max = 2 ** bits - 1
+            dtype = torch.quint8
+
         qconfig_kwargs.update(
             dict(
                 quant_min=quant_min,

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -22,7 +22,6 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import torch
 from torch.nn import BatchNorm2d, Conv2d, Embedding, Module, ReLU
 
-
 try:
     import torch.nn.intrinsic as nni
     from torch import quantization as torch_quantization
@@ -31,7 +30,6 @@ except Exception:
     torch_quantization = None
 
 from sparseml.pytorch.nn import ReLU as ReLU_nm
-
 
 __all__ = [
     "QATWrapper",
@@ -209,10 +207,10 @@ class QATWrapper(Module):
 
     @staticmethod
     def from_module(
-        module: Module,
-        reduce_range: bool = None,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+            module: Module,
+            reduce_range: bool = None,
+            activation_qconfig_kwargs: Dict[str, Any] = {},
+            weight_qconfig_kwargs: Dict[str, Any] = {},
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for
@@ -244,7 +242,7 @@ class QATWrapper(Module):
             activation_qconfig_kwargs
             if "activation_qconfig_kwargs" not in qat_wrapper_kwargs
             else activation_qconfig_kwargs
-            or qat_wrapper_kwargs["activation_qconfig_kwargs"]
+                 or qat_wrapper_kwargs["activation_qconfig_kwargs"]
         )
 
         qat_wrapper_kwargs["weight_qconfig_kwargs"] = (
@@ -257,20 +255,20 @@ class QATWrapper(Module):
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
     def __init__(
-        self,
-        forward_fn: Callable[[Any], Any],
-        num_inputs: int = 1,
-        kwarg_input_names: List[str] = None,
-        num_outputs: int = 1,
-        input_qconfigs: Union[
-            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-        ] = "asymmetric",
-        output_qconfigs: Union[
-            "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
-        ] = "asymmetric",
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+            self,
+            forward_fn: Callable[[Any], Any],
+            num_inputs: int = 1,
+            kwarg_input_names: List[str] = None,
+            num_outputs: int = 1,
+            input_qconfigs: Union[
+                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+            ] = "asymmetric",
+            output_qconfigs: Union[
+                "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
+            ] = "asymmetric",
+            reduce_range: bool = False,
+            activation_qconfig_kwargs: Dict[str, Any] = {},
+            weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         super().__init__()
 
@@ -389,12 +387,12 @@ class QATWrapper(Module):
 
     @staticmethod
     def _load_qconfigs(
-        name: str,
-        expected_len: int,
-        qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
-        reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+            name: str,
+            expected_len: int,
+            qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
+            reduce_range: bool = False,
+            activation_qconfig_kwargs: Dict[str, Any] = {},
+            weight_qconfig_kwargs: Dict[str, Any] = {},
     ):
         if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
             raise ValueError(
@@ -451,23 +449,23 @@ def configure_module_bn_wrappers(module: Module):
             weights. Default is {}
     """
     # wrap any children of the given module as a QATWrapper if required
-    if not hasattr(module, "freeze_bn_stats"):
+    if not hasattr(module, 'freeze_bn_stats'):
         for child_name, child_module in module.named_children():
-            if type(child_module) in [
-                torch.nn.BatchNorm1d,
-                torch.nn.BatchNorm2d,
-                torch.nn.BatchNorm3d,
-            ]:
-                setattr(module, child_name, BNWrapper(child_module))
+            if type(child_module) in [torch.nn.BatchNorm1d, torch.nn.BatchNorm2d, torch.nn.BatchNorm3d]:
+                setattr(
+                    module,
+                    child_name,
+                    BNWrapper(child_module)
+                )
             # recurse on child module
             configure_module_bn_wrappers(child_module)
 
 
 def configure_module_qat_wrappers(
-    module: Module,
-    reduce_range: bool = False,
-    activation_qconfig_kwargs: Dict[str, Any] = {},
-    weight_qconfig_kwargs: Dict[str, Any] = {},
+        module: Module,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     if any submodule of the given module has the attribute wrap_qat == True,
@@ -506,6 +504,17 @@ def configure_module_qat_wrappers(
         )
 
 
+def compute_range(dtype: torch.dtype, bits: int):
+    if dtype == torch.qint8:
+        quant_min = -2 ** (bits - 1)
+        quant_max = 2 ** (bits - 1) - 1
+    elif dtype == torch.quint8:
+        quant_min = 0
+        quant_max = 2 ** bits - 1
+
+    return quant_min, quant_max
+
+
 def configure_module_default_qconfigs(module: Module):
     """
     if any submodule of the given module has a configure_qconfig function,
@@ -516,7 +525,7 @@ def configure_module_default_qconfigs(module: Module):
     """
     for submodule in module.modules():
         if hasattr(submodule, "configure_qconfig") and callable(
-            getattr(submodule, "configure_qconfig")
+                getattr(submodule, "configure_qconfig")
         ):
             submodule.configure_qconfig()
 
@@ -531,9 +540,9 @@ def add_quant_dequant(module, name=None, parent_module=None):
     """
     named_children = module.named_children()
     if (
-        type(module) in _QUANTIZABLE_MODULE_TYPES
-        and hasattr(module, "qconfig")
-        and module.qconfig
+            type(module) in _QUANTIZABLE_MODULE_TYPES
+            and hasattr(module, "qconfig")
+            and module.qconfig
     ):
         if parent_module is not None and len(list(named_children)) <= 0:
             module = torch_quantization.QuantWrapper(module)
@@ -557,7 +566,7 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
     """
     for submodule in module.modules():
         if submodule.__class__.__name__ in layer_class_names and hasattr(
-            submodule, "qconfig"
+                submodule, "qconfig"
         ):
             submodule.qconfig = torch_quantization.QConfig(
                 activation=torch.nn.Identity,
@@ -566,11 +575,15 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
 
 
 def get_qat_qconfig(
-    symmetric_activations: bool = False,
-    symmetric_weights: bool = True,
-    reduce_range: bool = False,
-    activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-    weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+        symmetric_activations: bool = False,
+        symmetric_weights: bool = True,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+        weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+        activation_dtype: Optional[torch.dtype] = torch.quint8,
+        weight_dtype: Optional[torch.dtype] = torch.qint8,
+        activation_bits: Optional[int] = 8,
+        weight_bits: Optional[int] = 8,
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
@@ -591,41 +604,34 @@ def get_qat_qconfig(
         torch.quantization.default_qat_qconfig is that the activation observer
         will not have reduce_range enabled.
     """
-    activation_qscheme = (
-        torch.per_tensor_symmetric if symmetric_activations else torch.per_tensor_affine
-    )
-    activation_observer_kwargs = dict(
-        observer=torch_quantization.MovingAverageMinMaxObserver,
-        quant_min=0,
-        quant_max=255,
-        dtype=torch.quint8,
-        qscheme=activation_qscheme,
-        reduce_range=reduce_range,
-    )
-    activation_observer_kwargs.update(activation_qconfig_kwargs or {})
-    activation_observer = torch_quantization.FakeQuantize.with_args(
-        **activation_observer_kwargs,
-    )
-    weight_qscheme = (
-        torch.per_tensor_symmetric if symmetric_weights else torch.per_tensor_affine
-    )
-    weight_observer_kwargs = dict(
-        observer=torch_quantization.MovingAverageMinMaxObserver,
-        quant_min=-128,
-        quant_max=127,
-        dtype=torch.qint8,
-        qscheme=weight_qscheme,
-        reduce_range=reduce_range,
-    )
-
-    weight_observer_kwargs.update(weight_qconfig_kwargs or {})
-    weight_observer = torch_quantization.FakeQuantize.with_args(
-        **weight_observer_kwargs,
-    )
+    activation_observer = get_observer(symmetric_activations, activation_dtype, activation_bits, reduce_range,
+                                       activation_qconfig_kwargs)
+    weight_observer = get_observer(symmetric_weights, weight_dtype, weight_bits, False, weight_qconfig_kwargs)
     return torch_quantization.QConfig(
         activation=activation_observer,
         weight=weight_observer,
     )
+
+
+def get_observer(symmetric: bool, dtype: torch.dtype, bits: int, reduce_range: bool, qconfig_kwargs: Dict[str, Any]):
+    qscheme = (
+        torch.per_tensor_symmetric if symmetric else torch.per_tensor_affine
+    )
+    quant_min, quant_max = compute_range(dtype, bits)
+    observer_kwargs = dict(
+        observer=torch_quantization.MovingAverageMinMaxObserver,
+        quant_min=quant_min,
+        quant_max=quant_max,
+        dtype=dtype,
+        qscheme=qscheme,
+        reduce_range=reduce_range,
+    )
+    observer_kwargs.update(qconfig_kwargs or {})
+    observer = torch_quantization.FakeQuantize.with_args(
+        **observer_kwargs,
+    )
+
+    return observer
 
 
 def fix_observer_quant_range(module: Module):
@@ -642,7 +648,7 @@ def fix_observer_quant_range(module: Module):
         if isinstance(submodule, torch_quantization.FakeQuantize):
             fake_quantize = submodule
         elif hasattr(submodule, "activation_post_process") and isinstance(
-            submodule.activation_post_process, torch_quantization.FakeQuantize
+                submodule.activation_post_process, torch_quantization.FakeQuantize
         ):
             fake_quantize = submodule.activation_post_process
         else:
@@ -651,9 +657,9 @@ def fix_observer_quant_range(module: Module):
         # continue if fake_quantize quant range not set, or observer quant range is set
         observer = fake_quantize.activation_post_process
         if (
-            fake_quantize.quant_min is None
-            or fake_quantize.quant_max is None
-            or (observer.quant_min is not None or observer.quant_max is not None)
+                fake_quantize.quant_min is None
+                or fake_quantize.quant_max is None
+                or (observer.quant_min is not None or observer.quant_max is not None)
         ):
             continue
         observer.quant_min = fake_quantize.quant_min
@@ -662,14 +668,14 @@ def fix_observer_quant_range(module: Module):
 
 
 def freeze_bn_stats(module: Module):
-    if hasattr(module, "freeze_bn_stats"):
+    if hasattr(module, 'freeze_bn_stats'):
         module.freeze_bn_stats()
 
 
 def fuse_module_conv_bn_relus(
-    module: Module,
-    inplace: bool = True,
-    override_bn_subclasses_forward: Union[bool, str] = True,
+        module: Module,
+        inplace: bool = True,
+        override_bn_subclasses_forward: Union[bool, str] = True,
 ) -> Module:
     """
     Performs fusion of Conv2d, BatchNorm2d, and ReLU layers found in the
@@ -704,14 +710,14 @@ def fuse_module_conv_bn_relus(
     for name, layer in module.named_modules():
         submodule_name = ".".join(name.split(".")[:-1])
         if (
-            len(current_block) == 1  # [Conv2d]
-            and isinstance(layer, BatchNorm2d)
-            and submodule_name == current_block_submodule_name
+                len(current_block) == 1  # [Conv2d]
+                and isinstance(layer, BatchNorm2d)
+                and submodule_name == current_block_submodule_name
         ) or (
-            len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
-            and isinstance(layer, ReLU)
-            and not isinstance(current_block[-1], ReLU)
-            and submodule_name == current_block_submodule_name
+                len(current_block) in [1, 2]  # [Conv2d] or [Conv2d, BatchNorm2d]
+                and isinstance(layer, ReLU)
+                and not isinstance(current_block[-1], ReLU)
+                and submodule_name == current_block_submodule_name
         ):
             if isinstance(layer, ReLU_nm):
                 _set_submodule(module, name, ReLU(inplace=layer.inplace))
@@ -748,11 +754,11 @@ def fuse_module_conv_bn_relus(
 
 
 def prepare_embeddings_qat(
-    module: Module,
-    qconfig: "torch.quantization.QConfig" = None,
-    reduce_range: bool = False,
-    activation_qconfig_kwargs: Dict[str, Any] = {},
-    weight_qconfig_kwargs: Dict[str, Any] = {},
+        module: Module,
+        qconfig: "torch.quantization.QConfig" = None,
+        reduce_range: bool = False,
+        activation_qconfig_kwargs: Dict[str, Any] = {},
+        weight_qconfig_kwargs: Dict[str, Any] = {},
 ):
     """
     adds a fake quantize call to the weights of any Embedding modules in the given
@@ -782,17 +788,24 @@ def prepare_embeddings_qat(
 
 
 def get_updated_qconfig_kwargs(qconfig_kwargs, bits, mode):
-    qconfig_kwargs = qconfig_kwargs.copy() if qconfig_kwargs else {}
+    qconfig_kwargs = (
+        qconfig_kwargs.copy()
+        if qconfig_kwargs
+        else {}
+    )
 
     # update qconfig_kwargs for bits
-    if bits and (qconfig_kwargs.get("quant_min") or qconfig_kwargs.get("quant_max")):
+    if bits and (
+            qconfig_kwargs.get("quant_min")
+            or qconfig_kwargs.get("quant_max")
+    ):
         raise ValueError(
             "Cannot override quant_max and quant_min when number of bits is set"
         )
 
     if bits:
         if mode == "symmetric":
-            quant_min = -(2 ** (bits - 1))
+            quant_min = -2 ** (bits - 1)
             quant_max = 2 ** (bits - 1) - 1
             dtype = torch.qint8
         else:

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -208,9 +208,15 @@ class QATWrapper(Module):
     @staticmethod
     def from_module(
             module: Module,
-            reduce_range: bool = None,
+            symmetric_activations: Optional[bool] = None,
+            symmetric_weights: Optional[bool] = None,
+            reduce_range: bool = False,
             activation_qconfig_kwargs: Dict[str, Any] = {},
             weight_qconfig_kwargs: Dict[str, Any] = {},
+            activation_dtype: Optional[torch.dtype] = None,
+            weight_dtype: Optional[torch.dtype] = None,
+            activation_bits: Optional[int] = None,
+            weight_bits: Optional[int] = None,
     ) -> "QATWrapper":
         """
         :param module: torch Module to create a QATWrapper for
@@ -232,6 +238,18 @@ class QATWrapper(Module):
             else {}
         )
 
+        qat_wrapper_kwargs["symmetric_activations"] = (
+            symmetric_activations
+            if "symmetric_activations" not in qat_wrapper_kwargs
+            else symmetric_activations or qat_wrapper_kwargs["symmetric_activations"]
+        )
+
+        qat_wrapper_kwargs["symmetric_weights"] = (
+            symmetric_weights or False
+            if "symmetric_weights" not in qat_wrapper_kwargs
+            else symmetric_weights or qat_wrapper_kwargs["symmetric_weights"]
+        )
+
         qat_wrapper_kwargs["reduce_range"] = (
             reduce_range or False
             if "reduce_range" not in qat_wrapper_kwargs
@@ -251,6 +269,30 @@ class QATWrapper(Module):
             else weight_qconfig_kwargs or qat_wrapper_kwargs["weight_qconfig_kwargs"]
         )
 
+        qat_wrapper_kwargs["activation_dtype"] = (
+            activation_dtype
+            if "activation_dtype" not in qat_wrapper_kwargs
+            else activation_dtype or qat_wrapper_kwargs["activation_dtype"]
+        )
+
+        qat_wrapper_kwargs["weight_dtype"] = (
+            weight_dtype
+            if "weight_dtype" not in qat_wrapper_kwargs
+            else weight_dtype or qat_wrapper_kwargs["weight_dtype"]
+        )
+
+        qat_wrapper_kwargs["activation_bits"] = (
+            activation_bits
+            if "activation_bits" not in qat_wrapper_kwargs
+            else activation_bits or qat_wrapper_kwargs["activation_bits"]
+        )
+
+        qat_wrapper_kwargs["weight_bits"] = (
+            weight_bits
+            if "weight_bits" not in qat_wrapper_kwargs
+            else weight_bits or qat_wrapper_kwargs["weight_bits"]
+        )
+
         module.qconfig = None
         return QATWrapper(forward_fn=module, **qat_wrapper_kwargs)
 
@@ -266,9 +308,15 @@ class QATWrapper(Module):
             output_qconfigs: Union[
                 "torch.quantization.QConfig", str, List["torch.quantization.QConfig"]
             ] = "asymmetric",
+            symmetric_activations: Optional[bool] = None,
+            symmetric_weights: Optional[bool] = None,
             reduce_range: bool = False,
             activation_qconfig_kwargs: Dict[str, Any] = {},
             weight_qconfig_kwargs: Dict[str, Any] = {},
+            activation_dtype: Optional[torch.dtype] = None,
+            weight_dtype: Optional[torch.dtype] = None,
+            activation_bits: Optional[int] = None,
+            weight_bits: Optional[int] = None,
     ):
         super().__init__()
 
@@ -288,25 +336,43 @@ class QATWrapper(Module):
         num_input_quant_stubs = num_inputs + len(self.kwarg_input_names)
 
         self.forward_fn = forward_fn
+        self._symmetric_activations = symmetric_activations
+        self._symmetric_weights = symmetric_weights
         self._reduce_range = reduce_range
         self._activation_qconfig_kwargs = activation_qconfig_kwargs
         self._weight_qconfig_kwargs = weight_qconfig_kwargs
+        self._activation_dtype = activation_dtype
+        self._weight_dtype = weight_dtype
+        self._activation_bits = activation_bits
+        self._weight_bits = weight_bits
 
         self.input_qconfigs = self._load_qconfigs(
             name="input_qconfigs",
             expected_len=num_input_quant_stubs,
             qconfigs=input_qconfigs,
+            symmetric_activations=self._symmetric_activations,
+            symmetric_weights=self._symmetric_weights,
             reduce_range=self._reduce_range,
             activation_qconfig_kwargs=self._activation_qconfig_kwargs,
             weight_qconfig_kwargs=self._weight_qconfig_kwargs,
+            activation_dtype=self._activation_dtype,
+            weight_dtype=self._weight_dtype,
+            activation_bits=self._activation_bits,
+            weight_bits=self._weight_bits,
         )
         self.output_qconfigs = self._load_qconfigs(
             name="output_qconfigs",
             expected_len=num_outputs,
             qconfigs=output_qconfigs,
+            symmetric_activations=self._symmetric_activations,
+            symmetric_weights=self._symmetric_weights,
             reduce_range=self._reduce_range,
             activation_qconfig_kwargs=self._activation_qconfig_kwargs,
             weight_qconfig_kwargs=self._weight_qconfig_kwargs,
+            activation_dtype=self._activation_dtype,
+            weight_dtype=self._weight_dtype,
+            activation_bits=self._activation_bits,
+            weight_bits=self._weight_bits,
         )
 
         self.input_quant_stubs = torch.nn.ModuleList(
@@ -390,9 +456,15 @@ class QATWrapper(Module):
             name: str,
             expected_len: int,
             qconfigs: Union["QConfig", str, List["QConfig"]],  # noqa: F821
+            symmetric_activations: Optional[bool] = None,
+            symmetric_weights: Optional[bool] = None,
             reduce_range: bool = False,
             activation_qconfig_kwargs: Dict[str, Any] = {},
             weight_qconfig_kwargs: Dict[str, Any] = {},
+            activation_dtype: Optional[torch.dtype] = None,
+            weight_dtype: Optional[torch.dtype] = None,
+            activation_bits: Optional[int] = None,
+            weight_bits: Optional[int] = None,
     ):
         if not isinstance(qconfigs, (str, torch_quantization.QConfig, List)):
             raise ValueError(
@@ -422,11 +494,21 @@ class QATWrapper(Module):
                     f"Found string with value {qconfig} in {name}"
                 )
 
+            if symmetric_activations is None:
+                _symmetric_activations = qconfig == "symmetric"
+            else:
+                _symmetric_activations = symmetric_activations
+
             qconfigs[idx] = get_qat_qconfig(
-                symmetric_activations=(qconfig == "symmetric"),
+                symmetric_activations=_symmetric_activations,
+                symmetric_weights=symmetric_weights,
                 reduce_range=reduce_range,
                 activation_qconfig_kwargs=activation_qconfig_kwargs,
                 weight_qconfig_kwargs=weight_qconfig_kwargs,
+                activation_dtype=activation_dtype,
+                weight_dtype=weight_dtype,
+                activation_bits=activation_bits,
+                weight_bits=weight_bits,
             )
 
         return qconfigs
@@ -463,9 +545,15 @@ def configure_module_bn_wrappers(module: Module):
 
 def configure_module_qat_wrappers(
         module: Module,
+        symmetric_activations: Optional[bool] = None,
+        symmetric_weights: Optional[bool] = None,
         reduce_range: bool = False,
         activation_qconfig_kwargs: Dict[str, Any] = {},
         weight_qconfig_kwargs: Dict[str, Any] = {},
+        activation_dtype: Optional[torch.dtype] = None,
+        weight_dtype: Optional[torch.dtype] = None,
+        activation_bits: Optional[int] = None,
+        weight_bits: Optional[int] = None,
 ):
     """
     if any submodule of the given module has the attribute wrap_qat == True,
@@ -490,29 +578,43 @@ def configure_module_qat_wrappers(
                 child_name,
                 QATWrapper.from_module(
                     module=child_module,
+                    symmetric_activations=symmetric_activations,
+                    symmetric_weights=symmetric_weights,
                     reduce_range=reduce_range,
                     activation_qconfig_kwargs=activation_qconfig_kwargs,
                     weight_qconfig_kwargs=weight_qconfig_kwargs,
+                    activation_dtype=activation_dtype,
+                    weight_dtype=weight_dtype,
+                    activation_bits=activation_bits,
+                    weight_bits=weight_bits,
                 ),
             )
         # recurse on child module
         configure_module_qat_wrappers(
             module=child_module,
+            symmetric_activations=symmetric_activations,
+            symmetric_weights=symmetric_weights,
             reduce_range=reduce_range,
             activation_qconfig_kwargs=activation_qconfig_kwargs,
             weight_qconfig_kwargs=weight_qconfig_kwargs,
+            activation_dtype=activation_dtype,
+            weight_dtype=weight_dtype,
+            activation_bits=activation_bits,
+            weight_bits=weight_bits,
         )
 
 
-def compute_range(dtype: torch.dtype, bits: int):
+def compute_range(dtype: Optional[torch.dtype], bits: Optional[int]):
+    dtype = dtype if dtype else torch.quint8
+    bits = bits if bits else 8
     if dtype == torch.qint8:
-        quant_min = -2 ** (bits - 1)
-        quant_max = 2 ** (bits - 1) - 1
+        quant_min = -(2 ** (bits - 1))
+        quant_max = (2 ** (bits - 1)) - 1
     elif dtype == torch.quint8:
         quant_min = 0
-        quant_max = 2 ** bits - 1
+        quant_max = (2 ** bits) - 1
 
-    return quant_min, quant_max
+    return quant_min, quant_max, dtype
 
 
 def configure_module_default_qconfigs(module: Module):
@@ -575,15 +677,15 @@ def remove_activation_qat_by_layer_name(module: Module, layer_class_names: List[
 
 
 def get_qat_qconfig(
-        symmetric_activations: bool = False,
-        symmetric_weights: bool = True,
+        symmetric_activations: Optional[bool] = None,
+        symmetric_weights: Optional[bool] = None,
         reduce_range: bool = False,
         activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
         weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-        activation_dtype: Optional[torch.dtype] = torch.quint8,
-        weight_dtype: Optional[torch.dtype] = torch.qint8,
-        activation_bits: Optional[int] = 8,
-        weight_bits: Optional[int] = 8,
+        activation_dtype: Optional[torch.dtype] = None,
+        weight_dtype: Optional[torch.dtype] = None,
+        activation_bits: Optional[int] = None,
+        weight_bits: Optional[int] = None,
 ) -> "torch.quantization.QConfig":
     """
     :param symmetric_activations: if True, activations will have a symmetric
@@ -606,18 +708,28 @@ def get_qat_qconfig(
     """
     activation_observer = get_observer(symmetric_activations, activation_dtype, activation_bits, reduce_range,
                                        activation_qconfig_kwargs)
-    weight_observer = get_observer(symmetric_weights, weight_dtype, weight_bits, False, weight_qconfig_kwargs)
+    if symmetric_weights is None:
+        _symmetric_weights = True
+    else:
+        _symmetric_weights = symmetric_weights
+
+    if weight_dtype is None:
+        _weight_dtype = torch.qint8
+    else:
+        _weight_dtype = weight_dtype
+
+    weight_observer = get_observer(_symmetric_weights, weight_dtype, weight_bits, False, weight_qconfig_kwargs)
     return torch_quantization.QConfig(
         activation=activation_observer,
         weight=weight_observer,
     )
 
 
-def get_observer(symmetric: bool, dtype: torch.dtype, bits: int, reduce_range: bool, qconfig_kwargs: Dict[str, Any]):
+def get_observer(symmetric: Optional[bool], dtype: Optional[torch.dtype], bits: Optional[int], reduce_range: bool, qconfig_kwargs: Dict[str, Any]):
     qscheme = (
         torch.per_tensor_symmetric if symmetric else torch.per_tensor_affine
     )
-    quant_min, quant_max = compute_range(dtype, bits)
+    quant_min, quant_max, dtype = compute_range(dtype, bits)
     observer_kwargs = dict(
         observer=torch_quantization.MovingAverageMinMaxObserver,
         quant_min=quant_min,
@@ -756,9 +868,15 @@ def fuse_module_conv_bn_relus(
 def prepare_embeddings_qat(
         module: Module,
         qconfig: "torch.quantization.QConfig" = None,
+        symmetric_activations: Optional[bool] = None,
+        symmetric_weights: Optional[bool] = None,
         reduce_range: bool = False,
-        activation_qconfig_kwargs: Dict[str, Any] = {},
-        weight_qconfig_kwargs: Dict[str, Any] = {},
+        activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+        weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
+        activation_dtype: Optional[torch.dtype] = None,
+        weight_dtype: Optional[torch.dtype] = None,
+        activation_bits: Optional[int] = None,
+        weight_bits: Optional[int] = None,
 ):
     """
     adds a fake quantize call to the weights of any Embedding modules in the given
@@ -776,11 +894,21 @@ def prepare_embeddings_qat(
         Default is False
     """
     if qconfig is None:
+        if symmetric_weights is None:
+            _symmetric_weights = False
+        else:
+            _symmetric_weights = symmetric_weights
+
         qconfig = get_qat_qconfig(
-            symmetric_weights=False,
+            symmetric_activations=symmetric_activations,
+            symmetric_weights=_symmetric_weights,
             reduce_range=reduce_range,
             activation_qconfig_kwargs=activation_qconfig_kwargs,
             weight_qconfig_kwargs=weight_qconfig_kwargs,
+            activation_dtype=activation_dtype,
+            weight_dtype=weight_dtype,
+            activation_bits=activation_bits,
+            weight_bits=weight_bits,
         )
     for submodule in module.modules():
         if type(submodule) is Embedding:

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -93,8 +93,8 @@ class QuantizationModifier(ScheduledModifier):
     :param submodules: List of submodule names to perform QAT on. Leave None to quantize
         entire model. Default is None
     :param model_fuse_fn_name: Name of model function to fuse the model in place prior
-        to performing QAT.  Set as None or 'no_fuse' to skip module fusing. Set as 'conv_bv_relus'
-        to use `sparseml.pytorch.utils.fuse_module_conv_bn_relus`.
+        to performing QAT.  Set as None or 'no_fuse' to skip module fusing. Set as
+         'conv_bv_relus' to use `sparseml.pytorch.utils.fuse_module_conv_bn_relus`.
         Default is None
     :param disable_quantization_observer_epoch: Epoch to disable updates to the module's
         quantization observers. After this point, quantized weights and zero points will
@@ -232,7 +232,7 @@ class QuantizationModifier(ScheduledModifier):
             to performing QAT. None to uses the default function
             `sparseml.pytorch.utils.fuse_module_conv_bn_relus`.
         """
-        fuse_fn = self._model_fuse_fn_name if self._model_fuse_fn_name else 'no_fuse'
+        fuse_fn = self._model_fuse_fn_name if self._model_fuse_fn_name else "no_fuse"
         return fuse_fn
 
     @model_fuse_fn_name.setter
@@ -355,7 +355,6 @@ class QuantizationModifier(ScheduledModifier):
             activations. Default is None, which will quantize activations to 8 bits.
         """
         return self._weight_bits
-
 
     @ModifierProp()
     def activation_qconfig_kwargs(self) -> Dict[str, Any]:
@@ -506,7 +505,7 @@ class QuantizationModifier(ScheduledModifier):
 
     def _enable_module_qat(self, module: Module):
         # fuse module Conv-BNs
-        if self._model_fuse_fn_name == 'conv_bn_relus':
+        if self._model_fuse_fn_name == "conv_bn_relus":
             self._model_fuse_fn_kwargs["inplace"] = True
             fuse_module_conv_bn_relus(module, **self._model_fuse_fn_kwargs)
         elif self.model_fuse_fn_name != "no_fuse":
@@ -529,10 +528,20 @@ class QuantizationModifier(ScheduledModifier):
 
         if not self._quantize_conv_output_activations:
             to_remove_layer_name.extend(
-                ["Conv1d", "Conv2d", "Conv3d",
-                 "ConvBn1d", "ConvBn2d", "ConvBn3d",
-                 "ConvReLU1d", "ConvReLU2d", "ConvReLU3d",
-                 "ConvBnReLU1d", "ConvBnReLU2d", "ConvBnReLU3d"]
+                [
+                    "Conv1d",
+                    "Conv2d",
+                    "Conv3d",
+                    "ConvBn1d",
+                    "ConvBn2d",
+                    "ConvBn3d",
+                    "ConvReLU1d",
+                    "ConvReLU2d",
+                    "ConvReLU3d",
+                    "ConvBnReLU1d",
+                    "ConvBnReLU2d",
+                    "ConvBnReLU3d",
+                ]
             )
 
         # prepare each module / submodule for quantization
@@ -564,7 +573,7 @@ class QuantizationModifier(ScheduledModifier):
             to_exclude.extend(self._exclude_module_types)
 
         if self._exclude_batchnorm:
-            to_exclude.extend(['BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d'])
+            to_exclude.extend(["BatchNorm1d", "BatchNorm2d", "BatchNorm3d"])
 
         self._exclude_module_types = to_exclude
         self._strip_excluded_module_qconfigs(module)
@@ -634,7 +643,9 @@ class QuantizationModifier(ScheduledModifier):
             module.train()
 
     def _get_updated_activation_qconfig_kwargs(self):
-        return get_updated_qconfig_kwargs(self.activation_qconfig_kwargs, self.activation_bits)
+        return get_updated_qconfig_kwargs(
+            self.activation_qconfig_kwargs, self.activation_bits
+        )
 
     def _get_updated_weight_qconfig_kwargs(self):
         return get_updated_qconfig_kwargs(self.weight_qconfig_kwargs, self.weight_bits)

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -234,7 +234,7 @@ class QuantizationModifier(ScheduledModifier):
             to performing QAT. None to uses the default function
             `sparseml.pytorch.utils.fuse_module_conv_bn_relus`.
         """
-        fuse_fn = self._model_fuse_fn_name if self._model_fuse_fn_name else 'no_fuse'
+        fuse_fn = self._model_fuse_fn_name if self._model_fuse_fn_name else 'conv_bn_relus'
         return fuse_fn
 
     @model_fuse_fn_name.setter
@@ -508,8 +508,8 @@ class QuantizationModifier(ScheduledModifier):
 
     def _enable_module_qat(self, module: Module):
         # fuse module Conv-BNs
-        if self._model_fuse_fn_name == 'conv_bn_relus':
-            self._model_fuse_fn_kwargs["inplace"] = True
+        if self.model_fuse_fn_name == 'conv_bn_relus':
+            self.model_fuse_fn_kwargs["inplace"] = True
             fuse_module_conv_bn_relus(module, **self._model_fuse_fn_kwargs)
         elif self.model_fuse_fn_name != "no_fuse":
             module_fuse_fn = getattr(module, self._model_fuse_fn_name, None)

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -509,7 +509,7 @@ class QuantizationModifier(ScheduledModifier):
     def _enable_module_qat(self, module: Module):
         # fuse module Conv-BNs
         if self.model_fuse_fn_name == 'conv_bn_relus':
-            self.model_fuse_fn_kwargs["inplace"] = True
+            self._model_fuse_fn_kwargs["inplace"] = True
             fuse_module_conv_bn_relus(module, **self._model_fuse_fn_kwargs)
         elif self.model_fuse_fn_name != "no_fuse":
             module_fuse_fn = getattr(module, self._model_fuse_fn_name, None)

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -47,14 +47,14 @@ except Exception:
 from sparseml.optim import BaseModifier, ModifierProp
 from sparseml.pytorch.optim.modifier import PyTorchModifierYAML, ScheduledModifier
 from sparseml.pytorch.sparsification.quantization.helpers import (
+    QUANTIZABLE_MODULE_TYPES,
     add_quant_dequant,
-    configure_module_bn_wrappers,
     configure_module_default_qconfigs,
     configure_module_qat_wrappers,
     fix_observer_quant_range,
-    freeze_bn_stats,
     fuse_module_conv_bn_relus,
     get_qat_qconfig,
+    get_updated_qconfig_kwargs,
     prepare_embeddings_qat,
     remove_activation_qat_by_layer_name,
 )
@@ -94,8 +94,8 @@ class QuantizationModifier(ScheduledModifier):
     :param submodules: List of submodule names to perform QAT on. Leave None to quantize
         entire model. Default is None
     :param model_fuse_fn_name: Name of model function to fuse the model in place prior
-        to performing QAT.  Set as None or 'no_fuse' to skip module fusing. Set as
-         'conv_bv_relus' to use `sparseml.pytorch.utils.fuse_module_conv_bn_relus`.
+        to performing QAT.  Set as 'no_fuse' to skip module fusing. Leave None to use
+        the default function `sparseml.pytorch.utils.fuse_module_conv_bn_relus`.
         Default is None
     :param disable_quantization_observer_epoch: Epoch to disable updates to the module's
         quantization observers. After this point, quantized weights and zero points will
@@ -113,26 +113,21 @@ class QuantizationModifier(ScheduledModifier):
     :param reduce_range: if True, the quantization range will be reduced by one bit.
         This may prevent overflow issues with model execution on certain hardware
         Default is False
-    :param quantize_linear_activations: if True, FakeQuantize ops will be run
-        for output activations of fully connected layers. Default is False.
-    :param quantize_conv_activations: if True, FakeQuantize ops will be run
-        for output activations of convolutional layers. Default is False.
+    :param quantize_linear_activations: if False, FakeQuantize ops will not be run
+        for activations of fully connected layers. this is important for quantizing
+        transformer based models such as BERT where the quantized MatMul outputs
+        are kept at 32 bits of precision and fake quantizing the outputs harm training
+        recovery. Default is True
     :param activation_bits: Number of bits to use for setting quant min/max values for
-        activations. Default is None, which will quantize activations to 8 bits.
-    :param weight_bits: Number of bits to use for setting quant min/max values for
-        weights. Default is None, which will quantize weights to 8 bits.
+            activations. Default is None, which will quantize activations to 8 bits.
     :param num_calibration_steps: Number of steps to run post training calibration for.
-        When None, the entire calibration_dataloader is used
-    :param exclude_batchnorm: If True, do not propagate quantization qconfigs to
-        batch-normalization modules
+            When None, the entire calibration_dataloader is used
     :param exclude_module_types: optional list of module class names
         to not propagate quantization configs to. Default is None
     :param activation_qconfig_kwargs: Additional kwargs for quantization of
-        activations.
+            activations.
     :param weight_qconfig_kwargs: Additional kwargs for quantization of
-        weights.
-    :param tenssorrt: if True sets quantization configuration for compatibility with
-       explict quantization as supported by TensorRT 8.2.
+            weights.
     """
 
     def __init__(
@@ -146,16 +141,15 @@ class QuantizationModifier(ScheduledModifier):
         model_fuse_fn_kwargs: Dict[str, Any] = None,
         quantize_embeddings: bool = True,
         reduce_range: bool = False,
-        quantize_linear_activations: bool = False,
-        quantize_conv_activations: bool = False,
+        quantize_linear_output_activations: bool = False,
+        quantize_conv_output_activations: bool = False,
+        quantize_add_input_activations: bool = True,
         activation_bits: Optional[int] = None,
         weight_bits: Optional[int] = None,
         num_calibration_steps: Optional[int] = None,
-        exclude_batchnorm: bool = True,
-        exclude_module_types: Optional[List[str]] = None,
+        exclude_module_types: Union[List[str], None] = None,
         activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
         weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
-        tensorrt: bool = False,
     ):
         if torch_quantization is None or torch_intrinsic is None:
             raise RuntimeError(
@@ -179,11 +173,11 @@ class QuantizationModifier(ScheduledModifier):
         self._freeze_bn_stats_epoch = freeze_bn_stats_epoch
         self._quantize_embeddings = quantize_embeddings
         self._reduce_range = reduce_range
-        self._quantize_linear_activations = quantize_linear_activations
-        self._quantize_conv_activations = quantize_conv_activations
+        self._quantize_linear_output_activations = quantize_linear_output_activations
+        self._quantize_conv_output_activations = quantize_conv_output_activations
+        self._quantize_add_input_activations = quantize_add_input_activations
         self._activation_bits = activation_bits
         self._weight_bits = weight_bits
-        self._exclude_batchnorm = exclude_batchnorm
         self._exclude_module_types = exclude_module_types
 
         self._modules_to_quantize = None
@@ -192,7 +186,6 @@ class QuantizationModifier(ScheduledModifier):
         self._bn_stats_frozen = False
         self._activation_qconfig_kwargs = activation_qconfig_kwargs
         self._weight_qconfig_kwargs = weight_qconfig_kwargs
-        self._tensorrt = tensorrt
 
         self._calibration_dataloader = None
         self._calibration_function = None
@@ -237,21 +230,10 @@ class QuantizationModifier(ScheduledModifier):
     def model_fuse_fn_name(self) -> Union[str, None]:
         """
         :return: Name of model function to fuse the model in place prior
-            to performing QAT. None sets to default function.
-            If tensorrt flag is True, default is 'no_fuse', otherwise
+            to performing QAT. None to uses the default function
             `sparseml.pytorch.utils.fuse_module_conv_bn_relus`.
         """
-        if self._tensorrt:
-            fuse_fn = (
-                self._model_fuse_fn_name if self._model_fuse_fn_name else "no_fuse"
-            )
-        else:
-            fuse_fn = (
-                self._model_fuse_fn_name
-                if self._model_fuse_fn_name
-                else "conv_bn_relus"
-            )
-        return fuse_fn
+        return self._model_fuse_fn_name
 
     @model_fuse_fn_name.setter
     def model_fuse_fn_name(self, value: Union[str, None]):
@@ -280,7 +262,7 @@ class QuantizationModifier(ScheduledModifier):
 
     @disable_quantization_observer_epoch.setter
     def disable_quantization_observer_epoch(self, value: Union[float, None]):
-        """print
+        """
         :params value: Epoch to disable updates to the module's
             quantization observers. After this point, quantized weights and zero points
             will not be updated. Set None to not disable observers during QAT
@@ -332,20 +314,23 @@ class QuantizationModifier(ScheduledModifier):
         return self._reduce_range
 
     @ModifierProp()
-    def quantize_linear_activations(self) -> bool:
+    def quantize_linear_output_activations(self) -> bool:
         """
-        :return: if True, FakeQuantize ops will be run for output activations
-            of fully connected layers
+        :return: if False, FakeQuantize ops will not be run
+            for activations of fully connected layers. this is important for quantizing
+            transformer based models such as BERT where the quantized MatMul outputs
+            are kept at 32 bits of precision and fake quantizing the outputs harm
+            training recovery
         """
-        return self._quantize_linear_activations
+        return self._quantize_linear_output_activations
 
     @ModifierProp()
-    def quantize_conv_activations(self) -> bool:
+    def quantize_conv_output_activations(self) -> bool:
         """
-        :return: if True, FakeQuantize ops will be run for output activations
-            of convolutional layers
+        :return: if False, FakeQuantize ops will not be run
+            for activations of convolutional layers.
         """
-        return self._quantize_conv_activations
+        return self._quantize_linear_output_activations
 
     @ModifierProp()
     def exclude_module_types(self) -> Union[List[str], None]:
@@ -367,9 +352,10 @@ class QuantizationModifier(ScheduledModifier):
     def weight_bits(self) -> Optional[int]:
         """
         :return: Number of bits to be use for setting quant min/max values for
-            weights. Default is None, which will quantize weights to 8 bits.
+            activations. Default is None, which will quantize activations to 8 bits.
         """
         return self._weight_bits
+
 
     @ModifierProp()
     def activation_qconfig_kwargs(self) -> Dict[str, Any]:
@@ -387,16 +373,7 @@ class QuantizationModifier(ScheduledModifier):
             for weights
 
         """
-        if (
-            self._weight_qconfig_kwargs is not None
-            and "observer" in self._weight_qconfig_kwargs
-        ):
-            kwargs = self._weight_qconfig_kwargs.copy()
-            if kwargs["observer"] == "minmaxobserver":
-                kwargs["observer"] = torch_quantization.MinMaxObserver
-            return kwargs
-        else:
-            return self._weight_qconfig_kwargs
+        return self._weight_qconfig_kwargs
 
     @ModifierProp()
     def num_calibration_steps(self) -> Optional[int]:
@@ -405,15 +382,6 @@ class QuantizationModifier(ScheduledModifier):
             When None, the entire calibration_dataloader is used
         """
         return self._num_calibration_steps
-
-    @ModifierProp()
-    def tensorrt(self) -> Dict[str, Any]:
-        """
-        :return: Dictionary with correct quant_min, quant_max, and dtype values
-            for activations
-
-        """
-        return self._tensorrt
 
     def initialize(
         self,
@@ -448,7 +416,10 @@ class QuantizationModifier(ScheduledModifier):
         if self._submodules is not None:
             found_submodules = []
             for name, submodule in module.named_modules():
-                if name in self._submodules:
+                if (
+                        type(submodule) in QUANTIZABLE_MODULE_TYPES
+                        and name in self._submodules
+                ):
                     self._modules_to_quantize.append(_ModuleToQuantize(name, submodule))
                     found_submodules.append(name)
             if not len(found_submodules) == len(self._submodules):
@@ -533,15 +504,15 @@ class QuantizationModifier(ScheduledModifier):
 
         if self._freeze_bn_stats_update_ready(epoch):
             for _, quant_module in self._modules_to_quantize:
-                quant_module.apply(freeze_bn_stats)
+                quant_module.apply(torch_intrinsic.qat.freeze_bn_stats)
             self._bn_stats_frozen = True
 
     def _enable_module_qat(self, module: Module):
         # fuse module Conv-BNs
-        if self.model_fuse_fn_name == "conv_bn_relus":
-            self._model_fuse_fn_kwargs["inplace"] = True
-            fuse_module_conv_bn_relus(module, **self._model_fuse_fn_kwargs)
-        elif self.model_fuse_fn_name != "no_fuse":
+        if (
+            self._model_fuse_fn_name is not None
+            and self._model_fuse_fn_name != "no_fuse"
+        ):  # module class fn
             module_fuse_fn = getattr(module, self._model_fuse_fn_name, None)
             if module_fuse_fn is None or not callable(module_fuse_fn):
                 raise ValueError(
@@ -551,105 +522,49 @@ class QuantizationModifier(ScheduledModifier):
                     )
                 )
             module_fuse_fn(**self._model_fuse_fn_kwargs)
+        elif self._model_fuse_fn_name is None:  # default auto fn
+            self._model_fuse_fn_kwargs["inplace"] = True
+            fuse_module_conv_bn_relus(module, **self._model_fuse_fn_kwargs)
 
-        # build list of layer types that should not quantize output activations
+        activation_qconfig_kwargs = self._get_updated_activation_qconfig_kwargs()
+        weight_qconfig_kwargs = self._get_updated_weight_qconfig_kwargs()
+
         to_remove_layer_name = []
-        if not self._quantize_linear_activations:
-            to_remove_layer_name.extend(["Linear", "LinearReLU"])
+        if not self._quantize_linear_output_activations:
+            to_remove_layer_name.extend(["Linear", "LinearReLu"])
 
-        if not self._quantize_conv_activations:
+        if not self._quantize_conv_output_activations:
             to_remove_layer_name.extend(
-                [
-                    "Conv1d",
-                    "Conv2d",
-                    "Conv3d",
-                    "ConvBn1d",
-                    "ConvBn2d",
-                    "ConvBn3d",
-                    "ConvReLU1d",
-                    "ConvReLU2d",
-                    "ConvReLU3d",
-                    "ConvBnReLU1d",
-                    "ConvBnReLU2d",
-                    "ConvBnReLU3d",
-                ]
+                ["Conv1d", "Conv2d", "Conv3d",
+                 "ConvBn1d", "ConvBn2d", "ConvBn3d",
+                 "ConvReLU1d", "ConvReLU2d", "ConvReLU3d",
+                 "ConvBnReLU1d", "ConvBnReLU2d", "ConvBnReLU3d"]
             )
-        if len(to_remove_layer_name) == 0:
-            to_remove_layer_name = None
-
-        # fix for freezing batchnorm statistics when not fusing BN with convs.
-        # pytorch only supports freezing batchnorm statistics for fused modules.
-        # this fix wraps BN modules adding with a new module class that supports
-        # methods related to freezing/unfreezing BN statistics.
-        configure_module_bn_wrappers(module)
-
-        # set qconfig.
-        # if tensorrt flag is used, set activation and weights to symmetric
-        # quantization.
-        # otherwise, use the default values set in get_qat_qconfig
-        if self.tensorrt:
-            _symmetric_activations = True
-            _activation_dtype = torch.qint8
-            _symmetric_weights = True
-            _weight_dtype = torch.qint8
-        else:
-            _symmetric_activations = None
-            _activation_dtype = None
-            _symmetric_weights = None
-            _weight_dtype = None
-
-        qconfig = get_qat_qconfig(
-            symmetric_activations=_symmetric_activations,
-            symmetric_weights=_symmetric_weights,
-            reduce_range=self._reduce_range,
-            activation_qconfig_kwargs=self.activation_qconfig_kwargs,
-            weight_qconfig_kwargs=self.weight_qconfig_kwargs,
-            activation_dtype=_activation_dtype,
-            weight_dtype=_weight_dtype,
-            activation_bits=self.activation_bits,
-            weight_bits=self.weight_bits,
-        )
 
         # prepare each module / submodule for quantization
+        qconfig = get_qat_qconfig(
+            reduce_range=self._reduce_range,
+            activation_qconfig_kwargs=activation_qconfig_kwargs,
+            weight_qconfig_kwargs=weight_qconfig_kwargs,
+        )
         for name, quant_module in self._modules_to_quantize:
             # wrap any modules with wrap_qat set to True as QATWrapper(s)
             configure_module_qat_wrappers(
                 quant_module,
-                symmetric_activations=_symmetric_activations,
-                symmetric_weights=_symmetric_weights,
                 reduce_range=self._reduce_range,
-                activation_qconfig_kwargs=self.activation_qconfig_kwargs,
-                weight_qconfig_kwargs=self.weight_qconfig_kwargs,
-                activation_dtype=_activation_dtype,
-                weight_dtype=_weight_dtype,
-                activation_bits=self.activation_bits,
-                weight_bits=self.weight_bits,
+                activation_qconfig_kwargs=activation_qconfig_kwargs,
+                weight_qconfig_kwargs=weight_qconfig_kwargs,
             )
-
             # set quantization config (asymmetric activations, symmetric weights)
             quant_module.qconfig = qconfig
-
             # wrap all conv / linear blocks in with quantization observers
             torch_quantization.propagate_qconfig_(quant_module)
             configure_module_default_qconfigs(quant_module)
 
             add_quant_dequant(quant_module, name, module)
-
-            # Remove output quantization from appropriate modules
-            if to_remove_layer_name:
-                remove_activation_qat_by_layer_name(quant_module, to_remove_layer_name)
+            remove_activation_qat_by_layer_name(quant_module, to_remove_layer_name)
 
         # remove qconfigs for module types in exclude_module_types
-        to_exclude = []
-        if self._exclude_module_types:
-            to_exclude.extend(self._exclude_module_types)
-
-        # if exclude_batchnorm flag is used, add batch norm layers to list of
-        # modules to exclude qconfig
-        if self._exclude_batchnorm:
-            to_exclude.extend(["BatchNorm1d", "BatchNorm2d", "BatchNorm3d"])
-
-        self._exclude_module_types = to_exclude
         if self._exclude_module_types:
             self._strip_excluded_module_qconfigs(module)
 
@@ -658,15 +573,9 @@ class QuantizationModifier(ScheduledModifier):
         if self._quantize_embeddings:
             prepare_embeddings_qat(
                 module,
-                symmetric_activations=_symmetric_activations,
-                symmetric_weights=_symmetric_weights,
                 reduce_range=self._reduce_range,
-                activation_qconfig_kwargs=self.activation_qconfig_kwargs,
-                weight_qconfig_kwargs=self.weight_qconfig_kwargs,
-                activation_dtype=_activation_dtype,
-                weight_dtype=_weight_dtype,
-                activation_bits=self.activation_bits,
-                weight_bits=self.weight_bits,
+                activation_qconfig_kwargs=activation_qconfig_kwargs,
+                weight_qconfig_kwargs=weight_qconfig_kwargs,
             )
 
         # propagate custom quant min/max range from FakeQuantize to Observer objects
@@ -722,6 +631,12 @@ class QuantizationModifier(ScheduledModifier):
 
         if module_training:
             module.train()
+
+    def _get_updated_activation_qconfig_kwargs(self):
+        return get_updated_qconfig_kwargs(self.activation_qconfig_kwargs, self.activation_bits)
+
+    def _get_updated_weight_qconfig_kwargs(self):
+        return get_updated_qconfig_kwargs(self.weight_qconfig_kwargs, self.weight_bits)
 
     def _disable_quantization_observer_update_ready(self, epoch: float) -> bool:
         return (

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -141,8 +141,8 @@ class QuantizationModifier(ScheduledModifier):
         model_fuse_fn_kwargs: Dict[str, Any] = None,
         quantize_embeddings: bool = True,
         reduce_range: bool = False,
-        quantize_linear_output_activations: bool = False,
-        quantize_conv_output_activations: bool = False,
+        quantize_linear_activations: bool = False,
+        quantize_conv_activations: bool = False,
         activation_bits: Optional[int] = None,
         weight_bits: Optional[int] = None,
         num_calibration_steps: Optional[int] = None,
@@ -174,8 +174,8 @@ class QuantizationModifier(ScheduledModifier):
         self._freeze_bn_stats_epoch = freeze_bn_stats_epoch
         self._quantize_embeddings = quantize_embeddings
         self._reduce_range = reduce_range
-        self._quantize_linear_output_activations = quantize_linear_output_activations
-        self._quantize_conv_output_activations = quantize_conv_output_activations
+        self._quantize_linear_activations = quantize_linear_activations
+        self._quantize_conv_activations = quantize_conv_activations
         self._activation_bits = activation_bits
         self._weight_bits = weight_bits
         self._exclude_batchnorm = exclude_batchnorm
@@ -320,7 +320,7 @@ class QuantizationModifier(ScheduledModifier):
         return self._reduce_range
 
     @ModifierProp()
-    def quantize_linear_output_activations(self) -> bool:
+    def quantize_linear_activations(self) -> bool:
         """
         :return: if False, FakeQuantize ops will not be run
             for activations of fully connected layers. this is important for quantizing
@@ -328,15 +328,15 @@ class QuantizationModifier(ScheduledModifier):
             are kept at 32 bits of precision and fake quantizing the outputs harm
             training recovery
         """
-        return self._quantize_linear_output_activations
+        return self._quantize_linear_activations
 
     @ModifierProp()
-    def quantize_conv_output_activations(self) -> bool:
+    def quantize_conv_activations(self) -> bool:
         """
         :return: if False, FakeQuantize ops will not be run
             for activations of convolutional layers.
         """
-        return self._quantize_conv_output_activations
+        return self._quantize_conv_activations
 
     @ModifierProp()
     def exclude_module_types(self) -> Union[List[str], None]:
@@ -544,10 +544,10 @@ class QuantizationModifier(ScheduledModifier):
             module_fuse_fn(**self._model_fuse_fn_kwargs)
 
         to_remove_layer_name = []
-        if not self._quantize_linear_output_activations:
+        if not self._quantize_linear_activations:
             to_remove_layer_name.extend(["Linear", "LinearReLU"])
 
-        if not self._quantize_conv_output_activations:
+        if not self._quantize_conv_activations:
             to_remove_layer_name.extend(
                 ["Conv1d", "Conv2d", "Conv3d",
                  "ConvBn1d", "ConvBn2d", "ConvBn3d",

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -379,7 +379,7 @@ class QuantizationModifier(ScheduledModifier):
             for weights
 
         """
-        if "observer" in self._weight_qconfig_kwargs:
+        if self._weight_qconfig_kwargs is not None and "observer" in self._weight_qconfig_kwargs:
             kwargs = self._weight_qconfig_kwargs.copy()
             if kwargs["observer"] == "minmaxobserver":
                 kwargs["observer"] = torch_quantization.MinMaxObserver

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -242,9 +242,15 @@ class QuantizationModifier(ScheduledModifier):
             `sparseml.pytorch.utils.fuse_module_conv_bn_relus`.
         """
         if self._tensorrt:
-            fuse_fn = self._model_fuse_fn_name if self._model_fuse_fn_name else 'no_fuse'
+            fuse_fn = (
+                self._model_fuse_fn_name if self._model_fuse_fn_name else "no_fuse"
+            )
         else:
-            fuse_fn = self._model_fuse_fn_name if self._model_fuse_fn_name else 'conv_bn_relus'
+            fuse_fn = (
+                self._model_fuse_fn_name
+                if self._model_fuse_fn_name
+                else "conv_bn_relus"
+            )
         return fuse_fn
 
     @model_fuse_fn_name.setter
@@ -365,7 +371,6 @@ class QuantizationModifier(ScheduledModifier):
         """
         return self._weight_bits
 
-
     @ModifierProp()
     def activation_qconfig_kwargs(self) -> Dict[str, Any]:
         """
@@ -382,15 +387,16 @@ class QuantizationModifier(ScheduledModifier):
             for weights
 
         """
-        if self._weight_qconfig_kwargs is not None and "observer" in self._weight_qconfig_kwargs:
+        if (
+            self._weight_qconfig_kwargs is not None
+            and "observer" in self._weight_qconfig_kwargs
+        ):
             kwargs = self._weight_qconfig_kwargs.copy()
             if kwargs["observer"] == "minmaxobserver":
                 kwargs["observer"] = torch_quantization.MinMaxObserver
             return kwargs
         else:
             return self._weight_qconfig_kwargs
-
-
 
     @ModifierProp()
     def num_calibration_steps(self) -> Optional[int]:
@@ -532,7 +538,7 @@ class QuantizationModifier(ScheduledModifier):
 
     def _enable_module_qat(self, module: Module):
         # fuse module Conv-BNs
-        if self.model_fuse_fn_name == 'conv_bn_relus':
+        if self.model_fuse_fn_name == "conv_bn_relus":
             self._model_fuse_fn_kwargs["inplace"] = True
             fuse_module_conv_bn_relus(module, **self._model_fuse_fn_kwargs)
         elif self.model_fuse_fn_name != "no_fuse":
@@ -553,10 +559,20 @@ class QuantizationModifier(ScheduledModifier):
 
         if not self._quantize_conv_activations:
             to_remove_layer_name.extend(
-                ["Conv1d", "Conv2d", "Conv3d",
-                 "ConvBn1d", "ConvBn2d", "ConvBn3d",
-                 "ConvReLU1d", "ConvReLU2d", "ConvReLU3d",
-                 "ConvBnReLU1d", "ConvBnReLU2d", "ConvBnReLU3d"]
+                [
+                    "Conv1d",
+                    "Conv2d",
+                    "Conv3d",
+                    "ConvBn1d",
+                    "ConvBn2d",
+                    "ConvBn3d",
+                    "ConvReLU1d",
+                    "ConvReLU2d",
+                    "ConvReLU3d",
+                    "ConvBnReLU1d",
+                    "ConvBnReLU2d",
+                    "ConvBnReLU3d",
+                ]
             )
         if len(to_remove_layer_name) == 0:
             to_remove_layer_name = None
@@ -591,7 +607,7 @@ class QuantizationModifier(ScheduledModifier):
             activation_dtype=_activation_dtype,
             weight_dtype=_weight_dtype,
             activation_bits=self.activation_bits,
-            weight_bits=self.weight_bits
+            weight_bits=self.weight_bits,
         )
 
         # prepare each module / submodule for quantization
@@ -607,7 +623,7 @@ class QuantizationModifier(ScheduledModifier):
                 activation_dtype=_activation_dtype,
                 weight_dtype=_weight_dtype,
                 activation_bits=self.activation_bits,
-                weight_bits=self.weight_bits
+                weight_bits=self.weight_bits,
             )
 
             # set quantization config (asymmetric activations, symmetric weights)
@@ -631,7 +647,7 @@ class QuantizationModifier(ScheduledModifier):
         # if exclude_batchnorm flag is used, add batch norm layers to list of
         # modules to exclude qconfig
         if self._exclude_batchnorm:
-            to_exclude.extend(['BatchNorm1d', 'BatchNorm2d', 'BatchNorm3d'])
+            to_exclude.extend(["BatchNorm1d", "BatchNorm2d", "BatchNorm3d"])
 
         self._exclude_module_types = to_exclude
         if self._exclude_module_types:


### PR DESCRIPTION
Changes in quantization:

1. Created flag to remove Q/DQ from output activations for conv layers. Set to True by default.
2. Changed default to True for flag to remove Q/DQ from output activations for linear layers.
3. Created flag to change number of bits for weight activation (similar to the already existing flag for activation bits).
4. Created flag to avoid quantization of BatchNorm layers when fusing is not used. Set to True by default.
6. Created flag to enable quantization compatible with tensorrt. Set to False by default.
    - Sets activation quantization to symmetric and UINT8.
    - Sets default fusing function to 'no_fuse'.
7. Created a wrapper module (BNWrapper) that allows one to freeze BatchNorm statistics when BN layers are not fused. PyTorch default only works when BN layers are fused.
8. Crated a wrapper module (_AddReLU) for the FloatFunctional class that performs the Add + ReLU operations in ResNet. This wrapper enables the module to be wrapped by a QATWrapper when quantized, and is set to quantize only the first input.