### PR TITLE
Revert rn residual quant

### DIFF
--- a/src/sparseml/pytorch/models/classification/resnet.py
+++ b/src/sparseml/pytorch/models/classification/resnet.py
@@ -151,7 +151,7 @@ class _AddReLU(Module):
         if FloatFunctional:
             self.functional = FloatFunctional()
             self.wrap_qat = True
-            self.qat_wrapper_kwargs = {"num_inputs": 1, "num_outputs": 0}
+            self.qat_wrapper_kwargs = {"num_inputs": 1, "num_outputs": 1}
         else:
             self.functional = ReLU(num_channels=num_channels, inplace=True)
 
@@ -185,7 +185,11 @@ class _BasicBlock(Module):
             else None
         )
 
-        self.add_relu = _AddReLU(out_channels)
+        # self.add_relu = _AddReLU(out_channels)
+        if FloatFunctional:
+            self.self.add_relu = FloatFunctional()
+        else:
+            self.self.add_relu = ReLU(num_channels=out_channels, inplace=True)
 
         self.initialize()
 
@@ -198,9 +202,13 @@ class _BasicBlock(Module):
         out = self.bn2(out)
 
         identity_val = self.identity(inp) if self.identity is not None else inp
-        out = self.add_relu(identity_val, out)
+        # out = self.add_relu(identity_val, out)
+        # return out
 
-        return out
+        if isinstance(self.add_relu, FloatFunctional):
+            return self.add_relu.add_relu(identity_val, out)
+        else:
+            return self.add_relu(identity_val + out)
 
     def initialize(self):
         _init_conv(self.conv1)
@@ -242,7 +250,11 @@ class _BottleneckBlock(Module):
             else None
         )
 
-        self.add_relu = _AddReLU(out_channels)
+        # self.add_relu = _AddReLU(out_channels)
+        if FloatFunctional:
+            self.self.add_relu = FloatFunctional()
+        else:
+            self.self.add_relu = ReLU(num_channels=out_channels, inplace=True)
 
         self.initialize()
 
@@ -260,9 +272,13 @@ class _BottleneckBlock(Module):
 
         identity_val = self.identity(inp) if self.identity is not None else inp
 
-        out = self.add_relu(identity_val, out)
+        # out = self.add_relu(identity_val, out)
+        # return out
 
-        return out
+        if isinstance(self.add_relu, FloatFunctional):
+            return self.add_relu.add_relu(identity_val, out)
+        else:
+            return self.add_relu(identity_val + out)
 
     def initialize(self):
         _init_conv(self.conv1)

--- a/src/sparseml/pytorch/models/classification/resnet.py
+++ b/src/sparseml/pytorch/models/classification/resnet.py
@@ -187,9 +187,9 @@ class _BasicBlock(Module):
 
         # self.add_relu = _AddReLU(out_channels)
         if FloatFunctional:
-            self.self.add_relu = FloatFunctional()
+            self.add_relu = FloatFunctional()
         else:
-            self.self.add_relu = ReLU(num_channels=out_channels, inplace=True)
+            self.add_relu = ReLU(num_channels=out_channels, inplace=True)
 
         self.initialize()
 
@@ -252,9 +252,9 @@ class _BottleneckBlock(Module):
 
         # self.add_relu = _AddReLU(out_channels)
         if FloatFunctional:
-            self.self.add_relu = FloatFunctional()
+            self.add_relu = FloatFunctional()
         else:
-            self.self.add_relu = ReLU(num_channels=out_channels, inplace=True)
+            self.add_relu = ReLU(num_channels=out_channels, inplace=True)
 
         self.initialize()
 


### PR DESCRIPTION
PR to revert changes made to the definition of resnet models to state prior to quantization refactor. Changes made during quantization refactor are kept as comments for future. Checked that pushed quantized models can load correctly.