### PR TITLE
No need to infer again inputs_device

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_distillation.py
+++ b/src/sparseml/pytorch/optim/modifier_distillation.py
@@ -299,7 +299,7 @@ class DistillationModifier(ScheduledUpdateModifier):
                 f"Teacher device {teacher_device} does not match "
                 f"inputs device {inputs_device}, moving teacher to correct device"
             )
-            self._teacher.to(device_of(teacher_inputs))
+            self._teacher.to(inputs_device)
 
         with torch.no_grad():
             teacher_outputs = tensors_module_forward(


### PR DESCRIPTION
Just a tiny fix to avoid unnecessary call to `device_of(teacher_inputs)`.