### PR TITLE
[quantization-refactor] mark/propagate conv export mode

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -673,6 +673,12 @@ class QuantizationModifier(ScheduledModifier):
         self._qat_enabled = True
         self._calibrate_if_possible(module)
 
+        # mark export mode for module Conv layers
+        module.export_with_qlinearconv = self._quantize_conv_activations
+        if hasattr(module, "module"):
+            # for DP/DDP unwrapping
+            module.module.export_with_qlinearconv = self._quantize_conv_activations
+
     def _calibrate_if_possible(self, module):
         if self.num_calibration_steps == 0 and self._calibration_dataloader:
             warnings.warn(

--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -498,7 +498,15 @@ def export_onnx(
             quantize_torch_qat_export,
         )
 
-        quantize_torch_qat_export(model=file_path, output_file_path=file_path)
+        use_qlinearconv = hasattr(module, "export_with_qlinearconv") and (
+            module.export_with_qlinearconv
+        )
+
+        quantize_torch_qat_export(
+            model=file_path,
+            output_file_path=file_path,
+            use_qlinearconv=use_qlinearconv,
+        )
 
     if skip_input_quantize:
         try:


### PR DESCRIPTION
ensures that if a module is quantized with `quantize_conv_activations=False` the new ONNX export conversion for `ConvInteger` will be run. Maintains backwards compatibility for existing recipes/exports