### PR TITLE
Long mask_type backwards compatibility

### DIFF
--- a/src/sparseml/sparsification/modifier_pruning.py
+++ b/src/sparseml/sparsification/modifier_pruning.py
@@ -168,7 +168,7 @@ class GMPruningModifier(BaseModifier, BaseScheduled, BaseUpdate):
         self._leave_enabled = convert_to_bool(leave_enabled)
         self._inter_func = inter_func
         self._mask_type = mask_type
-        if len(self._mask_type) > 2 and all(i==1 for i in mask_type[2:]):
+        if len(self._mask_type) > 2 and all(i == 1 for i in mask_type[2:]):
             self._mask_type = self._mask_type[:2]
         self._leave_enabled = convert_to_bool(leave_enabled)
 

--- a/src/sparseml/sparsification/modifier_pruning.py
+++ b/src/sparseml/sparsification/modifier_pruning.py
@@ -168,7 +168,7 @@ class GMPruningModifier(BaseModifier, BaseScheduled, BaseUpdate):
         self._leave_enabled = convert_to_bool(leave_enabled)
         self._inter_func = inter_func
         self._mask_type = mask_type
-        if len(self._mask_type) > 2 and all(i == 1 for i in mask_type[2:]):
+        if len(self._mask_type) > 2 and all(i == 1 for i in self.mask_type[2:]):
             self._mask_type = self._mask_type[:2]
         self._leave_enabled = convert_to_bool(leave_enabled)
 

--- a/src/sparseml/sparsification/modifier_pruning.py
+++ b/src/sparseml/sparsification/modifier_pruning.py
@@ -168,6 +168,8 @@ class GMPruningModifier(BaseModifier, BaseScheduled, BaseUpdate):
         self._leave_enabled = convert_to_bool(leave_enabled)
         self._inter_func = inter_func
         self._mask_type = mask_type
+        if len(self._mask_type) > 2 and all(i==1 for i in mask_type[2:]):
+            self._mask_type = self._mask_type[:2]
         self._leave_enabled = convert_to_bool(leave_enabled)
 
         self.validate()


### PR DESCRIPTION
Yolov5 quantized models on sparsezoo have length 4 mask_types which are not currently supported (i.e. [1, 4, 1, 1]. This PR adds backwards compatibility for those masks.