### PR TITLE
Click refactor for Pruning Sensitivity analysis

### DIFF
--- a/src/sparseml/pytorch/image_classification/pr_sensitivity.py
+++ b/src/sparseml/pytorch/image_classification/pr_sensitivity.py
@@ -15,86 +15,80 @@
 """
 #####
 Command help:
-python integrations/pytorch/pr_sensitivity.py --help
-usage: pr_sensitivity.py [-h] --arch-key ARCH_KEY --dataset DATASET
-                         --dataset-path DATASET_PATH
-                         [--pretrained PRETRAINED]
-                         [--pretrained-dataset PRETRAINED_DATASET]
-                         [--model-kwargs MODEL_KWARGS]
-                         [--dataset-kwargs DATASET_KWARGS]
-                         [--model-tag MODEL_TAG] [--save-dir SAVE_DIR]
-                         [--device DEVICE]
-                         [--loader-num-workers LOADER_NUM_WORKERS]
-                         [--no-loader-pin-memory]
-                         [--loader-pin-memory [LOADER_PIN_MEMORY]]
-                         [--checkpoint-path CHECKPOINT_PATH]
-                         [--steps-per-measurement STEPS_PER_MEASUREMENT]
-                         [--batch-size BATCH_SIZE]
-                         [--approximate [APPROXIMATE]]
+Usage: sparseml.image_classification.pr_sensitivity.py [OPTIONS]
 
-Utility script to Run a kernel sparsity (pruning) analysis for a
-desired image classification architecture
+  Run kernel sparsity (pruning) analysis for a desired image classification
+  architecture
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --arch-key ARCH_KEY   The type of model to use, ex: resnet50, vgg16,
-                        mobilenet put as help to see the full list
-                        (will raise an exception with the list)
-  --dataset DATASET     The dataset to use for training, ex: imagenet,
-                        imagenette, cifar10, etc. Set to imagefolder
-                        for a generic dataset setup with an image
-                        folder structure setup like imagenet or
-                        loadable by a dataset in
-                        sparseml.pytorch.datasets
-  --dataset-path DATASET_PATH
-                        The root path to where the dataset is stored
-  --pretrained PRETRAINED
-                        The type of pretrained weights to use, default
-                        is true to load the default pretrained weights
-                        for the model. Otherwise should be set to the
-                        desired weights type: [base, optim, optim-
-                        perf]. To not load any weights set to one of
-                        [none, false]
-  --pretrained-dataset PRETRAINED_DATASET
-                        The dataset to load pretrained weights for if
-                        pretrained is set. Default is None which will
-                        load the default dataset for the architecture.
-                        Ex can be set to imagenet, cifar10, etc
-  --model-kwargs MODEL_KWARGS
-                        Keyword arguments to be passed to model
-                        constructor, should be given as a json object
-  --dataset-kwargs DATASET_KWARGS
-                        Keyword arguments to be passed to dataset
-                        constructor, should be given as a json object
-  --model-tag MODEL_TAG
-                        A tag to use for the model for saving results
-                        under save-dir, defaults to the model arch and
-                        dataset used
-  --save-dir SAVE_DIR   The path to the directory for saving results
-  --device DEVICE       The device to run on (can also include ids for
-                        data parallel), ex: cpu, cuda, cuda:0,1
-  --loader-num-workers LOADER_NUM_WORKERS
-                        The number of workers to use for data loading
-  --no-loader-pin-memory
-                        Do not use pinned memory for data loading
-  --loader-pin-memory [LOADER_PIN_MEMORY]
-                        Use pinned memory for data loading
-  --checkpoint-path CHECKPOINT_PATH
-                        A path to a previous checkpoint to load the
-                        state from and resume the state for. If
-                        provided, pretrained will be ignored. If using
-                        a SparseZoo recipe, can also provide 'zoo' to
-                        load the base weights associated with that
-                        recipe
-  --steps-per-measurement STEPS_PER_MEASUREMENT
-                        The number of steps (batches) to run for each
-                        measurement
-  --batch-size BATCH_SIZE
-                        The batch size to use for analysis
-  --approximate [APPROXIMATE]
-                        approximate without running data through the
-                        model(uses one shot analysis if --approximate
-                        not passed)
+Options:
+  -d, --dataset TEXT              The dataset to use for analysis, ex:
+                                  `imagenet`, `imagenette`, `cifar10`, etc.
+                                  Set to `imagefolder` for a generic dataset
+                                  setup with imagefolder type structure like
+                                  imagenet or loadable by a dataset in
+                                  `sparseml.pytorch.datasets`  [required]
+  --dataset-path, --dataset_path DIRECTORY
+                                  The root dir path where the dataset is
+                                  stored or should be downloaded to if
+                                  available  [required]
+  --arch_key, --arch-key TEXT     The architecture key for image
+                                  classification model; example: `resnet50`,
+                                  `mobilenet`. Note: Will be read from the
+                                  checkpoint if not specified
+  --checkpoint-path, --checkpoint_path TEXT
+                                  A path to a previous checkpoint to load the
+                                  state from and resume the state for. If
+                                  provided, pretrained will be ignored
+  --pretrained TEXT               The type of pretrained weights to use, loads
+                                  default pretrained weights for the model if
+                                  not specified or set to `True`. Otherwise
+                                  should be set to the desired weights type:
+                                  [base, optim, optim-perf]. To not load any
+                                  weights setto one of [none, false]
+                                  [default: True]
+  --pretrained-dataset, --pretrained_dataset TEXT
+                                  The dataset to load pretrained weights for
+                                  if pretrained is set. Load the default
+                                  dataset for the architecture if set to None.
+                                  examples:`imagenet`, `cifar10`, etc...
+  --model-kwargs, --model_kwargs TEXT
+                                  Keyword arguments to be passed to model
+                                  constructor, should be given as a json
+                                  object
+  --dataset-kwargs, --dataset_kwargs TEXT
+                                  Keyword arguments to be passed to dataset
+                                  constructor, should be specified as a json
+                                  object
+  --model-tag, --model_tag TEXT   A tag for saving results under save-dir,
+                                  defaults to the model arch and dataset used
+  --save-dir, --save_dir DIRECTORY
+                                  The path to the directory for saving results
+                                  [default: pytorch_vision]
+  --device TEXT                   The device to run on (can also include ids
+                                  for data parallel), ex: cpu, cuda, cuda:0,1
+                                  [default: cuda]
+  --loader-num-workers, --loader_num_workers INTEGER
+                                  The number of workers to use for data
+                                  loading
+  --loader-pin-memory, --loader_pin_memory / --loader-no-pin-memory,
+  --loader_no_pin_memory
+                                  Use pinned memory for data loading
+                                  [default: loader-pin-memory]
+  --steps-per-measurement, --steps_per_measurement INTEGER
+                                  The number of steps (batches) to run for
+                                  each measurement  [default: 20]
+  --batch-size, --batch_size INTEGER
+                                  The batch size to use for analysis
+                                  [default: 64]
+  --approximate                   approximate without running data through the
+                                  model(uses one shot analysis if
+                                  --approximate not passed)  [default: False]
+  -is, --image-size, --image_size INTEGER
+                                  The size of the image input to the model.
+                                  Value should be equal to S for [C, S, S] or
+                                  [S, S, C] dimensional input  [default: 224]
+  --help                          Show this message and exit.
+
 #########
 EXAMPLES
 #########
@@ -110,14 +104,14 @@ Note: Might need to install pycocotools using pip
 """
 import json
 import os
