### PR TITLE
fix QATWrapper not properly overwritting qconfig properties for symmetric activations

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -119,10 +119,12 @@ class QConfigProperties:
         Default is torch.qint8.
     :param activation_bits: number of bits for activations. Default is 8.
     :param weight_bits: number of bits for weights. Default is 8.
+    :param tensorrt: if True sets quantization configuration for compatibility with
+       explict quantization as supported by TensorRT 8.2.
     """
 
-    _symmetric_activations: Optional[bool] = None
-    _symmetric_weights: Optional[bool] = None
+    _symmetric_activations: bool = False
+    _symmetric_weights: bool = True
     reduce_range: bool = False
     activation_dtype: torch.dtype = torch.quint8
     weight_dtype: torch.dtype = torch.qint8
@@ -130,30 +132,24 @@ class QConfigProperties:
     weight_bits: int = 8
     activation_qconfig_kwargs: Dict[str, Any] = field(default_factory=dict)
     weight_qconfig_kwargs: Dict[str, Any] = field(default_factory=dict)
+    tensorrt: bool = False
 
     @property
     def symmetric_activations(self) -> bool:
-        if self._symmetric_activations:
-            return self._symmetric_activations
-        else:
-            return False
+        # always use symmetric activations in tensorrt mode
+        return self.tensorrt or self._symmetric_activations
 
     @symmetric_activations.setter
     def symmetric_activations(self, value: bool):
-        if self._symmetric_activations is None:
-            self._symmetric_activations = value
+        self._symmetric_activations = value
 
     @property
     def symmetric_weights(self) -> bool:
-        if self._symmetric_weights:
-            return self._symmetric_weights
-        else:
-            return True
+        return self.tensorrt or self._symmetric_weights
 
     @symmetric_weights.setter
     def symmetric_weights(self, value: bool):
-        if self._symmetric_weights is None:
-            self._symmetric_weights = value
+        self._symmetric_weights = value
 
 
 class QATWrapper(Module):
@@ -365,9 +361,10 @@ class QATWrapper(Module):
                     f"Found string with value {qconfig} in {name}"
                 )
 
-            qproperties.symmetric_activations = qconfig == "symmetric"
+            qproperties_idx = deepcopy(qproperties)
+            qproperties_idx.symmetric_activations = qconfig == "symmetric"
 
-            qconfigs[idx] = get_qat_qconfig(qproperties)
+            qconfigs[idx] = get_qat_qconfig(qproperties_idx)
 
         return qconfigs
 

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -615,9 +615,8 @@ class QuantizationModifier(ScheduledModifier):
                 "Overriding quantization scheme to symmetric int8 "
                 "for both weights and activations because tensorrt flag is True."
             )
-            qproperties.symmetric_activations = True
+            qproperties.tensorrt = True
             qproperties.activation_dtype = torch.qint8
-            qproperties.symmetric_weights = True
             qproperties.weight_dtype = torch.qint8
 
         qconfig = get_qat_qconfig(qproperties)


### PR DESCRIPTION
symmetric activations/weights in `QConfigProperties` was made immutable originally so in tensorrt mode activations could not be changed from symmetric. this introduced a bug for `QATWrapper` where when setting qconfig properties with mixed symmetric and asymmetric qconfigs, they would only be set with one of the schemes.

This PR introduces a fix to 1) make setting activation/weights mutable to fix `QATWrapper` logic and 2) adjust logic of symmetric weights/activations in `QConfigProperties` to work with a `tensorrt` field as a source of truth to keep the scheme safe when in tensorrt mode

Tested locally against bert and distilbert models in default and tensrort mode that correct schemes are set in their QATMatMul layers