### PR TITLE
Click refactor for SparseML-PyTorch integration

### DIFF
--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -12,123 +12,129 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 """
 ######
 Command help:
-usage: sparseml.image_classification.train [-h] --train-batch-size
-                                           TRAIN_BATCH_SIZE --test-batch-size
-                                           TEST_BATCH_SIZE --dataset DATASET
-                                           --dataset-path DATASET_PATH
-                                           [--arch-key ARCH_KEY]
-                                           [--checkpoint-path CHECKPOINT_PATH]
-                                           [--init-lr INIT_LR]
-                                           [--optim-args OPTIM_ARGS]
-                                           [--recipe-path RECIPE_PATH]
-                                           [--eval-mode [EVAL_MODE]]
-                                           [--optim OPTIM]
-                                           [--logs-dir LOGS_DIR]
-                                           [--save-best-after SAVE_BEST_AFTER]
-                                           [--save-epochs SAVE_EPOCHS [SAVE_EPOCHS ...]]
-                                           [--use-mixed-precision [USE_MIXED_PRECISION]]
-                                           [--debug-steps DEBUG_STEPS]
-                                           [--pretrained PRETRAINED]
-                                           [--pretrained-dataset PRETRAINED_DATASET]
-                                           [--model-kwargs MODEL_KWARGS]
-                                           [--dataset-kwargs DATASET_KWARGS]
-                                           [--model-tag MODEL_TAG]
-                                           [--save-dir SAVE_DIR]
-                                           [--device DEVICE]
-                                           [--loader-num-workers LOADER_NUM_WORKERS]
-                                           [--no-loader-pin-memory]
-                                           [--loader-pin-memory [LOADER_PIN_MEMORY]]
-                                           [--image-size IMAGE_SIZE]
+Usage: sparseml.image_classification.train [OPTIONS]
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --train-batch-size TRAIN_BATCH_SIZE
-                        The batch size to use while training
-  --test-batch-size TEST_BATCH_SIZE
-                        The batch size to use while testing
-  --dataset DATASET     The dataset to use for training, ex: imagenet,
-                        imagenette, cifar10, etc. Set to imagefolder for a
-                        generic dataset setup with an image folder structure
-                        setup like imagenet or loadable by a dataset in
-                        sparseml.pytorch.datasets
-  --dataset-path DATASET_PATH
-                        The root path to where the dataset is stored
-  --arch-key ARCH_KEY   The type of model to use, ex: resnet50, vgg16,
-                        mobilenet put as help to see the full list (will raise
-                        an exception with the list)
-  --checkpoint-path CHECKPOINT_PATH
-                        A path to a previous checkpoint to load the state from
-                        and resume the state for. If provided, pretrained will
-                        be ignored. If using a SparseZoo recipe, can also
-                        provide 'zoo' to load the base weights associated with
-                        that recipe
-  --init-lr INIT_LR     The initial learning rate to use while training, the
-                        actual initial value used should be set by the
-                        sparseml recipe
-  --optim-args OPTIM_ARGS
-                        Additional args to be passed to the optimizer passed
-                        in as a json object. Defaults set for SGD
-  --recipe-path RECIPE_PATH
-                        The path to the yaml file containing the modifiers and
-                        schedule to apply them with. Can also provide a
-                        SparseZoo stub prefixed with 'zoo:' with an optional
-                        'recipe_type=' argument
-  --eval-mode [EVAL_MODE]
-                        Puts into evaluation mode so that the model can be
-                        evaluated on the desired dataset
-  --optim OPTIM         The optimizer type to use, one of ['Adadelta',
-                        'Adagrad', 'Adam', 'AdamW', 'SparseAdam', 'Adamax',
-                        'ASGD', 'SGD', 'RAdam', 'Rprop', 'RMSprop',
-                        'Optimizer', 'NAdam', 'LBFGS']. Defaults to `SGD`
-  --logs-dir LOGS_DIR   The path to the directory for saving logs
-  --save-best-after SAVE_BEST_AFTER
-                        start saving the best validation result after the
-                        given epoch completes until the end of training
-  --save-epochs SAVE_EPOCHS [SAVE_EPOCHS ...]
-                        epochs to save checkpoints at
-  --use-mixed-precision [USE_MIXED_PRECISION]
-                        Trains model using mixed precision. Supported
-                        environments are single GPU and multiple GPUs using
-                        DistributedDataParallel with one GPU per process
-  --debug-steps DEBUG_STEPS
-                        Amount of steps to run for training and testing for a
-                        debug mode
-  --pretrained PRETRAINED
-                        The type of pretrained weights to use, default is true
-                        to load the default pretrained weights for the model.
-                        Otherwise should be set to the desired weights type:
-                        [base, optim, optim-perf]. To not load any weights set
-                        to one of [none, false]
-  --pretrained-dataset PRETRAINED_DATASET
-                        The dataset to load pretrained weights for if
-                        pretrained is set. Default is None which will load the
-                        default dataset for the architecture. Ex can be set to
-                        imagenet, cifar10, etc
-  --model-kwargs MODEL_KWARGS
-                        Keyword arguments to be passed to model constructor,
-                        should be given as a json object
-  --dataset-kwargs DATASET_KWARGS
-                        Keyword arguments to be passed to dataset constructor,
-                        should be given as a json object
-  --model-tag MODEL_TAG
-                        A tag to use for the model for saving results under
-                        save-dir, defaults to the model arch and dataset used
-  --save-dir SAVE_DIR   The path to the directory for saving results
-  --device DEVICE       The device to run on (can also include ids for data
-                        parallel), ex: cpu, cuda, cuda:0,1
-  --loader-num-workers LOADER_NUM_WORKERS
-                        The number of workers to use for data loading
-  --no-loader-pin-memory
-                        Do not use pinned memory for data loading
-  --loader-pin-memory [LOADER_PIN_MEMORY]
-                        Use pinned memory for data loading
-  --image-size IMAGE_SIZE
-                        The size of the image input to the model
-  --ffcv [FFCV]         Use FFCv for training. Defaults to False
+  PyTorch training integration with SparseML for image classification models
+
+Options:
+  --train-batch-size, --train_batch_size INTEGER
+                                  Train batch size  [required]
+  --test-batch-size, --test_batch_size INTEGER
+                                  Test/Validation batch size  [required]
+  -d, --dataset TEXT              The dataset to use for training, ex:
+                                  `imagenet`, `imagenette`, `cifar10`, etc.
+                                  Set to `imagefolder` for a generic dataset
+                                  setup with imagefolder type structure like
+                                  imagenet or loadable by a dataset in
+                                  `sparseml.pytorch.datasets`  [required]
+  --dataset-path, --dataset_path DIRECTORY
+                                  The root dir path where the dataset is
+                                  stored or should be downloaded to if
+                                  available  [required]
+  --arch_key, --arch-key TEXT     The architecture key for image
+                                  classification model; example: `resnet50`,
+                                  `mobilenet`. Note: Will be read from the
+                                  checkpoint if not specified
+  --local_rank, --local-rank INTEGER
+                                  Local rank for distributed training
+  --checkpoint-path, --checkpoint_path TEXT
+                                  A path to a previous checkpoint to load the
+                                  state from and resume the state for. If
+                                  provided, pretrained will be ignored . If
+                                  using a SparseZoo recipe, can also provide
+                                  'zoo' to load the base weights associated
+                                  with that recipe. Additionally, can also
+                                  provide a SparseZoo model stub to load model
+                                  weights from SparseZoo
+  --init-lr FLOAT                 The initial learning rate to use while
+                                  training, the actual initial value used will
+                                  be set by thesparseml recipe  [default:
+                                  1e-09]
+  --recipe-path, --recipe_path TEXT
+                                  The path to the yaml/md file containing the
+                                  modifiers and schedule to apply them with.
+                                  Can also provide a SparseZoo stub prefixed
+                                  with 'zoo:' with an optional '?recipe_type='
+                                  argument
+  --eval-mode, --eval_mode, --eval / --no-eval-mode, --no_eval_mode, --no-eval
+                                  Puts model into evaluation mode (Model
+                                  weights are not updated)  [default: no-eval-
+                                  mode]
+  --optim, --optimizer [Adadelta|Adagrad|Adam|AdamW|SparseAdam|Adamax|ASGD|SGD|
+                        Rprop|RMSprop|LBFGS]
+                                  The optimizer type to use, one of
+                                  ['Adadelta', 'Adagrad', 'Adam', 'AdamW',
+                                  'SparseAdam', 'Adamax', 'ASGD', 'SGD',
+                                  'Rprop', 'RMSprop', 'LBFGS'].  [default:
+                                  SGD]
+  --optim-args, --optimizer-args, --optim_args, --optimizer_args TEXT
+                                  Additional args to be passed to the
+                                  optimizer; should be specified as a json
+                                  object. Default args set for SGD
+  --logs-dir, --logs_dir DIRECTORY
+                                  The path to the directory for saving logs
+                                  [default: pytorch_vision_train/tensorboard-
+                                  logs]
+  --save-best-after, --save_best_after INTEGER
+                                  Save the best validation result after the
+                                  given epoch completes until the end of
+                                  training  [default: 1]
+  -se, --save-epochs, --save_epochs TEXT
+                                  Epochs to save checkpoints at
+  --use-mixed-precision, --use_mixed_precision, --amp
+                                  Trains model using mixed precision.
+                                  Supported environments are single GPU and
+                                  multiple GPUs using
+                                  `DistributedDataParallel` with one GPU per
+                                  process
+  -ds, --debug-steps, --debug_steps INTEGER
+                                  Amount of steps to run for training and
+                                  testing for when in debug mode
+  --pretrained TEXT               The type of pretrained weights to use, loads
+                                  default pretrained weights for the model if
+                                  not specified or set to `True`. Otherwise
+                                  should be set to the desired weights type:
+                                  [base, optim, optim-perf]. To not load any
+                                  weights setto one of [none, false]
+                                  [default: True]
+  --pretrained-dataset, --pretrained_dataset TEXT
+                                  The dataset to load pretrained weights for
+                                  if pretrained is set. Load the default
+                                  dataset for the architecture if set to None.
+                                  examples:`imagenet`, `cifar10`, etc...
+  --model-kwargs, --model_kwargs TEXT
+                                  Keyword arguments to be passed to model
+                                  constructor, should be given as a json
+                                  object
+  --dataset-kwargs, --dataset_kwargs TEXT
+                                  Keyword arguments to be passed to dataset
+                                  constructor, should be specified as a json
+                                  object
+  --model-tag, --model_tag TEXT   A tag for saving results under save-dir,
+                                  defaults to the model arch and dataset used
+  --save-dir, --save_dir DIRECTORY
+                                  The path to the directory for saving results
+                                  [default: pytorch_vision]
+  --device TEXT                   The device to run on (can also include ids
+                                  for data parallel), ex: cpu, cuda, cuda:0,1
+                                  [default: cuda]
+  --loader-num-workers, --loader_num_workers INTEGER
+                                  The number of workers to use for data
+                                  loading
+  --loader-pin-memory, --loader_pin_memory / --loader-no-pin-memory,
+  --loader_no_pin_memory
+                                  Use pinned memory for data loading
+                                  [default: loader-pin-memory]
+  -is, --image-size, --image_size INTEGER
+                                  The size of the image input to the model.
+                                  Value should be equal to S for [C, S, S] or
+                                  [S, S, C] dimensional input  [default: 224]
+  --ffcv                          Use `ffcv` for loading data  [default:
+                                  False]
+  --help                          Show this message and exit.
 
 #########
 EXAMPLES
@@ -136,15 +142,14 @@ EXAMPLES
 
 ##########
 Example command for pruning resnet50 on imagenet dataset:
-python sparseml.image_classification.train \
+sparseml.image_classification.train \
     --recipe-path ~/sparseml_recipes/pruning_resnet50.yaml \
     --arch-key resnet50 --dataset imagenet --dataset-path ~/datasets/ILSVRC2012 \
     --train-batch-size 256 --test-batch-size 1024
 
 ##########
 Example command for transfer learning sparse mobilenet_v1 on an image folder dataset:
-python sparseml.image_classification.train \
-    --sparse-transfer-learn \
+sparseml.image_classification.train \
     --recipe-path  ~/sparseml_recipes/pruning_mobilenet.yaml \
     --arch-key mobilenet_v1 --pretrained pruned-moderate \
     --dataset imagefolder --dataset-path ~/datasets/my_imagefolder_dataset \
@@ -152,388 +157,468 @@ python sparseml.image_classification.train \
 
 ##########
 Template command for running training with this script on multiple GPUs using
-DistributedDataParallel using mixed precision. Note - DDP support in this script
-only tested for torch==1.7.0.
+`DistributedDataParallel` using mixed precision. Note - DDP support in this
+script only tested for torch==1.7.0.
 python -m torch.distributed.launch \
 --nproc_per_node <NUM GPUs> \
 sparseml.image_classification.train \
 --use-mixed-precision \
 <TRAIN.PY ARGUMENTS>
 """