-from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
+from torch.nn import Module
 from torch.utils.data import DataLoader
 
+import click
 from sparseml import get_main_logger
-from sparseml.pytorch.image_classification.utils import NmArgumentParser, helpers
-from sparseml.pytorch.models import ModelRegistry
+from sparseml.pytorch.image_classification.utils import helpers
 from sparseml.pytorch.optim import (
     pruning_loss_sens_magnitude,
     pruning_loss_sens_one_shot,
@@ -133,298 +127,204 @@ CURRENT_TASK = helpers.Tasks.PR_SENSITIVITY
 LOGGER = get_main_logger()
 
 
-@dataclass
-class PRAnalysisArguments:
-    """
-    Represents the arguments we use in our PyTorch integration scripts for
-    kernel sparsity (pruning) analysis tasks
-
-    Using :class:`NmArgumentParser` we can turn this class into `argparse
-    <https://docs.python.org/3/library/argparse.html#module-argparse>`__
-    arguments that can be specified on the command line.
-
-    :param arch_key: A str key representing the type of model to use,
-        ex:resnet50.
-    :param dataset: The dataset to use for training, ex imagenet, imagenette,
-        etc; Set to `imagefolder` for a custom dataset.
-    :param dataset_path: Root path to dataset location.
-    :param pretrained: The type of pretrained weights to use default is true to
-        load the default pretrained weights for the model Otherwise should be
-        set to the desired weights type: [base, optim, optim-perf]; To not
-        load any weights set to one of [none, false].
-    :param pretrained_dataset: str representing the dataset to load
-        pretrained weights for if pretrained is set; Default is None which will
-        load the default dataset for the architecture; Ex can be set to
-        imagenet, cifar10, etc".
-    :param model_kwargs: json object containing keyword arguments to be
-        passed to model constructor.
-    :param dataset_kwargs: json object to load keyword arguments to be
-        passed to dataset constructor.
-    :param model_tag: A str tag to use for the model for saving results
-        under save-dir, defaults to the model arch and dataset used.
-    :param save_dir: The path to the directory for saving results,
-        default="pytorch_vision".
-    :param device: str represnting the device to run on
-        (can also include ids for data parallel), ex:{cpu, cuda, cuda:0,1}.
-    :param loader_num_workers: int number of workers to use for data
-        loading, default=4.
-    :param loader_pin_memory: bool to use pinned memory for data loading,
-        default=True.
-    :param checkpoint_path: A path to a previous checkpoint to load the state
-        from and resume the state for; Also works with SparseZoo recipes;
-        Set to zoo to automatically download and load weights associated with
-        a recipe.
-    :param steps_per_measurement: The number of steps (batches) to run for
-        each measurement
-    :param batch_size: The batch size to use for analysis
-    :param approximate: approximate without running data through the model
-        (uses one shot analysis if --approximate not passed)
-    """
-
-    dataset: str = field(
-        metadata={
-            "help": "The dataset to use for training, "
-            "ex: imagenet, imagenette, cifar10, etc. "
-            "Set to imagefolder for a generic dataset setup "
-            "with an image folder structure setup like imagenet or "
-            "loadable by a dataset in sparseml.pytorch.datasets"
-        }
-    )
-
-    dataset_path: str = field(
-        metadata={
-            "help": "The root path to where the dataset is stored",
-        }
-    )
-    arch_key: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": "The type of model to use, ex: resnet50, vgg16, mobilenet "
-            "put as help to see the full list (will raise an exception "
-            "with the list)",
-        },
-    )
-    pretrained: str = field(
-        default=True,
-        metadata={
-            "help": "The type of pretrained weights to use, "
-            "default is true to load the default pretrained weights "
-            "for the model. Otherwise should be set to the desired "
-            "weights type: [base, optim, optim-perf]. To not load any"
-            " weights set  to one of [none, false]"
-        },
-    )
-
-    pretrained_dataset: str = field(
-        default=None,
-        metadata={
-            "help": "The dataset to load pretrained weights for if pretrained"
-            "is set. Default is None which will load the default "
-            "dataset for the architecture. Ex can be set to imagenet,"
-            "cifar10, etc",
-        },
-    )
-
-    model_kwargs: json.loads = field(
-        default_factory=lambda: {},
-        metadata={
-            "help": "Keyword arguments to be passed to model constructor, "
-            "should be given as a json object"
-        },
-    )
-
-    dataset_kwargs: json.loads = field(
-        default_factory=lambda: {},
-        metadata={
-            "help": "Keyword arguments to be passed to dataset constructor, "
-            "should be given as a json object",
-        },
-    )
-
-    model_tag: str = field(
-        default=None,
-        metadata={
-            "help": "A tag to use for the model for saving results under "
-            "save-dir, defaults to the model arch and dataset used",
-        },
-    )
-
-    save_dir: str = field(
-        default="pytorch_vision",
-        metadata={
-            "help": "The path to the directory for saving results",
-        },
-    )
-
-    device: str = field(
-        default=default_device(),
-        metadata={
-            "help": "The device to run on (can also include ids for "
-            "data parallel), ex: cpu, cuda, cuda:0,1"
-        },
-    )
-
-    loader_num_workers: int = field(
-        default=4, metadata={"help": "The number of workers to use for data loading"}
-    )
-
-    loader_pin_memory: bool = field(
-        default=True, metadata={"help": "Use pinned memory for data loading"}
-    )
-
-    checkpoint_path: str = field(
-        default=None,
-        metadata={
-            "help": "A path to a previous checkpoint to load the state from "
-            "and resume the state for. If provided, pretrained will "
-            "be ignored. If using a SparseZoo recipe, can also "
-            "provide 'zoo' to load the base weights associated with "
-            "that recipe"
-        },
-    )
-
-    steps_per_measurement: int = field(
-        default=15,
-        metadata={"help": "The number of steps (batches) to run for each measurement"},
-    )
-    batch_size: int = field(
-        default=64, metadata={"help": "The batch size to use for analysis"}
-    )
-
-    approximate: Optional[bool] = field(
-        default=False,
-        metadata={
-            "help": "approximate without running data through the model"
-            "(uses one shot analysis if --approximate not passed)",
-        },
-    )
-
-    def __post_init__(self):
-        self.arch_key = helpers.get_arch_key(
-            arch_key=self.arch_key,
-            checkpoint_path=self.checkpoint_path,
-        )
-
-        if "preprocessing_type" not in self.dataset_kwargs and (
-            "coco" in self.dataset.lower() or "voc" in self.dataset.lower()
-        ):
-            if "ssd" in self.arch_key.lower():
-                self.dataset_kwargs["preprocessing_type"] = "ssd"
-            elif "yolo" in self.arch_key.lower():
-                self.dataset_kwargs["preprocessing_type"] = "yolo"
-
-        self.is_main_process = True
-        self.local_rank = -1
-        self.rank = -1
-
-
-def pruning_loss_sensitivity(
-    args: PRAnalysisArguments,
-    model,
-    train_loader: DataLoader,
+@click.command()
+@click.option(
+    "--dataset",
+    "-d",
+    type=str,
+    required=True,
+    help="The dataset to use for analysis, "
+    "ex: `imagenet`, `imagenette`, `cifar10`, etc. "
+    "Set to `imagefolder` for a generic dataset setup with "
+    "imagefolder type structure like imagenet or loadable by "
+    "a dataset in `sparseml.pytorch.datasets`",
+)
+@click.option(
+    "--dataset-path",
+    "--dataset_path",
+    type=click.Path(dir_okay=True, file_okay=False),
+    callback=helpers.create_dir_callback,
+    required=True,
+    help="The root dir path where the dataset is stored or should "
+    "be downloaded to if available",
+)
+@click.option(
+    "--arch_key",
+    "--arch-key",
+    type=str,
+    default=None,
+    help="The architecture key for image classification model; "
+    "example: `resnet50`, `mobilenet`. "
+    "Note: Will be read from the checkpoint if not specified",
+)
+@click.option(
+    "--checkpoint-path",
+    "--checkpoint_path",
+    type=str,
+    default=None,
+    help="A path to a previous checkpoint to load the state from "
+    "and resume the state for. If provided, pretrained will "
+    "be ignored",
+)
+@click.option(
+    "--pretrained",
+    type=str,
+    default=True,
+    show_default=True,
+    help="The type of pretrained weights to use, "
+    "loads default pretrained weights for "
+    "the model if not specified or set to `True`. "
+    "Otherwise should be set to the desired weights "
+    "type: [base, optim, optim-perf]. To not load any weights set"
+    "to one of [none, false]",
+)
+@click.option(
+    "--pretrained-dataset",
+    "--pretrained_dataset",
+    type=str,
+    default=None,
+    show_default=True,
+    help="The dataset to load pretrained weights for if pretrained is "
+    "set. Load the default dataset for the architecture if set to None. "
+    "examples:`imagenet`, `cifar10`, etc...",
+)
+@click.option(
+    "--model-kwargs",
+    "--model_kwargs",
+    default=json.dumps({}),
+    type=str,
+    callback=helpers.parse_json_callback,
+    help="Keyword arguments to be passed to model constructor, should "
+    "be given as a json object",
+)
+@click.option(
+    "--dataset-kwargs",
+    "--dataset_kwargs",
+    default=json.dumps({}),
+    type=str,
+    callback=helpers.parse_json_callback,
+    help="Keyword arguments to be passed to dataset constructor, "
+    "should be specified as a json object",
+)
+@click.option(
+    "--model-tag",
+    "--model_tag",
+    type=str,
+    default=None,
+    help="A tag for saving results under save-dir, "
+    "defaults to the model arch and dataset used",
+)
+@click.option(
+    "--save-dir",
+    "--save_dir",
+    type=click.Path(dir_okay=True, file_okay=False),
+    default="pytorch_vision",
+    callback=helpers.create_dir_callback,
+    show_default=True,
+    help="The path to the directory for saving results",
+)
+@click.option(
+    "--device",
+    default=default_device(),
+    show_default=True,
+    help="The device to run on (can also include ids for data "
+    "parallel), ex: cpu, cuda, cuda:0,1",
+)
+@click.option(
+    "--loader-num-workers",
+    "--loader_num_workers",
+    type=int,
+    default=4,
+    help="The number of workers to use for data loading",
+)
+@click.option(
+    "--loader-pin-memory/--loader-no-pin-memory",
+    "--loader_pin_memory/--loader_no_pin_memory",
+    default=True,
+    is_flag=True,
+    show_default=True,
+    help="Use pinned memory for data loading",
+)
+@click.option(
+    "--steps-per-measurement",
+    "--steps_per_measurement",
+    type=int,
+    default=20,
+    show_default=True,
+    help="The number of steps (batches) to run for each measurement",
+)
+@click.option(
+    "--batch-size",
+    "--batch_size",
+    type=int,
+    default=64,
+    show_default=True,
+    help="The batch size to use for analysis",
+)
+@click.option(
+    "--approximate",
+    is_flag=True,
+    show_default=True,
+    help="approximate without running data through the model"
+    "(uses one shot analysis if --approximate not passed)",
+)
+@click.option(
+    "--image-size",
+    "--image_size",
+    "-is",
+    type=int,
+    default=224,
+    show_default=True,
+    help="The size of the image input to the model. Value should be "
+    "equal to S for [C, S, S] or [S, S, C] dimensional input",
+)
+def main(
+    dataset: str,
+    dataset_path: str,
+    arch_key: Optional[str],
+    checkpoint_path: Optional[str],
+    pretrained: Union[str, bool],
+    pretrained_dataset: Optional[str],
+    model_kwargs: Dict[str, Any],
+    dataset_kwargs: Dict[str, Any],
+    model_tag: Optional[str],
     save_dir: str,
-    loggers: List[Any],
-) -> None:
+    device: Optional[str],
+    loader_num_workers: int,
+    loader_pin_memory: bool,
+    steps_per_measurement: int,
+    batch_size: int,
+    approximate: bool,
+    image_size: int,
+):
     """
-    Utility function for pruning sensitivity analysis
-
-    :param args : A PRAnalysisArguments object containing config for current
-        analysis
-    :param model: loaded model architecture to analyse
-    :param train_loader: A DataLoader for training data
-    :param save_dir: Directory to save results
-    :param loggers: List of loggers to use during analysis
+    Run kernel sparsity (pruning) analysis for a
+    desired image classification architecture
     """
