### PR TITLE
Switch off fp16 on QAT start

### DIFF
--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -370,13 +370,14 @@ def save_model_training(
     :param arch_key: if provided, the `arch_key` will be saved in the
         checkpoint
     """
-    has_top1 = "top1acc" in val_res.results
-    metric_name = "top-1 accuracy" if has_top1 else "val_loss"
-    metric = val_res.result_mean("top1acc" if has_top1 else DEFAULT_LOSS_KEY).item()
-    print(
-        f"Saving model for epoch {epoch} and {metric_name} "
-        f"{metric} to {save_dir} for {save_name}"
-    )
+    if val_res is not None:
+        has_top1 = "top1acc" in val_res.results
+        metric_name = "top-1 accuracy" if has_top1 else "val_loss"
+        metric = val_res.result_mean("top1acc" if has_top1 else DEFAULT_LOSS_KEY).item()
+        print(
+            f"Saving model for epoch {epoch} and {metric_name} "
+            f"{metric} to {save_dir} for {save_name}"
+        )
     exporter = ModuleExporter(model, save_dir)
     exporter.export_pytorch(
         optim,

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -172,7 +172,7 @@ class ImageClassificationTrainer(Trainer):
         train_mode = mode == "train"
         validation_mode = not train_mode
 
-        if self.manager.qat_active(epoch=self.epoch):
+        if torch.__version__ < "1.9" and self.manager.qat_active(epoch=self.epoch):
             # switch off fp16
             self._device_context.use_mixed_precision = False
 

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -124,7 +124,7 @@ class ImageClassificationTrainer(Trainer):
 
         self.optim_name = optim_name
         self.epoch = 0
-        self.device_context = ModuleDeviceContext(
+        self._device_context = ModuleDeviceContext(
             use_mixed_precision=self.use_mixed_precision,
         )
         if self.train_loader is not None:
@@ -174,7 +174,7 @@ class ImageClassificationTrainer(Trainer):
 
         if self.manager.qat_active(epoch=self.epoch):
             # switch off fp16
-            self.device_context.use_mixed_precision = False
+            self._device_context.use_mixed_precision = False
 
         if validation_mode:
             return self._run_validation_epoch(
@@ -238,7 +238,7 @@ class ImageClassificationTrainer(Trainer):
             loss=self.train_loss,
             optimizer=self.optim,
             loggers=self.loggers,
-            device_context=self.device_context,
+            device_context=self._device_context,
         )
         _LOGGER.info(f"created Module Trainer: {trainer}")
 


### PR DESCRIPTION
This PR updates `ImageClassificationTrainer` to switch off `fp16` on QAT start 

Noting that `torch > 1.9`. does not crash if mixed precision is not switched off before QAT start thus the additional check