### PR TITLE
Use teacher's tokenizer if different from the student's

### DIFF
--- a/src/sparseml/pytorch/optim/modifier_distillation.py
+++ b/src/sparseml/pytorch/optim/modifier_distillation.py
@@ -278,15 +278,12 @@ class DistillationModifier(ScheduledUpdateModifier):
                 "distillation loss update"
             )
 
-        teacher_inputs = (
-            (
+        if teacher_inputs is None:
+            teacher_inputs = (
                 student_inputs
                 if not self._teacher_input_keys
                 else {key: student_inputs[key] for key in self._teacher_input_keys}
             )
-            if teacher_inputs is None
-            else teacher_inputs
-        )
 
         # copy to keep from updating student's inputs
         teacher_inputs = deepcopy(teacher_inputs)

--- a/src/sparseml/pytorch/optim/modifier_distillation.py
+++ b/src/sparseml/pytorch/optim/modifier_distillation.py
@@ -377,7 +377,7 @@ class DistillationModifier(ScheduledUpdateModifier):
                 target=TF.softmax(teacher_val / self._temperature, dim=-1),
                 reduction="sum",
             )
-            * (self._temperature**2)
+            * (self._temperature ** 2)
             / (student_val.numel() / student_val.shape[-1])
         )
         return v

--- a/src/sparseml/pytorch/optim/modifier_distillation.py
+++ b/src/sparseml/pytorch/optim/modifier_distillation.py
@@ -99,6 +99,8 @@ class DistillationModifier(ScheduledUpdateModifier):
         self._teacher = None
         self._distillation_enabled = False
 
+        self._logged_loss_terms = {}
+
     @BaseModifier.sparsification_types.getter
     def sparsification_types(self) -> List[SparsificationTypes]:
         """
@@ -248,6 +250,7 @@ class DistillationModifier(ScheduledUpdateModifier):
         steps_per_epoch: int,
         student_outputs: Union[Tensor, Dict, Iterable] = None,
         student_inputs: Union[Tensor, Iterable[Tensor], Dict[Any, Tensor]] = None,
+        teacher_inputs: Union[Tensor, Iterable[Tensor], Dict[Any, Tensor]] = None,
         **kwargs,
     ) -> Tensor:
         """
@@ -261,27 +264,30 @@ class DistillationModifier(ScheduledUpdateModifier):
             (calculate batch number using this and epoch)
         :return: loss tensor with knowledge distillation loss added
         """
-        self._latest_student_loss = None
-        self._latest_teacher_loss = None
-        self._latest_distillation_loss = None
-        self._latest_student_loss = super().loss_update(
+        loss = super().loss_update(
             loss, module, optimizer, epoch, steps_per_epoch, **kwargs
         )
+        self._logged_loss_terms["task_loss"] = loss
 
         if not self.update_ready(epoch, steps_per_epoch):
-            return self._latest_student_loss
+            return loss
 
         if student_outputs is None or student_inputs is None:
             raise ValueError(
-                "Student outputs and teacher inputs are required for "
+                "Student outputs and student inputs are required for "
                 "distillation loss update"
             )
 
         teacher_inputs = (
-            student_inputs
-            if not self._teacher_input_keys
-            else {key: student_inputs[key] for key in self._teacher_input_keys}
+            (
+                student_inputs
+                if not self._teacher_input_keys
+                else {key: student_inputs[key] for key in self._teacher_input_keys}
+            )
+            if teacher_inputs is None
+            else teacher_inputs
         )
+
         # copy to keep from updating student's inputs
         teacher_inputs = deepcopy(teacher_inputs)
 
@@ -312,29 +318,13 @@ class DistillationModifier(ScheduledUpdateModifier):
                 f"teacher output type of {type(teacher_outputs)}"
             )
 
-        distill_losses = []
-        if isinstance(student_outputs, Tensor):
-            distill_losses.append(
-                self._calc_distill_loss(student_outputs, teacher_outputs)
-            )
-        elif isinstance(student_outputs, Dict):
-            for key in self._distill_output_keys or student_outputs:
-                distill_losses.append(
-                    self._calc_distill_loss(student_outputs[key], teacher_outputs[key])
-                )
-        elif isinstance(student_outputs, Iterable):
-            for idx in self._distill_output_keys or range(len(student_outputs)):
-                distill_losses.append(
-                    self._calc_distill_loss(student_outputs[idx], teacher_outputs[idx])
-                )
-
-        # get distillation loss as average of individual output distillation loss values
-        self._latest_teacher_loss = sum(distill_losses) / len(distill_losses)
-        self._latest_distillation_loss = ((1.0 - self._hardness) * loss) + (
-            self._hardness * self._latest_teacher_loss
+        teacher_loss = self._kldiv_output_loss(student_outputs, teacher_outputs)
+        total_loss = ((1.0 - self._hardness) * loss) + (self._hardness * teacher_loss)
+        self._logged_loss_terms.update(
+            {"teacher_loss": teacher_loss, "total_loss": total_loss}
         )
 
-        return self._latest_distillation_loss
+        return total_loss
 
     def log_update(
         self,
@@ -354,13 +344,8 @@ class DistillationModifier(ScheduledUpdateModifier):
         """
         super().log_update(module, optimizer, epoch, steps_per_epoch)
 
