### PR TITLE
Add: Functionality to resume-training from a previously stopped run.

### DIFF
--- a/src/sparseml/pytorch/image_classification/export.py
+++ b/src/sparseml/pytorch/image_classification/export.py
@@ -357,7 +357,7 @@ def export_setup(args_: ExportArgs) -> Tuple[Module, Optional[str], Any]:
         dataset=args_.dataset,
         model_kwargs=args_.model_kwargs,
     )
-    model, args_.arch_key = helpers.create_model(
+    model, args_.arch_key, _ = helpers.create_model(
         checkpoint_path=args_.checkpoint_path,
         recipe_path=None,
         num_classes=num_classes,

--- a/src/sparseml/pytorch/image_classification/lr_analysis.py
+++ b/src/sparseml/pytorch/image_classification/lr_analysis.py
@@ -420,7 +420,7 @@ def main():
         dataset=args_.dataset,
         model_kwargs=args_.model_kwargs,
     )
-    model, args_.arch_key = helpers.create_model(
+    model, args_.arch_key, _ = helpers.create_model(
         checkpoint_path=args_.checkpoint_path,
         recipe_path=None,
         num_classes=num_classes,

--- a/src/sparseml/pytorch/image_classification/pr_sensitivity.py
+++ b/src/sparseml/pytorch/image_classification/pr_sensitivity.py
@@ -437,7 +437,7 @@ def main():
         model_kwargs=args_.model_kwargs,
     )
 
-    model, args_.arch_key = helpers.create_model(
+    model, args_.arch_key, _ = helpers.create_model(
         checkpoint_path=args_.checkpoint_path,
         recipe_path=None,
         num_classes=num_classes,

--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -257,6 +257,7 @@ class TrainingArguments:
     :param image_size: int representing the size of the image input to the model
         default=224.
     :param ffcv: bool Use ffcv for training, Defaults to False
+    :param resume: bool to resume training from a checkpoint, default=False.
     """
 
     train_batch_size: int = field(
@@ -464,6 +465,10 @@ class TrainingArguments:
     ffcv: bool = field(
         default=False,
         metadata={"help": "Use ffcv for training, Defaults to False"},
+    )
+    resume: bool = field(
+        default=False,
+        metadata={"help": "Resume training from a checkpoint"},
     )
 
     def __post_init__(self):
@@ -685,7 +690,7 @@ def _init_image_classification_trainer_and_save_dirs(
         extras = {"top1acc": TopKAccuracy(1), "top5acc": TopKAccuracy(5)}
         return CrossEntropyLossWrapper(extras=extras)
 
-    model, train_args.arch_key = helpers.create_model(
+    model, train_args.arch_key, epoch = helpers.create_model(
         checkpoint_path=train_args.checkpoint_path,
         recipe_path=train_args.recipe_path,
         num_classes=num_classes,
@@ -693,6 +698,7 @@ def _init_image_classification_trainer_and_save_dirs(
         pretrained=train_args.pretrained,
         pretrained_dataset=train_args.pretrained_dataset,
         local_rank=train_args.local_rank,
+        resume=train_args.resume,
         **train_args.model_kwargs,
     )
 
@@ -728,6 +734,7 @@ def _init_image_classification_trainer_and_save_dirs(
             model=model,
             key=train_args.arch_key,
             recipe_path=train_args.recipe_path,
+            start_epoch=epoch,
             ddp=ddp,
             device=train_args.device,
             use_mixed_precision=train_args.use_mixed_precision,


### PR DESCRIPTION
This PR will add support for resuming training from a previously stopped run; the epoch is read from the checkpoint if present. However, the recipe must be provided explicitly.

Add `--resume` argument, and provide a checkpoint with epoch #; 

For example:
```bash
sparseml.image_classification.train \
--recipe-path zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original \
--checkpoint-path ~/models/custom-checkpoint/fake-epoch-2.pth \
--pretrained True --dataset imagenette --dataset-path dataset \
--train-batch-size 128 --test-batch-size 256 --loader-num-workers 8 \
--model-tag resnet50-imagenette-pruned-conservative --resume
```

The checkpoint must contain epoch # when training was stopped, else it is assumed to be epoch 0
```python
{
     "state_dict" : ...,
     "epoch" : 2,
      .
      .
}
```