### PR TITLE
Fix: default python log calls to debug level

### DIFF
--- a/src/sparseml/pytorch/utils/logger.py
+++ b/src/sparseml/pytorch/utils/logger.py
@@ -369,7 +369,7 @@ class PythonLogger(LambdaLogger):
         :return: True if logged, False otherwise.
         """
         if not level:
-            level = self._log_level
+            level = LOGGING_LEVELS["debug"]
 
         if level > LOGGING_LEVELS["debug"]:
             format = "%s %s step %s: %s"


### PR DESCRIPTION
Scalar logs with `level=None` were getting written to file. This fix ensures that they remain at the debug level unless explicitly set otherwise