-import argparse
 import json
 import os
-from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
-from torch.utils.data import DataLoader
 
+import click
 from sparseml import get_main_logger
 from sparseml.pytorch.image_classification.utils import (
+    DEFAULT_OPTIMIZER,
+    OPTIMIZERS,
     ImageClassificationTrainer,
-    NmArgumentParser,
     helpers,
 )
-from sparseml.pytorch.utils import (
-    CrossEntropyLossWrapper,
-    TopKAccuracy,
-    default_device,
-    get_prunable_layers,
-    model_to_device,
-    set_deterministic_seeds,
-    tensor_sparsity,
-)
+from sparseml.pytorch.utils import default_device, get_prunable_layers, tensor_sparsity
 
 
 CURRENT_TASK = helpers.Tasks.TRAIN
 LOGGER = get_main_logger()
 
 
-@dataclass
-class TrainingArguments:
-    """
-    Represents the arguments we use in our PyTorch integration scripts for
-    training tasks
-
-    Using :class:`NmArgumentParser` we can turn this class into `argparse
-    <https://docs.python.org/3/library/argparse.html#module-argparse>`__
-    arguments that can be specified on the command line.
-
-    :param train_batch_size: An int representing the training batch size.
-    :param test_batch_size: An int representing the test batch size.
-    :param arch_key: A str key representing the type of model to use,
-        ex:resnet50.
-    :param dataset: The dataset to use for training, ex imagenet, imagenette,
-        etc; Set to `imagefolder` for a custom dataset.
-    :param dataset_path: Root path to dataset location.
-    :param local_rank: DDP argument set by PyTorch in DDP mode, default -1
-    :param checkpoint_path: A path to a previous checkpoint to load the state
-        from and resume the state for; Also works with SparseZoo recipes;
-        Set to zoo to automatically download and load weights associated with a
-        recipe.
-    :param init_lr: float representing the initial learning for training,
-        default=1e-9 .
-    :param optim_args: Additional arguments to be passed in to the optimizer as
-        a json object
-    :param recipe_path: The path to the yaml file containing the modifiers and
-        schedule to apply them with; Can also provide a SparseZoo stub prefixed
-        with 'zoo:'.
-    :param eval_mode: bool to start evaluation mode so that the model can be
-        evaluated on the desired dataset.
-    :param optim: str representing the optimizer type to use, one of
-        [SGD, Adam, RMSprop].
-    :param logs_dir: The path to the directory for saving logs.
-    :param save_best_after: int epoch number to start saving the best
-        validation result after until the end of training.
-    :param save_epochs: int epochs to save checkpoints at.
-    :param use_mixed_precision: bool to train model using mixed precision.
-        Supported environments are single GPU and multiple GPUs using
-        DistributedDataParallel with one GPU per process.
-    :param debug_steps: int representing amount of steps to run for training and
-        testing for debug mode default=-1.
-    :param pretrained: The type of pretrained weights to use default is true
-        to load the default pretrained weights for the model Otherwise should
-        be set to the desired weights type: [base, optim, optim-perf];
-        To not load any weights set to one of [none, false].
-    :param pretrained_dataset: str representing the dataset to load pretrained
-        weights for if pretrained is set; Default is None which will load the
-        default dataset for the architecture; Ex can be set to imagenet,
-        cifar10, etc".
-    :param model_kwargs: json object containing keyword arguments to be
-        passed to model constructor.
-    :param dataset_kwargs: json object to load keyword arguments to be passed
-        to dataset constructor.
-    :param model_tag: A str tag to use for the model for saving results
-        under save-dir, defaults to the model arch and dataset used.
-    :param save_dir: The path to the directory for saving results,
-        default="pytorch_vision".
-    :param device: str represnting the device to run on (can also include ids
-        for data parallel), ex:{cpu, cuda, cuda:0,1}.
-    :param loader_num_workers: int number of workers to use for data loading,
-        default=4.
-    :param loader_pin_memory: bool to use pinned memory for data loading,
-        default=True.
-    :param image_size: int representing the size of the image input to the model
-        default=224.
-    :param ffcv: bool Use ffcv for training, Defaults to False
-    """
-
-    train_batch_size: int = field(
-        metadata={"help": "The batch size to use while training"}
-    )
-
-    test_batch_size: int = field(
-        metadata={"help": "The batch size to use while testing"}
-    )
-
-    dataset: str = field(
-        metadata={
-            "help": "The dataset to use for training, "
-            "ex: imagenet, imagenette, cifar10, etc. "
-            "Set to imagefolder for a generic dataset setup "
-            "with an image folder structure setup like imagenet or"
-            " loadable by a dataset in sparseml.pytorch.datasets"
-        }
-    )
-
-    dataset_path: str = field(
-        metadata={
-            "help": "The root path to where the dataset is stored",
-        }
-    )
-    arch_key: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": "The type of model to use, ex: resnet50, vgg16, mobilenet "
-            "put as help to see the full list (will raise an exception"
-            "with the list)",
-        },
-    )
-    local_rank: int = field(
-        default=-1,
-        metadata={
-            "keep_underscores": True,
-            "help": argparse.SUPPRESS,
-        },
-    )
-
-    checkpoint_path: str = field(
-        default=None,
-        metadata={
-            "help": "A path to a previous checkpoint to load the state from "
-            "and resume the state for. If provided, pretrained will "
-            "be ignored . If using a SparseZoo recipe, can also "
-            "provide 'zoo' to load the base weights associated with "
-            "that recipe"
-        },
-    )
-
-    init_lr: float = field(
-        default=1e-9,
-        metadata={
-            "help": "The initial learning rate to use while training, "
-            "the actual initial value used should be set by the"
-            " sparseml recipe"
-        },
-    )
-
-    recipe_path: str = field(
-        default=None,
-        metadata={
-            "help": "The path to the yaml file containing the modifiers and "
-            "schedule to apply them with. Can also provide a "
-            "SparseZoo stub prefixed with 'zoo:' with an optional "
-            "'?recipe_type=' argument"
-        },
-    )
-
-    eval_mode: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Puts into evaluation mode so that the model can be "
-            "evaluated on the desired dataset"
-        },
-    )
-    optim_choices = [key for key in torch.optim.__dict__.keys() if key[0].isupper()]
-    default_optim = "SGD"
-    optim: str = field(
-        default=default_optim,
-        metadata={
-            "help": f"The optimizer type to use, one of {optim_choices}."
-            f" Defaults to `{default_optim}`"
-        },
-    )
-    optim_args: json.loads = field(
-        default_factory=lambda: {
+@click.command()
+@click.option(
+    "--train-batch-size",
+    "--train_batch_size",
+    type=int,
+    required=True,
+    help="Train batch size",
+)
+@click.option(
+    "--test-batch-size",
+    "--test_batch_size",
+    type=int,
+    required=True,
+    help="Test/Validation batch size",
+)
+@click.option(
+    "--dataset",
+    "-d",
+    type=str,
+    required=True,
+    help="The dataset to use for training, "
+    "ex: `imagenet`, `imagenette`, `cifar10`, etc. "
+    "Set to `imagefolder` for a generic dataset setup with "
+    "imagefolder type structure like imagenet or loadable by "
+    "a dataset in `sparseml.pytorch.datasets`",
+)
+@click.option(
+    "--dataset-path",
+    "--dataset_path",
+    type=click.Path(dir_okay=True, file_okay=False),
+    callback=helpers.create_dir_callback,
+    required=True,
+    help="The root dir path where the dataset is stored or should "
+    "be downloaded to if available",
+)
+@click.option(
+    "--arch_key",
+    "--arch-key",
+    type=str,
+    default=None,
+    help="The architecture key for image classification model; "
+    "example: `resnet50`, `mobilenet`. "
+    "Note: Will be read from the checkpoint if not specified",
+)
+@click.option(
+    "--local_rank",
+    "--local-rank",
+    type=int,
+    default=-1,
+    help="Local rank for distributed training",
+)
+@click.option(
+    "--checkpoint-path",
+    "--checkpoint_path",
+    type=str,
+    default=None,
+    help="A path to a previous checkpoint to load the state from "
+    "and resume the state for. If provided, pretrained will "
+    "be ignored . If using a SparseZoo recipe, can also "
+    "provide 'zoo' to load the base weights associated with "
+    "that recipe. Additionally, can also provide a SparseZoo model stub "
+    "to load model weights from SparseZoo",
+)
+@click.option(
+    "--init-lr",
+    type=float,
+    default=1e-9,
+    show_default=True,
+    help="The initial learning rate to use while training, "
+    "the actual initial value used will be set by the"
+    "sparseml recipe",
+)
+@click.option(
+    "--recipe-path",
+    "--recipe_path",
+    type=str,
+    default=None,
+    help="The path to the yaml/md file containing the modifiers and "
+    "schedule to apply them with. Can also provide a "
+    "SparseZoo stub prefixed with 'zoo:' with an optional "
+    "'?recipe_type=' argument",
+)
+@click.option(
+    "--eval-mode/--no-eval-mode",
+    "--eval_mode/--no_eval_mode",
+    "--eval/--no-eval",
+    is_flag=True,
+    show_default=True,
+    help="Puts model into evaluation mode (Model weights are not updated)",
+)
+@click.option(
+    "--optim",
+    "--optimizer",
+    type=click.Choice(OPTIMIZERS, case_sensitive=True),
+    default=DEFAULT_OPTIMIZER,
+    show_default=True,
+    help=f"The optimizer type to use, one of {OPTIMIZERS}.",
+)
+@click.option(
+    "--optim-args",
+    "--optimizer-args",
+    "--optim_args",
+    "--optimizer_args",
+    default=json.dumps(
+        {
             "momentum": 0.9,
             "nesterov": True,
             "weight_decay": 0.0001,
-        },
-        metadata={
-            "help": "Additional args to be passed to the optimizer passed in"
-            f" as a json object. Defaults set for {default_optim}",
-        },
-    )
+        }
+    ),
+    type=str,
+    callback=helpers.parse_json_callback,
+    help="Additional args to be passed to the optimizer; "
+    "should be specified as a json object. "
+    f"Default args set for {DEFAULT_OPTIMIZER}",
+)
+@click.option(
+    "--logs-dir",
+    "--logs_dir",
+    type=click.Path(dir_okay=True, file_okay=False),
+    default=os.path.join("pytorch_vision_train", "tensorboard-logs"),
+    callback=helpers.create_dir_callback,
+    show_default=True,
+    help="The path to the directory for saving logs",
+)
+@click.option(
+    "--save-best-after",
+    "--save_best_after",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Save the best validation result after the given "
+    "epoch completes until the end of training",
+)
+@click.option(
+    "--save-epochs",
+    "--save_epochs",
+    "-se",
+    cls=helpers.OptionEatAllArguments,
+    callback=helpers.parse_into_tuple_of_ints,
+    help="Epochs to save checkpoints at",
+)
+@click.option(
+    "--use-mixed-precision",
+    "--use_mixed_precision",
+    "--amp",
+    is_flag=True,
+    help="Trains model using mixed precision. Supported "
+    "environments are single GPU and multiple GPUs using "
+    "`DistributedDataParallel` with one GPU per process",
+)
+@click.option(
+    "--debug-steps",
+    "--debug_steps",
+    "-ds",
+    type=int,
+    default=-1,
+    help="Amount of steps to run for training and testing for when in " "debug mode",
+)
+@click.option(
+    "--pretrained",
+    type=str,
+    default=True,
+    show_default=True,
+    help="The type of pretrained weights to use, "
+    "loads default pretrained weights for "
+    "the model if not specified or set to `True`. "
+    "Otherwise should be set to the desired weights "
+    "type: [base, optim, optim-perf]. To not load any weights set"
+    "to one of [none, false]",
+)
+@click.option(
+    "--pretrained-dataset",
+    "--pretrained_dataset",
+    type=str,
+    default=None,
+    show_default=True,
+    help="The dataset to load pretrained weights for if pretrained is "
+    "set. Load the default dataset for the architecture if set to None. "
+    "examples:`imagenet`, `cifar10`, etc...",
+)
+@click.option(
+    "--model-kwargs",
+    "--model_kwargs",
+    default=json.dumps({}),
+    type=str,
+    callback=helpers.parse_json_callback,
+    help="Keyword arguments to be passed to model constructor, should "
+    "be given as a json object",
+)
+@click.option(
+    "--dataset-kwargs",
+    "--dataset_kwargs",
+    default=json.dumps({}),
+    type=str,
+    callback=helpers.parse_json_callback,
+    help="Keyword arguments to be passed to dataset constructor, "
+    "should be specified as a json object",
+)
+@click.option(
+    "--model-tag",
+    "--model_tag",
+    type=str,
+    default=None,
+    help="A tag for saving results under save-dir, "
+    "defaults to the model arch and dataset used",
+)
+@click.option(
+    "--save-dir",
+    "--save_dir",
+    type=click.Path(dir_okay=True, file_okay=False),
+    default="pytorch_vision",
+    callback=helpers.create_dir_callback,
+    show_default=True,
+    help="The path to the directory for saving results",
+)
+@click.option(
+    "--device",
+    default=default_device(),
+    show_default=True,
+    help="The device to run on (can also include ids for data "
+    "parallel), ex: cpu, cuda, cuda:0,1",
+)
+@click.option(
+    "--loader-num-workers",
+    "--loader_num_workers",
+    type=int,
+    default=4,
+    help="The number of workers to use for data loading",
+)
+@click.option(
+    "--loader-pin-memory/--loader-no-pin-memory",
+    "--loader_pin_memory/--loader_no_pin_memory",
+    default=True,
+    is_flag=True,
+    show_default=True,
+    help="Use pinned memory for data loading",
+)
+@click.option(
+    "--image-size",
+    "--image_size",
+    "-is",
+    type=int,
+    default=224,
+    show_default=True,
+    help="The size of the image input to the model. Value should be "
+    "equal to S for [C, S, S] or [S, S, C] dimensional input",
+)
+@click.option(
+    "--ffcv",
+    is_flag=True,
+    show_default=True,
+    help="Use `ffcv` for loading data",
+)
+def main(
+    train_batch_size: int,
+    test_batch_size: int,
+    dataset: str,
+    dataset_path: str,
+    arch_key: Optional[str],
+    local_rank: int,
+    checkpoint_path: Optional[str],
+    init_lr: float,
+    recipe_path: Optional[str],
+    eval_mode: bool,
+    optim: str,
+    optim_args: Dict[str, Any],
+    logs_dir: str,
+    save_best_after: int,
+    save_epochs: Tuple[int, ...],
+    use_mixed_precision: bool,
+    debug_steps: int,
+    pretrained: Union[str, bool],
+    pretrained_dataset: Optional[str],
+    model_kwargs: Dict[str, Any],
+    dataset_kwargs: Dict[str, Any],
+    model_tag: Optional[str],
+    save_dir: str,
+    device: Optional[str],
+    loader_num_workers: int,
+    loader_pin_memory: bool,
+    image_size: int,
+    ffcv: bool,
+):
+    """
+    PyTorch training integration with SparseML for image classification models
+    """
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    rank = int(os.environ.get("RANK", -1))
 
