### PR TITLE
[Fix] Reverting back to `torch==1.9.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,12 +56,12 @@ _deepsparse_deps = [
     f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}"
 ]
 _pytorch_deps = [
-    "torch>=1.1.0,<=1.9.0",
+    "torch>=1.1.0,<=1.9.1",
     "tensorboard>=1.0",
     "tensorboardX>=1.0",
     "gputils",
 ]
-_pytorch_vision_deps = _pytorch_deps + ["torchvision>=0.3.0,<=0.10.0"]
+_pytorch_vision_deps = _pytorch_deps + ["torchvision>=0.3.0,<=0.10.1"]
 _tensorflow_v1_deps = ["tensorflow<2.0.0", "tensorboard<2.0.0", "tf2onnx>=1.0.0,<1.6"]
 _tensorflow_v1_gpu_deps = [
     "tensorflow-gpu<2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -56,12 +56,12 @@ _deepsparse_deps = [
     f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}"
 ]
 _pytorch_deps = [
-    "torch>=1.1.0,<=1.10.2",
+    "torch>=1.1.0,<=1.9.0",
     "tensorboard>=1.0",
     "tensorboardX>=1.0",
     "gputils",
 ]
-_pytorch_vision_deps = _pytorch_deps + ["torchvision>=0.3.0,<=0.11.3"]
+_pytorch_vision_deps = _pytorch_deps + ["torchvision>=0.3.0,<=0.10.0"]
 _tensorflow_v1_deps = ["tensorflow<2.0.0", "tensorboard<2.0.0", "tf2onnx>=1.0.0,<1.6"]
 _tensorflow_v1_gpu_deps = [
     "tensorflow-gpu<2.0.0",

--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -97,12 +97,17 @@ class BaseManager(BaseObject):
     def metadata(self):
         return self._metadata
 
+    @metadata.setter
+    def metadata(self, value):
+        self._metadata = value
+
     @classmethod
     def compose_staged(
         cls,
         base_recipe: Union[str, "BaseManager"],
         additional_recipe: Union[str, "BaseManager"],
         keep_original_epochs: bool = False,
+        save_path: Optional[str] = None,
     ) -> "BaseManager":
         """
         composes two recipes into a multi-stage recipe where epochs
@@ -117,18 +122,20 @@ class BaseManager(BaseObject):
         :param keep_original_epochs: by default, epochs in additional_recipe will
             be overwritten to come after base_recipe. setting keep_original_epochs
             to True prevents this behavior. Default is False
+        :param save_path: optional path string; if provided, will be used to
+            immediately save the combined multi-stage recipe to yaml
         :return: framework Manager object with the loaded composed recipe
         """
 
         # will load using class implementation of from_yaml
         # will fail from BaseModifier
-        if not isinstance(base_recipe, BaseManager):
-            base_recipe = cls.from_yaml(base_recipe)
-        if not isinstance(additional_recipe, BaseManager):
-            additional_recipe = cls.from_yaml(additional_recipe)
+        if isinstance(base_recipe, BaseManager):
+            base_recipe = str(base_recipe)
+        base_recipe = cls.from_yaml(base_recipe)
 
-        base_recipe_metadata = deepcopy(base_recipe._metadata)
-        additional_recipe_metadata = deepcopy(additional_recipe._metadata)
+        if isinstance(additional_recipe, BaseManager):
+            additional_recipe = str(additional_recipe)
+        additional_recipe = cls.from_yaml(additional_recipe)
 
         # Both base_recipe and additional_recipe are non-staged_recipes
         if isinstance(base_recipe.modifiers, List) and isinstance(
@@ -136,25 +143,23 @@ class BaseManager(BaseObject):
         ):
             # Need to generate stage names for two standard recipes
             base_stage_name, additional_stage_name = "stage_0", "stage_1"
-            base_stages = {base_stage_name: deepcopy(base_recipe.modifiers)}
 
-            additional_stages = {
-                additional_stage_name: deepcopy(additional_recipe.modifiers)
-            }
+            base_stages = {base_stage_name: base_recipe.modifiers}
+            additional_stages = {additional_stage_name: additional_recipe.modifiers}
 
-            base_recipe_metadata[base_stage_name] = base_recipe_metadata.pop(
+            base_recipe.metadata[base_stage_name] = base_recipe.metadata.pop(
                 RECIPE_METADATA_KEY
             )
-            additional_recipe_metadata[
+            additional_recipe.metadata[
                 additional_stage_name
-            ] = additional_recipe_metadata.pop(RECIPE_METADATA_KEY)
+            ] = additional_recipe.metadata.pop(RECIPE_METADATA_KEY)
 
         # Base_recipe is staged recipe and additional_recipe is not
         elif isinstance(base_recipe.modifiers, OrderedDict) and isinstance(
             additional_recipe.modifiers, List
         ):
 
-            base_stages = deepcopy(base_recipe.modifiers)
+            base_stages = base_recipe.modifiers
 
             additional_stage_name = f"stage_{len(base_stages) + 1}"
             if additional_stage_name in base_stages.keys():
@@ -165,32 +170,30 @@ class BaseManager(BaseObject):
                     "Please edit the stage name in the checkpoint file."
                 )
 
-            additional_stages = {
-                additional_stage_name: deepcopy(additional_recipe.modifiers)
-            }
+            additional_stages = {additional_stage_name: additional_recipe.modifiers}
 
-            additional_recipe_metadata[
+            additional_recipe.metadata[
                 additional_stage_name
-            ] = additional_recipe_metadata.pop(RECIPE_METADATA_KEY)
+            ] = additional_recipe.metadata.pop(RECIPE_METADATA_KEY)
 
         # Additional_recipe is staged recipe and base_recipe is not
         elif isinstance(base_recipe.modifiers, List) and isinstance(
             additional_recipe.modifiers, OrderedDict
         ):
-            additional_stages = deepcopy(additional_recipe.modifiers)
+            additional_stages = additional_recipe.modifiers
 
             base_stage_name = f"pre_{list(additional_stages.keys())[0]}"
 
-            base_stages = {base_stage_name: deepcopy(base_recipe.modifiers)}
+            base_stages = {base_stage_name: base_recipe.modifiers}
 
-            base_recipe_metadata[base_stage_name] = base_recipe_metadata.pop(
+            base_recipe.metadata[base_stage_name] = base_recipe.metadata.pop(
                 RECIPE_METADATA_KEY
             )
 
         # Both recipes are staged.
         else:
-            base_stages = deepcopy(base_recipe.modifiers)
-            additional_stages = deepcopy(additional_recipe.modifiers)
+            base_stages = base_recipe.modifiers
+            additional_stages = additional_recipe.modifiers
 
         base_keys = set(base_stages.keys())
         additional_keys = set(additional_stages.keys())
@@ -214,10 +217,15 @@ class BaseManager(BaseObject):
         combined_stages = base_stages
         combined_stages.update(additional_stages)
 
-        combined_metadata = base_recipe_metadata
-        combined_metadata.update(additional_recipe_metadata)
+        combined_metadata = base_recipe.metadata
+        combined_metadata.update(additional_recipe.metadata)
 
-        return cls(combined_stages, combined_metadata)
+        combined_manager = cls(combined_stages, combined_metadata)
+
+        if save_path:
+            combined_manager.save(save_path)
+
+        return combined_manager
 
     @ModifierProp(serializable=False)
     def modifiers(self) -> Union[List[BaseModifier], Dict[str, List[BaseModifier]]]:
@@ -399,7 +407,7 @@ class BaseManager(BaseObject):
             for mod in modifiers_list:
                 yield mod
 
-    def to_string_lines(self, include_metadata: bool = False) -> List[str]:
+    def to_string_lines(self, include_metadata: bool = True) -> List[str]:
         """
         :param include_metadata: boolean indicator whether metadata shall be
             appended to the yaml file before saving. Default is False.

--- a/src/sparseml/pytorch/base.py
+++ b/src/sparseml/pytorch/base.py
@@ -49,7 +49,7 @@ __all__ = [
 
 
 _TORCH_MIN_VERSION = "1.0.0"
-_TORCH_MAX_VERSION = "1.10.100"  # set bug to 100 to support all future 1.10.X  versions
+_TORCH_MAX_VERSION = "1.9.100"  # set bug to 100 to support all future 1.9.X versions
 
 
 def check_torch_install(


### PR DESCRIPTION
In the last release, before we knew about the incoming problems with onnx export, I updated the latest supported torch version to `1.10.2` (0.11 release). However, we are not yet ready to support it and the sensible thing to do is to rollback, and bring back `1.10.X` in release 0.13.

Kudos to @KSGulin for catching this. To reproduce the issue, one should grab a switch branch to #632  install fresh dependencies from `setup.py`, and run the included transformers integration tests. 

They will fail, directly because the transformers `export` method fails if the torch version is higher than `1.9.X`.