-        losses = {
-            "original_loss": self._latest_student_loss,
-            "teacher_loss": self._latest_teacher_loss,
-            "distillation_loss": self._latest_distillation_loss,
-        }
         self.log_named_scalars(
-            name_value_pairs=losses.items(),
+            name_value_pairs=self._logged_loss_terms.items(),
             epoch=epoch,
             steps_per_epoch=steps_per_epoch,
         )
@@ -383,13 +368,44 @@ class DistillationModifier(ScheduledUpdateModifier):
         self._teacher = None
         self._distillation_enabled = False
 
-    def _calc_distill_loss(self, student_val: Tensor, teacher_val: Tensor) -> Tensor:
-        return (
+    def _calc_distill_head_output_loss(
+        self, student_val: Tensor, teacher_val: Tensor
+    ) -> Tensor:
+        v = (
             TF.kl_div(
                 input=TF.log_softmax(student_val / self._temperature, dim=-1),
                 target=TF.softmax(teacher_val / self._temperature, dim=-1),
                 reduction="sum",
             )
-            / (student_val.numel() / student_val.shape[-1])  # scale "sum" w/ batchsize
-            * (self._temperature ** 2)
+            * (self._temperature**2)
+            / (student_val.numel() / student_val.shape[-1])
         )
+        return v
+
+    def _kldiv_output_loss(self, student_outputs, teacher_outputs):
+        # Distillation loss from the head outputs
+        distill_head_output_losses = []
+        if isinstance(student_outputs, Tensor):
+            distill_head_output_losses.append(
+                self._calc_distill_head_output_loss(student_outputs, teacher_outputs)
+            )
+        elif isinstance(student_outputs, Dict):
+            for key in self._distill_output_keys or student_outputs:
+                distill_head_output_losses.append(
+                    self._calc_distill_head_output_loss(
+                        student_outputs[key], teacher_outputs[key]
+                    )
+                )
+        elif isinstance(student_outputs, Iterable):
+            for idx in self._distill_output_keys or range(len(student_outputs)):
+                distill_head_output_losses.append(
+                    self._calc_distill_head_output_loss(
+                        student_outputs[idx], teacher_outputs[idx]
+                    )
+                )
+        kldiv_output_loss = (
+            sum(distill_head_output_losses) / len(distill_head_output_losses)
+            if distill_head_output_losses
+            else 0.0
+        )
+        return kldiv_output_loss

--- a/src/sparseml/transformers/masked_language_modeling.py
+++ b/src/sparseml/transformers/masked_language_modeling.py
@@ -482,6 +482,10 @@ def main():
         tokenizer = AutoTokenizer.from_pretrained(
             model_args.tokenizer_name, **tokenizer_kwargs
         )
+    elif model_args.distill_teacher is not None:
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_args.distill_teacher, **tokenizer_kwargs
+        )
     elif model_args.model_name_or_path:
         tokenizer = AutoTokenizer.from_pretrained(
             model_args.model_name_or_path, **tokenizer_kwargs

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -24,6 +24,7 @@ Fine-tuning the library models for question answering integrated with sparseml
 # You can also adapt this script on your own question answering task.
 # Pointers for this are left as comments.
 
+import inspect
 import logging
 import os
 import sys
@@ -428,7 +429,29 @@ def main():
         use_auth_token=True if model_args.use_auth_token else None,
     )
 
+    model, teacher = SparseAutoModel.question_answering_from_pretrained_distil(
+        model_name_or_path=model_args.model_name_or_path,
+        model_kwargs={
+            "config": config,
+            "cache_dir": model_args.cache_dir,
+            "revision": model_args.model_revision,
+            "use_auth_token": True if model_args.use_auth_token else None,
+        },
+        teacher_name_or_path=model_args.distill_teacher,
+        teacher_kwargs={
+            "cache_dir": model_args.cache_dir,
+            "use_auth_token": True if model_args.use_auth_token else None,
+        },
+    )
+
     if model_args.distill_teacher is not None:
