### PR TITLE
Properly collect metadata for transformers

### DIFF
--- a/src/sparseml/transformers/masked_language_modeling.py
+++ b/src/sparseml/transformers/masked_language_modeling.py
@@ -33,7 +33,7 @@ import logging
 import math
 import os
 import sys
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from itertools import chain
 from typing import Optional
 
@@ -55,7 +55,11 @@ from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
 from sparseml.transformers.sparsification import Trainer
-from sparseml.transformers.utils import SparseAutoModel, get_shared_tokenizer_src
+from sparseml.transformers.utils import (
+    SparseAutoModel,
+    extract_metadata_from_args,
+    get_shared_tokenizer_src,
+)
 
 
 metadata_args = [
@@ -673,7 +677,10 @@ def main():
         model=model,
         model_state_path=model_args.model_name_or_path,
         recipe=data_args.recipe,
-        metadata_args=metadata_args,
+        metadata=extract_metadata_from_args(
+            metadata_args,
+            {**asdict(model_args), **asdict(data_args), **asdict(training_args)},
+        ),
         recipe_args=data_args.recipe_args,
         teacher=teacher,
         args=training_args,

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -27,7 +27,7 @@ Fine-tuning the library models for question answering integrated with sparseml
 import logging
 import os
 import sys
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Optional
 
 import datasets
@@ -52,7 +52,11 @@ from sparseml.transformers.sparsification import (
     QuestionAnsweringTrainer,
     postprocess_qa_predictions,
 )
-from sparseml.transformers.utils import SparseAutoModel, get_shared_tokenizer_src
+from sparseml.transformers.utils import (
+    SparseAutoModel,
+    extract_metadata_from_args,
+    get_shared_tokenizer_src,
+)
 
 
 # Will error if the minimal version of Transformers is not installed. Remove at your
@@ -764,7 +768,10 @@ def main():
         model_state_path=model_args.model_name_or_path,
         recipe=data_args.recipe,
         recipe_args=data_args.recipe_args,
-        metadata_args=metadata_args,
+        metadata=extract_metadata_from_args(
+            metadata_args,
+            {**asdict(model_args), **asdict(data_args), **asdict(training_args)},
+        ),
         teacher=teacher,
         args=training_args,
         train_dataset=train_dataset if training_args.do_train else None,

--- a/src/sparseml/transformers/sparsification/question_answering.py
+++ b/src/sparseml/transformers/sparsification/question_answering.py
@@ -25,7 +25,7 @@ import inspect
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import datasets
 import numpy as np
@@ -180,8 +180,7 @@ class QuestionAnsweringTrainer(TrainerInterface, _QuestionAnsweringTrainer):
     :param recipe_args: A json string, csv key=value string, or dictionary containing
         arguments to override the root arguments within the recipe such as
         learning rate or num epochs
-    :param metadata_args A list of arguments to be extracted from training_args
-        and passed as metadata for the final, saved recipe.
+    :param metadata: A dictionary of extracted metadata for the final saved recipe.
     :param teacher: teacher model for distillation. Set to 'self' to distill
         from the loaded model or 'disable' to turn of distillation
     :param kwargs: key word arguments passed to the parent class
@@ -193,7 +192,7 @@ class QuestionAnsweringTrainer(TrainerInterface, _QuestionAnsweringTrainer):
         model_state_path: str,
         recipe: str,
         recipe_args: Optional[Union[Dict[str, Any], str]] = None,
-        metadata_args: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         teacher: Optional[Module] = None,
         **kwargs,
     ):
@@ -202,7 +201,7 @@ class QuestionAnsweringTrainer(TrainerInterface, _QuestionAnsweringTrainer):
             model_state_path=model_state_path,
             recipe=recipe,
             recipe_args=recipe_args,
-            metadata_args=metadata_args,
+            metadata=metadata,
             teacher=teacher,
             **kwargs,
         )

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -85,8 +85,7 @@ class RecipeManagerTrainerInterface:
     :param recipe_args: A json string, csv key=value string, or dictionary containing
         arguments to override the root arguments within the recipe such as
         learning rate or num epochs
-    :param metadata_args A list of arguments to be extracted from training_args
-        and passed as metadata for the final, saved recipe.
+    :param metadata: A dictionary of extracted metadata for the final saved recipe.
     :param teacher: teacher model for distillation. Set to 'self' to distill
         from the loaded model or 'disable' to turn of distillation
     :param kwargs: key word arguments passed to the parent class
@@ -98,7 +97,7 @@ class RecipeManagerTrainerInterface:
         model_state_path: str,
         recipe: Optional[str],
         recipe_args: Optional[Union[Dict[str, Any], str]] = None,
-        metadata_args: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         teacher: Optional[Union[Module, str]] = None,
         **kwargs,
     ):
@@ -108,13 +107,7 @@ class RecipeManagerTrainerInterface:
         self.recipe = recipe
         self.recipe_args = recipe_args
         self.teacher = teacher
-        self.metadata = (
-            self._extract_metadata(
-                metadata_args=metadata_args, training_args=kwargs["args"]
-            )
-            if ("args" in kwargs and metadata_args)
-            else None
-        )
+        self.metadata = metadata
 
         report_to = (
             ""
@@ -447,24 +440,6 @@ class RecipeManagerTrainerInterface:
             f"all sparsification info: {sparsification_info}"
         )
 