-    # loss setup
-    if not args.approximate:
-        loss = CrossEntropyLossWrapper()
-        LOGGER.info(f"created loss: {loss}")
-    else:
-        loss = None
-
-    # device setup
-    if not args.approximate:
-        module, device, device_ids = model_to_device(model, args.device)
-    else:
-        device = None
-
-    # kernel sparsity analysis
-    if args.approximate:
-        analysis = pruning_loss_sens_magnitude(model)
-    else:
-        analysis = pruning_loss_sens_one_shot(
-            model,
-            train_loader,
-            loss,
-            device,
-            args.steps_per_measurement,
-            tester_loggers=loggers,
-        )
-
-    # saving and printing results
-    LOGGER.info("completed...")
-    LOGGER.info(f"Saving results in {save_dir}")
-    analysis.save_json(
-        os.path.join(
-            save_dir,
-            "ks_approx_sensitivity.json"
-            if args.approximate
-            else "ks_one_shot_sensitivity.json",
-        )
-    )
-    analysis.plot(
-        os.path.join(
-            save_dir,
-            os.path.join(
-                save_dir,
-                "ks_approx_sensitivity.png"
-                if args.approximate
-                else "ks_one_shot_sensitivity.png",
-            ),
-        ),
-        plot_integral=True,
-    )
-    analysis.print_res()
-
-
-def main():
-    """
-    Driver function for the script
-    """
-    _parser = NmArgumentParser(
-        dataclass_types=PRAnalysisArguments,
-        description="Utility script to Run a "
-        "kernel sparsity (pruning) analysis "
-        "for a desired image classification architecture",
-    )
-
-    args_, _ = _parser.parse_args_into_dataclasses()
+    is_main_process = True
+    local_rank = -1
 
     save_dir, loggers = helpers.get_save_dir_and_loggers(
         task=CURRENT_TASK,
-        is_main_process=args_.is_main_process,
-        save_dir=args_.save_dir,
-        arch_key=args_.arch_key,
-        model_tag=args_.model_tag,
-        dataset_name=args_.dataset,
+        is_main_process=is_main_process,
+        save_dir=save_dir,
+        arch_key=arch_key,
+        model_tag=model_tag,
+        dataset_name=dataset,
     )