+        model_forward_params = list(inspect.signature(model.forward).parameters.keys())
+        teacher_forward_params = list(
+            inspect.signature(teacher.forward).parameters.keys()
+        )
+        diff = [p for p in model_forward_params if p not in teacher_forward_params]
+        if diff:
+            raise RuntimeError("Teacher tokenizer cannot be used for student.")
         tokenizer_src = model_args.distill_teacher
     else:
         tokenizer_src = (
@@ -443,20 +466,6 @@ def main():
         use_fast=True,
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
-    )
-    model, teacher = SparseAutoModel.question_answering_from_pretrained_distil(
-        model_name_or_path=model_args.model_name_or_path,
-        model_kwargs={
-            "config": config,
-            "cache_dir": model_args.cache_dir,
-            "revision": model_args.model_revision,
-            "use_auth_token": True if model_args.use_auth_token else None,
-        },
-        teacher_name_or_path=model_args.distill_teacher,
-        teacher_kwargs={
-            "cache_dir": model_args.cache_dir,
-            "use_auth_token": True if model_args.use_auth_token else None,
-        },
     )
 
     # Tokenizer check: this script requires a fast tokenizer.

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -427,10 +427,18 @@ def main():
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
     )
+
+    if model_args.distill_teacher is not None:
+        tokenizer_src = model_args.distill_teacher
+    else:
+        tokenizer_src = (
+            model_args.tokenizer_name
+            if model_args.tokenizer_name
+            else model_args.model_name_or_path
+        )
+
     tokenizer = AutoTokenizer.from_pretrained(
-        model_args.tokenizer_name
-        if model_args.tokenizer_name
-        else model_args.model_name_or_path,
+        tokenizer_src,
         cache_dir=model_args.cache_dir,
         use_fast=True,
         revision=model_args.model_revision,

--- a/src/sparseml/transformers/sparsification/question_answering.py
+++ b/src/sparseml/transformers/sparsification/question_answering.py
@@ -27,6 +27,7 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import datasets
 import numpy as np
 from torch.nn import Module
 from tqdm.auto import tqdm
@@ -220,7 +221,8 @@ class QuestionAnsweringTrainer(TrainerInterface, _QuestionAnsweringTrainer):
                 model_signature_columns | teacher_signature_columns
             )
 
-            # Labels may be named label or label_ids, the default data collator handles that.
+            # Labels may be named label or label_ids, the default data
+            # collator handles that.
             self._signature_columns += ["label", "label_ids"]
 
         return super()._remove_unused_columns(dataset, description)