-    def _extract_metadata(
-        self, metadata_args: List[str], training_args: TrainingArguments
-    ) -> Dict:
-        metadata = {}
-        training_args_dict = training_args.to_dict()
-
-        for arg in metadata_args:
-            if arg not in training_args_dict.keys():
-                logging.warning(
-                    f"Required metadata argument {arg} was not found "
-                    f"in the training arguments. Setting {arg} to None."
-                )
-                metadata[arg] = None
-            else:
-                metadata[arg] = training_args_dict[arg]
-
-        return metadata
-
     def _check_super_defined(self, func: str):
         if not hasattr(super(), func):
             raise NotImplementedError(
@@ -614,8 +589,7 @@ class TrainerInterface(RecipeManagerTrainerInterface):
     :param recipe_args: A json string, csv key=value string, or dictionary containing
         arguments to override the root arguments within the recipe such as
         learning rate or num epochs
-    :param metadata_args A list of arguments to be extracted from training_args
-        and passed as metadata for the final, saved recipe.
+    :param metadata: A dictionary of extracted metadata for the final saved recipe.
     :param teacher: teacher model for distillation. Set to 'self' to distill
         from the loaded model or 'disable' to turn of distillation
     :param kwargs: key word arguments passed to the parent class
@@ -627,7 +601,7 @@ class TrainerInterface(RecipeManagerTrainerInterface):
         model_state_path: str,
         recipe: Optional[str],
         recipe_args: Optional[Union[Dict[str, Any], str]] = None,
-        metadata_args: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         teacher: Optional[Union[Module, str]] = None,
         **kwargs,
     ):
@@ -637,7 +611,7 @@ class TrainerInterface(RecipeManagerTrainerInterface):
             model_state_path=model_state_path,
             recipe=recipe,
             recipe_args=recipe_args,
-            metadata_args=metadata_args,
+            metadata=metadata,
             teacher=teacher,
             **kwargs,
         )

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -28,7 +28,7 @@ import logging
 import os
 import random
 import sys
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Optional
 
 import datasets
@@ -51,7 +51,11 @@ from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
 from sparseml.transformers.sparsification import Trainer
-from sparseml.transformers.utils import SparseAutoModel, get_shared_tokenizer_src
+from sparseml.transformers.utils import (
+    SparseAutoModel,
+    extract_metadata_from_args,
+    get_shared_tokenizer_src,
+)
 
 
 # Will error if the minimal version of Transformers is not installed.
@@ -635,7 +639,10 @@ def main():
         model=model,
         model_state_path=model_args.model_name_or_path,
         recipe=data_args.recipe,
-        metadata_args=metadata_args,
+        metadata=extract_metadata_from_args(
+            metadata_args,
+            {**asdict(model_args), **asdict(data_args), **asdict(training_args)},
+        ),
         recipe_args=data_args.recipe_args,
         teacher=teacher,
         args=training_args,

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -26,7 +26,7 @@ Fine-tuning the library models for token classification
 import logging
 import os
 import sys
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Optional
 
 import datasets
@@ -48,7 +48,11 @@ from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
 from sparseml.transformers.sparsification import Trainer
-from sparseml.transformers.utils import SparseAutoModel, get_shared_tokenizer_src
+from sparseml.transformers.utils import (
+    SparseAutoModel,
+    extract_metadata_from_args,
+    get_shared_tokenizer_src,
+)
 
 
 # Will error if the minimal version of Transformers is not installed.
@@ -634,7 +638,10 @@ def main():
         model=model,
         model_state_path=model_args.model_name_or_path,
         recipe=data_args.recipe,
-        metadata_args=metadata_args,
+        metadata=extract_metadata_from_args(
+            metadata_args,
+            {**asdict(model_args), **asdict(data_args), **asdict(training_args)},
+        ),
         recipe_args=data_args.recipe_args,
         teacher=teacher,
         args=training_args,

--- a/src/sparseml/transformers/utils/helpers.py
+++ b/src/sparseml/transformers/utils/helpers.py
@@ -16,10 +16,30 @@
 Helper variables and functions for integrating SparseML with huggingface/transformers
 flows
 """
+import logging
+from typing import Any, Dict, List
+
 
 __all__ = [
     "RECIPE_NAME",
+    "extract_metadata_from_args",
 ]
 
 
 RECIPE_NAME = "recipe.yaml"
+_LOGGER = logging.getLogger(__name__)
+
+
+def extract_metadata_from_args(metadata_args: List[str], args: Dict[str, Any]) -> Dict:
+    metadata = {}
+    for arg in metadata_args:
+        if arg not in args.keys():
+            _LOGGER.warning(
+                f"Required metadata argument {arg} was not found "
+                f"in the training arguments. Setting {arg} to None."
+            )
+            metadata[arg] = None
+        else:
+            metadata[arg] = args[arg]
+
+    return metadata


### PR DESCRIPTION
Fixes https://github.com/neuralmagic/sparseml/issues/742 by collecting metadata in the main when all args (model_args, data_args) are available