### PR TITLE
Added versions of AC/DC with different pruning criteria - Magnitude/G…

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_magnitude.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_magnitude.py
@@ -130,6 +130,7 @@ class GMPruningModifier(BaseGradualPruningModifier, BaseGMPruningModifier):
         global_sparsity: bool = False,
         phased: bool = False,
         score_type: str = "magnitude",
+        **kwargs
     ):
         self._check_deprecated_params(global_sparsity, phased, score_type)
 
@@ -264,6 +265,7 @@ class MagnitudePruningModifier(GMPruningModifier):
         leave_enabled: bool = True,
         inter_func: str = "cubic",
         mask_type: str = "unstructured",
+        **kwargs
     ):
         super(MagnitudePruningModifier, self).__init__(
             params=params,
@@ -346,6 +348,7 @@ class GlobalMagnitudePruningModifier(GMPruningModifier):
         leave_enabled: bool = True,
         inter_func: str = "cubic",
         mask_type: str = "unstructured",
+        **kwargs
     ):
         super(GlobalMagnitudePruningModifier, self).__init__(
             params=params,

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -64,10 +64,10 @@ class MFACPruningModifier(BaseGradualPruningModifier):
     init_sparsity until final_sparsity is reached over a given amount of time
     and applied with an interpolated function for each step taken.
 
-    Uses the Matrix-Free Approxmiate Curvature (M-FAC) algorithm for solving
+    Uses the Matrix-Free Approxmiate Curvature (M-FAC) algorithm from the 
+    paper https://arxiv.org/abs/2107.03356 for solving
     for optimal pruning updates by estimating the inverse Hessian matrix to the
     loss over time under the Optimal Brain Surgeon (OBS) framework.
-    A link to the paper will be included here in an upcoming update.
 
     | Sample yaml:
     |   !MFACPruningModifier
@@ -151,6 +151,7 @@ class MFACPruningModifier(BaseGradualPruningModifier):
         num_pages: int = 1,  # break computation into pages when block size is None
         available_devices: Optional[List[str]] = None,
         mask_type: str = "unstructured",
+        **kwargs
     ):
         super().__init__(
             params=params,

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_movement.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_movement.py
@@ -96,6 +96,7 @@ class MovementPruningModifier(GMPruningModifier):
         leave_enabled: bool = True,
         inter_func: str = "cubic",
         mask_type: str = "unstructured",
+        **kwargs
     ):
         super(MovementPruningModifier, self).__init__(
             init_sparsity=init_sparsity,


### PR DESCRIPTION
The original M-FAC paper https://arxiv.org/abs/2107.03356 and the current implementation in sparseml has only AC/DC implementation with the layer-wise MagnitudePruning modifier. 

However, the formulation of AC/DC allows to use any pruning scorer - GlobalMagnitude/M-FAC/Movement on the compression step. I've created implementation that allows to use different pruning scorers:

- `ACDCMagnitudePruningModifier`
- `ACDCGlobalMagnitudePruningModifier`
- `ACDCMovementPruningModifier`
- `ACDCMFACPruningModifier`

There is a flaw, that in my implementation in order to work with constructors in subclasses,  I had to add `**kwargs` in the constructors of the base modifiers : `MagnitudePruningModifier, GlobalMagnitudePruningModifier, MovementPruningModifier, MFACPruningModifier`.