-
-    input_shape = ModelRegistry.input_shape(key=args_.arch_key)
-    # assume shape [C, S, S] where S is the image size
-    image_size = input_shape[1]
 
     train_dataset, train_loader = (
         helpers.get_dataset_and_dataloader(
-            dataset_name=args_.dataset,
-            dataset_path=args_.dataset_path,
-            batch_size=args_.batch_size,
+            dataset_name=dataset,
+            dataset_path=dataset_path,
+            batch_size=batch_size,
             image_size=image_size,
-            dataset_kwargs=args_.dataset_kwargs,
+            dataset_kwargs=dataset_kwargs,
             training=True,
-            loader_num_workers=args_.loader_num_workers,
-            loader_pin_memory=args_.loader_pin_memory,
+            loader_num_workers=loader_num_workers,
+            loader_pin_memory=loader_pin_memory,
         )
-        if not args_.approximate
+        if not approximate
         else (None, None)
     )
 
@@ -433,21 +333,104 @@ def main():
     num_classes = helpers.infer_num_classes(
         train_dataset=train_dataset,
         val_dataset=val_dataset,
-        dataset=args_.dataset,
-        model_kwargs=args_.model_kwargs,
+        dataset=dataset,
+        model_kwargs=model_kwargs,
     )
 
-    model, args_.arch_key = helpers.create_model(
-        checkpoint_path=args_.checkpoint_path,
+    model, arch_key = helpers.create_model(
+        checkpoint_path=checkpoint_path,
         recipe_path=None,
         num_classes=num_classes,
-        arch_key=args_.arch_key,
-        pretrained=args_.pretrained,
-        pretrained_dataset=args_.pretrained_dataset,
-        local_rank=args_.local_rank,
-        **args_.model_kwargs,
+        arch_key=arch_key,
+        pretrained=pretrained,
+        pretrained_dataset=pretrained_dataset,
+        local_rank=local_rank,
+        **model_kwargs,
     )
-    pruning_loss_sensitivity(args_, model, train_loader, save_dir, loggers)
+
+    pruning_loss_sensitivity(
+        model=model,
+        train_loader=train_loader,
+        save_dir=save_dir,
+        loggers=loggers,
+        approximate=approximate,
+        device=device,
+        steps_per_measurement=steps_per_measurement,
+    )
+
+
+def pruning_loss_sensitivity(
+    model: Module,
+    train_loader: DataLoader,
+    save_dir: str,
+    loggers: List[Any],
+    approximate: bool,
+    device: Union[str, int],
+    steps_per_measurement: int,
+) -> None:
+    """
+    Utility function for pruning sensitivity analysis
+
+    :param model: loaded model architecture to analyse
+    :param train_loader: A DataLoader for training data
+    :param save_dir: Directory to save results
+    :param loggers: List of loggers to use during analysis
+    :param approximate: Whether to use one shot analysis
+    :param device: Device to use for analysis
+    :param steps_per_measurement: Number of steps to run for each measurement
+    """
+    # loss setup
+    if not approximate:
+        loss = CrossEntropyLossWrapper()
+        LOGGER.info(f"created loss: {loss}")
+    else:
+        loss = None
+
+    # device setup
+    if not approximate:
+        module, device, device_ids = model_to_device(
+            model=model,
+            device=device,
+        )
+    else:
+        device = None
+
+    # kernel sparsity analysis
+    if approximate:
+        analysis = pruning_loss_sens_magnitude(model)
+    else:
+        analysis = pruning_loss_sens_one_shot(
+            module=model,
+            data=train_loader,
+            loss=loss,
+            device=device,
+            steps_per_measurement=steps_per_measurement,
+            tester_loggers=loggers,
+        )
+
+    # saving and printing results
+    LOGGER.info("completed...")
+    LOGGER.info(f"Saving results in {save_dir}")
+    output_name = (
+        "ks_approx_sensitivity.json" if approximate else "ks_one_shot_sensitivity.json"
+    )
+    analysis.save_json(
+        os.path.join(
+            save_dir,
+            f"{output_name}.json",
+        )
+    )
+    analysis.plot(
+        os.path.join(
+            save_dir,
+            os.path.join(
+                save_dir,
+                f"{output_name}.png",
+            ),
+        ),
+        plot_integral=True,
+    )
+    analysis.print_res()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The goal of this PR is to make SparseML-PyTorch `PR-sensitivity analysis` integration (for image classification) more maintainable by removing dependency on `PRAnalysisArguments ` class.  The idea is to have a single source of truth for all command line arguments. This also integrates `click` with the train script as per standards.

The following commands have been tested locally to ensure these changes do not break existing flows:

```bash
sparseml.image_classification.pr_sensitivity \
    -d imagenette --dataset-path data \
    --arch-key resnet50
```

Output from above command:

```
2022-04-18 07:17:55 __main__     INFO     created loss: CrossEntropyLossWrapper(Loss: cross_entropy; Extras: )
KS Analysis: 100%|███████████████████████████████| 10800/10800 [12:38<00:00, 14.24it/s]
2022-04-18 07:30:36 __main__     INFO     completed...
2022-04-18 07:30:36 __main__     INFO     Saving results in /home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/pytorch_vision/resnet50_imagenette__03
KS Sensitivity
	Loss Avg		Loss Int		Id		Name
	1.5092		2.3686		None		input.conv.weight
	1.5205		2.3771		None		sections.0.0.conv1.weight
	1.5202		2.3759		None		sections.0.0.conv2.weight
	1.5200		2.3754		None		sections.0.0.conv3.weight
	1.5206		2.3753		None		sections.0.0.identity.conv.weight
	1.5189		2.3747		None		sections.0.1.conv1.weight
	1.5194		2.3750		None		sections.0.1.conv2.weight
	1.5187		2.3745		None		sections.0.1.conv3.weight
	1.5197		2.3756		None		sections.0.2.conv1.weight
	1.5189		2.3745		None		sections.0.2.conv2.weight
	1.5181		2.3740		None		sections.0.2.conv3.weight
	1.5142		2.3710		None		sections.1.0.conv1.weight
	1.5171		2.3734		None		sections.1.0.conv2.weight
	1.5170		2.3735		None		sections.1.0.conv3.weight
	1.5162		2.3727		None		sections.1.0.identity.conv.weight
	1.5177		2.3737		None		sections.1.1.conv1.weight
	1.5194		2.3756		None		sections.1.1.conv2.weight
	1.5176		2.3738		None		sections.1.1.conv3.weight
	1.5175		2.3734		None		sections.1.2.conv1.weight
	1.5178		2.3736		None		sections.1.2.conv2.weight
	1.5178		2.3736		None		sections.1.2.conv3.weight
	1.5183		2.3746		None		sections.1.3.conv1.weight
	1.5197		2.3753		None		sections.1.3.conv2.weight
	1.5176		2.3741		None		sections.1.3.conv3.weight
	1.5122		2.3693		None		sections.2.0.conv1.weight
	1.5160		2.3730		None		sections.2.0.conv2.weight
	1.5151		2.3718		None		sections.2.0.conv3.weight
	1.5147		2.3714		None		sections.2.0.identity.conv.weight
	1.5175		2.3737		None		sections.2.1.conv1.weight
	1.5230		2.3772		None		sections.2.1.conv2.weight
	1.5190		2.3753		None		sections.2.1.conv3.weight
	1.5171		2.3730		None		sections.2.2.conv1.weight
	1.5188		2.3743		None		sections.2.2.conv2.weight
	1.5199		2.3759		None		sections.2.2.conv3.weight
	1.5195		2.3747		None		sections.2.3.conv1.weight
	1.5168		2.3724		None		sections.2.3.conv2.weight
	1.5206		2.3765		None		sections.2.3.conv3.weight
	1.5171		2.3726		None		sections.2.4.conv1.weight
	1.5183		2.3734		None		sections.2.4.conv2.weight
	1.5216		2.3768		None		sections.2.4.conv3.weight
	1.5173		2.3726		None		sections.2.5.conv1.weight
	1.5166		2.3725		None		sections.2.5.conv2.weight
	1.5217		2.3769		None		sections.2.5.conv3.weight
	1.5145		2.3728		None		sections.3.0.conv1.weight
	1.5070		2.3640		None		sections.3.0.conv2.weight
	1.5122		2.3678		None		sections.3.0.conv3.weight
	1.5144		2.3694		None		sections.3.0.identity.conv.weight
	1.5233		2.3817		None		sections.3.1.conv1.weight
	1.5032		2.3578		None		sections.3.1.conv2.weight
	1.5230		2.3756		None		sections.3.1.conv3.weight
	1.5179		2.3776		None		sections.3.2.conv1.weight
	1.5118		2.3672		None		sections.3.2.conv2.weight
	1.5267		2.3836		None		sections.3.2.conv3.weight
	1.4946		2.3476		None		classifier.fc.weight
```