-    logs_dir: str = field(
-        default=os.path.join("pytorch_vision_train", "tensorboard-logs"),
-        metadata={
-            "help": "The path to the directory for saving logs",
-        },
-    )
+    # non DDP execution or 0th DDP process
+    is_main_process = rank in (-1, 0)
 
-    save_best_after: int = field(
-        default=-1,
-        metadata={
-            "help": "start saving the best validation result after the given "
-            "epoch completes until the end of training"
-        },
-    )
-    save_epochs: List[int] = field(
-        default_factory=lambda: [], metadata={"help": "epochs to save checkpoints at"}
-    )
-
-    use_mixed_precision: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "Trains model using mixed precision. Supported "
-            "environments are single GPU and multiple GPUs using "
-            "DistributedDataParallel with one GPU per process"
-        },
-    )
-
-    debug_steps: int = field(
-        default=-1,
-        metadata={
-            "help": "Amount of steps to run for training and testing for a "
-            "debug mode"
-        },
-    )
-
-    pretrained: str = field(
-        default=True,
-        metadata={
-            "help": "The type of pretrained weights to use, "
-            "default is true to load the default pretrained weights for "
-            "the model. Otherwise should be set to the desired weights "
-            "type: [base, optim, optim-perf]. To not load any weights set"
-            "to one of [none, false]"
-        },
-    )
-
-    pretrained_dataset: str = field(
-        default=None,
-        metadata={
-            "help": "The dataset to load pretrained weights for if pretrained is "
-            "set. Default is None which will load the default dataset for "
-            "the architecture. Ex can be set to imagenet, cifar10, etc",
-        },
-    )
-
-    model_kwargs: json.loads = field(
-        default_factory=lambda: {},
-        metadata={
-            "help": "Keyword arguments to be passed to model constructor, should "
-            "be given as a json object"
-        },
-    )
-
-    dataset_kwargs: json.loads = field(
-        default_factory=lambda: {},
-        metadata={
-            "help": "Keyword arguments to be passed to dataset constructor, "
-            "should be given as a json object",
-        },
-    )
-
-    model_tag: str = field(
-        default=None,
-        metadata={
-            "help": "A tag to use for the model for saving results under save-dir, "
-            "defaults to the model arch and dataset used",
-        },
-    )
-
-    save_dir: str = field(
-        default="pytorch_vision",
-        metadata={
-            "help": "The path to the directory for saving results",
-        },
-    )
-
-    device: str = field(
-        default=default_device(),
-        metadata={
-            "help": "The device to run on (can also include ids for data "
-            "parallel), ex: cpu, cuda, cuda:0,1"
-        },
-    )
-
-    loader_num_workers: int = field(
-        default=4, metadata={"help": "The number of workers to use for data loading"}
-    )
-
-    loader_pin_memory: bool = field(
-        default=True, metadata={"help": "Use pinned memory for data loading"}
-    )
-    image_size: int = field(
-        default=224, metadata={"help": "The size of the image input to the model"}
-    )
-
-    ffcv: bool = field(
-        default=False,
-        metadata={"help": "Use ffcv for training, Defaults to False"},
-    )
-
-    def __post_init__(self):
-        # add ddp args
-        env_world_size = int(os.environ.get("WORLD_SIZE", 1))
-        self.world_size = env_world_size
-
-        env_rank = int(os.environ.get("RANK", -1))
-        self.rank = env_rank
-
-        self.is_main_process = self.rank in [
-            -1,
-            0,
-        ]  # non DDP execution or 0th DDP process
-
-        # modify training batch size for give world size
-        assert self.train_batch_size % self.world_size == 0, (
-            f"Invalid training batch size for world size {self.world_size} "
-            f"given batch size {self.train_batch_size}. "
-            f"world size must divide training batch size evenly."
+    if not train_batch_size % world_size == 0:
+        raise ValueError(
+            f"Invalid training batch size for world size {world_size} "
+            f"given batch size {train_batch_size}. "
+            "world size must divide training batch size evenly."
         )
 
-        self.train_batch_size = self.train_batch_size // self.world_size
+    train_batch_size = train_batch_size // world_size
+    helpers.set_seeds(local_rank=local_rank)
 
-        if "preprocessing_type" not in self.dataset_kwargs and (
-            "coco" in self.dataset.lower() or "voc" in self.dataset.lower()
-        ):
-            if "ssd" in self.arch_key.lower():
-                self.dataset_kwargs["preprocessing_type"] = "ssd"
-            elif "yolo" in self.arch_key.lower():
-                self.dataset_kwargs["preprocessing_type"] = "yolo"
+    train_dataset, train_loader, = helpers.get_dataset_and_dataloader(
+        dataset_name=dataset,
+        dataset_path=dataset_path,
+        batch_size=train_batch_size,
+        image_size=image_size,
+        dataset_kwargs=dataset_kwargs,
+        training=True,
+        loader_num_workers=loader_num_workers,
+        loader_pin_memory=loader_pin_memory,
+        ffcv=ffcv,
+        device=device,
+    )
 
-        if self.local_rank != -1:
-            torch.distributed.init_process_group(backend="nccl", init_method="env://")
-            set_deterministic_seeds(0)
+    val_dataset, val_loader = (
+        helpers.get_dataset_and_dataloader(
+            dataset_name=dataset,
+            dataset_path=dataset_path,
+            batch_size=test_batch_size,
+            image_size=image_size,
+            dataset_kwargs=dataset_kwargs,
+            training=False,
+            loader_num_workers=loader_num_workers,
+            loader_pin_memory=loader_pin_memory,
+            ffcv=ffcv,
+            device=device,
+        )
+        if is_main_process
+        else (None, None)
+    )
 
-        self.approximate = False
+    num_classes = helpers.infer_num_classes(
+        train_dataset=train_dataset,
+        val_dataset=val_dataset,
+        dataset=dataset,
+        model_kwargs=model_kwargs,
+    )
+
+    model, arch_key = helpers.create_model(
+        checkpoint_path=checkpoint_path,
+        recipe_path=recipe_path,
+        num_classes=num_classes,
+        arch_key=arch_key,
+        pretrained=pretrained,
+        pretrained_dataset=pretrained_dataset,
+        local_rank=local_rank,
+        **model_kwargs,
+    )
+
+    save_dir, loggers = helpers.get_save_dir_and_loggers(
+        task=CURRENT_TASK,
+        is_main_process=is_main_process,
+        save_dir=save_dir,
+        arch_key=arch_key,
+        model_tag=model_tag,
+        dataset_name=dataset,
+        logs_dir=logs_dir,
+    )
+
+    LOGGER.info(f"created model with key {arch_key}: {model}")
+
+    ddp, device, model = helpers.ddp_aware_model_move(
+        device=device,
+        local_rank=local_rank,
+        model=model,
+        rank=rank,
+    )
+
+    LOGGER.info(f"running on device {device}")
+
+    trainer = ImageClassificationTrainer(
+        model=model,
+        key=arch_key,
+        recipe_path=recipe_path,
+        ddp=ddp,
+        device=device,
+        use_mixed_precision=use_mixed_precision,
+        val_loader=val_loader,
+        train_loader=train_loader,
+        is_main_process=is_main_process,
+        loggers=loggers,
+        loss_fn=helpers.get_loss_wrapper,
+        init_lr=init_lr,
+        optim_name=optim,
+        optim_kwargs=optim_args,
+    )
+
+    train(
+        trainer=trainer,
+        save_dir=save_dir,
+        debug_steps=debug_steps,
+        eval_mode=eval_mode,
+        is_main_process=is_main_process,
+        save_best_after=save_best_after,
+        save_epochs=save_epochs,
+        rank=rank,
+    )
 
 
 def train(
-    train_args: TrainingArguments,
-    num_classes: int,
-    train_loader: DataLoader,
-    val_loader: DataLoader,
-) -> None:
+    trainer: ImageClassificationTrainer,
+    save_dir: str,
+    debug_steps: int,
+    eval_mode: bool,
+    is_main_process: bool,
+    save_best_after: int,
+    save_epochs: Tuple[int, ...],
+    rank: int,
+):
     """
-    Utility function to drive the training processing
+    Utility function to run the training loop
 
-    :param train_args: A TrainingArguments object with
-        arguments for current training task
-    :param num_classes: The number of output classes in the dataset
-    :param train_loader: A DataLoader for training data
-    :param val_loader: A DataLoader for validation data
+    :param trainer: The ImageClassificationTrainer object
+    :param save_dir: The directory to save checkpoints to
+    :param debug_steps: The number of steps to run in debug mode
+    :param eval_mode: Whether to run in evaluation mode
+    :param is_main_process: Whether this is the main process
+    :param save_best_after: The number of epochs to wait before saving
+        a new best model
+    :param save_epochs: The epochs to save checkpoints for
+    :param rank: The rank of the process
     """