--- a/src/sparseml/transformers/sparsification/question_answering.py
+++ b/src/sparseml/transformers/sparsification/question_answering.py
@@ -21,6 +21,7 @@ Training and post-processing utilities for question answering.
 """
 
 import collections
+import inspect
 import json
 import logging
 import os
@@ -204,6 +205,25 @@ class QuestionAnsweringTrainer(TrainerInterface, _QuestionAnsweringTrainer):
             teacher=teacher,
             **kwargs,
         )
+
+    def _remove_unused_columns(
+        self, dataset: "datasets.Dataset", description: Optional[str] = None
+    ):
+        if self._signature_columns is None and self.teacher is not None:
+            model_signature = inspect.signature(self.model.forward)
+            model_signature_columns = set(model_signature.parameters.keys())
+
+            teacher_signature = inspect.signature(self.teacher.forward)
+            teacher_signature_columns = set(teacher_signature.parameters.keys())
+
+            self._signature_columns = list(
+                model_signature_columns | teacher_signature_columns
+            )
+
+            # Labels may be named label or label_ids, the default data collator handles that.
+            self._signature_columns += ["label", "label_ids"]
+
+        return super()._remove_unused_columns(dataset, description)
 
 
 def postprocess_qa_predictions(

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -23,6 +23,7 @@ import math
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import datasets
 import torch
 from torch import distributed as dist
 from torch.nn import Module
@@ -736,6 +737,8 @@ class Trainer(TrainerInterface, TransformersTrainer):
     def _remove_unused_columns(
         self, dataset: "datasets.Dataset", description: Optional[str] = None
     ):
+        if not self.args.remove_unused_columns:
+            return dataset
         if self._signature_columns is None and self.teacher is not None:
             model_signature = inspect.signature(self.model.forward)
             model_signature_columns = set(model_signature.parameters.keys())
@@ -747,7 +750,8 @@ class Trainer(TrainerInterface, TransformersTrainer):
                 model_signature_columns | teacher_signature_columns
             )
 
-            # Labels may be named label or label_ids, the default data collator handles that.
+            # Labels may be named label or label_ids, the default data
+            # collator handles that.
             self._signature_columns += ["label", "label_ids"]
 
         return super()._remove_unused_columns(dataset, description)

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -24,7 +24,6 @@ Finetuning the library models for sequence classification on GLUE
 # You can also adapt this script on your own text classification task.
 # Pointers for this are left as comments.
 
-import inspect
 import logging
 import os
 import random
@@ -52,7 +51,7 @@ from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
 from sparseml.transformers.sparsification import Trainer
-from sparseml.transformers.utils import SparseAutoModel
+from sparseml.transformers.utils import SparseAutoModel, get_shared_tokenizer_src
 
 
 # Will error if the minimal version of Transformers is not installed.
@@ -451,22 +450,11 @@ def main():
         },
     )
 
-    if model_args.distill_teacher is not None:
-        model_forward_params = list(inspect.signature(model.forward).parameters.keys())
-        teacher_forward_params = list(
-            inspect.signature(teacher.forward).parameters.keys()
-        )
-        diff = [p for p in model_forward_params if p not in teacher_forward_params]
-        if diff:
-            raise RuntimeError("Teacher tokenizer cannot be used for student.")
-        tokenizer_src = model_args.distill_teacher
-    else:
-        tokenizer_src = (
-            model_args.tokenizer_name
-            if model_args.tokenizer_name
-            else model_args.model_name_or_path
-        )
-
+    tokenizer_src = (
+        model_args.tokenizer_name
+        if model_args.tokenizer_name
+        else get_shared_tokenizer_src(model, teacher)
+    )
     tokenizer = AutoTokenizer.from_pretrained(
         tokenizer_src,
         cache_dir=model_args.cache_dir,

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -430,10 +430,18 @@ def main():
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
     )
+
+    if model_args.distill_teacher is not None:
+        tokenizer_src = model_args.distill_teacher
+    else:
+        tokenizer_src = (
+            model_args.tokenizer_name
+            if model_args.tokenizer_name
+            else model_args.model_name_or_path
+        )
+
     tokenizer = AutoTokenizer.from_pretrained(
-        model_args.tokenizer_name
-        if model_args.tokenizer_name
-        else model_args.model_name_or_path,
+        tokenizer_src,
         cache_dir=model_args.cache_dir,
         use_fast=model_args.use_fast_tokenizer,
         revision=model_args.model_revision,

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -420,14 +420,18 @@ def main():
         use_auth_token=True if model_args.use_auth_token else None,
     )
 
-    tokenizer_name_or_path = (
-        model_args.tokenizer_name
-        if model_args.tokenizer_name
-        else model_args.model_name_or_path
-    )
+    if model_args.distill_teacher is not None:
+        tokenizer_src = model_args.distill_teacher
+    else:
+        tokenizer_src = (
+            model_args.tokenizer_name
+            if model_args.tokenizer_name
+            else model_args.model_name_or_path
+        )
+
     if config.model_type in {"gpt2", "roberta"}:
         tokenizer = AutoTokenizer.from_pretrained(
-            tokenizer_name_or_path,
+            tokenizer_src,
             cache_dir=model_args.cache_dir,
             use_fast=True,
             revision=model_args.model_revision,
@@ -436,7 +440,7 @@ def main():
         )
     else:
         tokenizer = AutoTokenizer.from_pretrained(
-            tokenizer_name_or_path,
+            tokenizer_src,
             cache_dir=model_args.cache_dir,
             use_fast=True,
             revision=model_args.model_revision,

--- a/src/sparseml/transformers/utils/model.py
+++ b/src/sparseml/transformers/utils/model.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import logging
 import os
 from typing import Any, Dict, Optional, Tuple, Union
@@ -29,7 +30,7 @@ from transformers.file_utils import WEIGHTS_NAME
 from sparseml.pytorch.utils import ModuleSparsificationInfo
 
 
-__all__ = ["SparseAutoModel"]
+__all__ = ["SparseAutoModel", "get_shared_tokenizer_src"]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -381,3 +382,32 @@ class SparseAutoModel:
                 "Detected a TensorFlow model from model_name_or_path: "
                 f"{model_name_or_path}"
             )
+
+
+def get_shared_tokenizer_src(student: Module, teacher: Optional[Module]) -> str:
+    """
+    Get a tokenizer source used for both student and teacher, assuming
+    that they could be shared
+
+    :param student: the student model
+    :param teacher: the teacher model
+    :return: the source for the tokenizer shared between teacher and model
+    """
+
+    if teacher is not None:
+        student_forward_params = list(
+            inspect.signature(student.forward).parameters.keys()
+        )
+        teacher_forward_params = list(
+            inspect.signature(teacher.forward).parameters.keys()
+        )
+        diff = [p for p in student_forward_params if p not in teacher_forward_params]
+        if diff:
+            raise RuntimeError(
+                "Teacher tokenizer cannot be used for student "
+                f"due to missing args: {diff}"
+            )
+        src_model = teacher
+    else:
+        src_model = student
+    return src_model.config._name_or_path


### PR DESCRIPTION
This change fixes the tokenizer when distillation is used and the teacher and student models have different tokenizers. In that case, this fix reuses the teacher's tokenizer with the assumption that it "subsumes" that of the student.