-
-    trainer, save_dir = _init_image_classification_trainer_and_save_dirs(
-        train_args=train_args,
-        train_loader=train_loader,
-        val_loader=val_loader,
-        num_classes=num_classes,
-    )
 
     # Baseline eval run
     trainer.run_one_epoch(
         mode="validation",
-        max_steps=train_args.debug_steps,
+        max_steps=debug_steps,
         baseline_run=True,
     )
 
-    if not train_args.eval_mode:
+    if not eval_mode:
         helpers.save_recipe(recipe_manager=trainer.manager, save_dir=save_dir)
         LOGGER.info(f"Starting training from epoch {trainer.epoch}")
 
@@ -542,18 +627,18 @@ def train(
         while trainer.epoch < trainer.max_epochs:
             train_res = trainer.run_one_epoch(
                 mode="train",
-                max_steps=train_args.debug_steps,
+                max_steps=debug_steps,
             )
             LOGGER.info(f"\nEpoch {trainer.epoch} training results: {train_res}")
             # testing steps
-            if train_args.is_main_process:
+            if is_main_process:
                 val_res = trainer.run_one_epoch(
                     mode="val",
-                    max_steps=train_args.debug_steps,
+                    max_steps=debug_steps,
                 )
                 val_metric = val_res.result_mean(trainer.target_metric).item()
 
-                should_save_epoch = trainer.epoch >= train_args.save_best_after and (
+                should_save_epoch = trainer.epoch >= save_best_after and (
                     best_metric is None
                     or (
                         val_metric <= best_metric
@@ -576,9 +661,7 @@ def train(
 
             # save checkpoints
             should_save_epoch = (
-                train_args.is_main_process
-                and train_args.save_epochs
-                and trainer.epoch in train_args.save_epochs
+                is_main_process and save_epochs and trainer.epoch in save_epochs
             )
             if should_save_epoch:
                 save_name = (
@@ -600,8 +683,8 @@ def train(
 
         # export the final model
         LOGGER.info("completed...")
-        if train_args.is_main_process:
-            # only convert qat -> quantized ONNX graph for finalized model
+        if is_main_process:
+            # Convert QAT -> quantized ONNX graph for finalized model only
             helpers.save_model_training(
                 model=trainer.model,
                 optim=trainer.optim,
@@ -618,130 +701,9 @@ def train(
                 )
 
     # close DDP
-    if train_args.rank != -1:
+    if rank != -1:
+        assert hasattr(torch, "distributed")
         torch.distributed.destroy_process_group()
-
-
-def main():
-    """
-    Driver function for the script
-    """
-    parser = NmArgumentParser(dataclass_types=TrainingArguments)
-    training_args, _ = parser.parse_args_into_dataclasses()
-
-    train_dataset, train_loader, = helpers.get_dataset_and_dataloader(
-        dataset_name=training_args.dataset,
-        dataset_path=training_args.dataset_path,
-        batch_size=training_args.train_batch_size,
-        image_size=training_args.image_size,
-        dataset_kwargs=training_args.dataset_kwargs,
-        training=True,
-        loader_num_workers=training_args.loader_num_workers,
-        loader_pin_memory=training_args.loader_pin_memory,
-        ffcv=training_args.ffcv,
-        device=training_args.device,
-    )
-    val_dataset, val_loader = (
-        helpers.get_dataset_and_dataloader(
-            dataset_name=training_args.dataset,
-            dataset_path=training_args.dataset_path,
-            batch_size=training_args.test_batch_size,
-            image_size=training_args.image_size,
-            dataset_kwargs=training_args.dataset_kwargs,
-            training=False,
-            loader_num_workers=training_args.loader_num_workers,
-            loader_pin_memory=training_args.loader_pin_memory,
-            ffcv=training_args.ffcv,
-            device=training_args.device,
-        )
-        if training_args.is_main_process
-        else (None, None)
-    )
-
-    num_classes = helpers.infer_num_classes(
-        train_dataset=train_dataset,
-        val_dataset=val_dataset,
-        dataset=training_args.dataset,
-        model_kwargs=training_args.model_kwargs,
-    )
-
-    train(
-        train_args=training_args,
-        num_classes=num_classes,
-        train_loader=train_loader,
-        val_loader=val_loader,
-    )
-
-
-def _init_image_classification_trainer_and_save_dirs(
-    train_args: TrainingArguments,
-    train_loader: DataLoader,
-    val_loader: DataLoader,
-    num_classes: int,
-) -> Tuple[ImageClassificationTrainer, Optional[str]]:
-    # Initialize and return the image classification trainer
-
-    def _loss_fn():
-        extras = {"top1acc": TopKAccuracy(1), "top5acc": TopKAccuracy(5)}
-        return CrossEntropyLossWrapper(extras=extras)
-
-    model, train_args.arch_key = helpers.create_model(
-        checkpoint_path=train_args.checkpoint_path,
-        recipe_path=train_args.recipe_path,
-        num_classes=num_classes,
-        arch_key=train_args.arch_key,
-        pretrained=train_args.pretrained,
-        pretrained_dataset=train_args.pretrained_dataset,
-        local_rank=train_args.local_rank,
-        **train_args.model_kwargs,
-    )
-
-    save_dir, loggers = helpers.get_save_dir_and_loggers(
-        task=CURRENT_TASK,
-        is_main_process=train_args.is_main_process,
-        save_dir=train_args.save_dir,
-        arch_key=train_args.arch_key,
-        model_tag=train_args.model_tag,
-        dataset_name=train_args.dataset,
-        logs_dir=train_args.logs_dir,
-    )
-
-    LOGGER.info(f"created model with key {train_args.arch_key}: {model}")
-
-    if train_args.rank == -1:
-        ddp = False
-    else:
-        torch.cuda.set_device(train_args.local_rank)
-        train_args.device = train_args.local_rank
-        ddp = True
-
-    model, train_args.device, _ = model_to_device(
-        model=model,
-        device=train_args.device,
-        ddp=ddp,
-    )
-
-    LOGGER.info(f"running on device {train_args.device}")
-
-    return (
-        ImageClassificationTrainer(
-            model=model,
-            key=train_args.arch_key,
-            recipe_path=train_args.recipe_path,
-            ddp=ddp,
-            device=train_args.device,
-            use_mixed_precision=train_args.use_mixed_precision,
-            val_loader=val_loader,
-            train_loader=train_loader,
-            is_main_process=train_args.is_main_process,
-            loggers=loggers,
-            loss_fn=_loss_fn,
-            init_lr=train_args.init_lr,
-            optim_name=train_args.optim,
-            optim_kwargs=train_args.optim_args,
-        ),
-        save_dir,
-    )
 
 
 if __name__ == "__main__":

--- a/src/sparseml/pytorch/image_classification/utils/constants.py
+++ b/src/sparseml/pytorch/image_classification/utils/constants.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 # Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .constants import *
-from .nm_argparser import *
-from .trainer import *
+"""
+Constants for PyTorch Image Classification Integrations
+"""
+from inspect import isclass
+
+import torch
+
+
+__all__ = [
+    "OPTIMIZERS",
+    "DEFAULT_OPTIMIZER",
+]
+
+OPTIMIZERS = [
+    key
+    for key in torch.optim.__dict__.keys()
+    if isclass(torch.optim.__dict__[key]) and key != "Optimizer"
+]
+
+# Early exit if no optimizer is found
+if not OPTIMIZERS:
+    raise RuntimeError(
+        "No optimizers found in torch.optim. "
+        "Please install a torch optimizer to use this integration."
+    )
+
+DEFAULT_OPTIMIZER = "SGD" if "SGD" in OPTIMIZERS else OPTIMIZERS[0]


### PR DESCRIPTION
The goal of this PR is to make `SparseML-PyTorch` train integration (for image classification) more maintainable by removing dependency on `TrainingArguments` class.  The idea is to have a single source of truth for all command line arguments. This also integrates `click` with the train script as per standards.

The following commands have been tested locally to ensure these changes do not break existing flows:

```bash
sparseml.image_classification.train \
    --recipe-path "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative" \
     --arch-key resnet50 \
    --dataset imagenette \
    --dataset-path data \
    --train-batch-size 32 \
    --test-batch-size 32 \
    --checkpoint-path zoo
```