### PR TITLE
[Fix] Include `data_args` in transformers metadata.

### DIFF
--- a/src/sparseml/transformers/masked_language_modeling.py
+++ b/src/sparseml/transformers/masked_language_modeling.py
@@ -677,6 +677,7 @@ def main():
         recipe_args=data_args.recipe_args,
         teacher=teacher,
         args=training_args,
+        data_args=data_args,
         train_dataset=train_dataset if training_args.do_train else None,
         eval_dataset=eval_dataset if training_args.do_eval else None,
         tokenizer=tokenizer,

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -767,6 +767,7 @@ def main():
         metadata_args=metadata_args,
         teacher=teacher,
         args=training_args,
+        data_args=data_args,
         train_dataset=train_dataset if training_args.do_train else None,
         eval_dataset=eval_dataset if training_args.do_eval else None,
         eval_examples=eval_examples if training_args.do_eval else None,

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -21,6 +21,7 @@ import inspect
 import logging
 import math
 import os
+from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import datasets
@@ -108,11 +109,16 @@ class RecipeManagerTrainerInterface:
         self.recipe = recipe
         self.recipe_args = recipe_args
         self.teacher = teacher
+
+        training_args, data_args = kwargs.get("args"), kwargs.get("data_args")
+
         self.metadata = (
             self._extract_metadata(
-                metadata_args=metadata_args, training_args=kwargs["args"]
+                metadata_args=metadata_args,
+                training_args_dict=training_args.to_dict(),
+                data_args_dict=asdict(data_args),
             )
-            if ("args" in kwargs and metadata_args)
+            if (training_args or data_args)
             else None
         )
 
@@ -448,20 +454,29 @@ class RecipeManagerTrainerInterface:
         )
 
     def _extract_metadata(
-        self, metadata_args: List[str], training_args: TrainingArguments
-    ) -> Dict:
+        self,
+        metadata_args: List[str],
+        training_args_dict: Dict[str, Any],
+        data_args_dict: Dict[str, Any],
+    ) -> Dict[str, Any]:
         metadata = {}
-        training_args_dict = training_args.to_dict()
+        if not training_args_dict.keys().isdisjoint(data_args_dict.keys()):
+            raise ValueError(
+                "Found common keys in `training_args` and `data args`. "
+                "This is prohibitive and may lead to undesired behavior."
+            )
+
+        args_dict = {**training_args_dict, **data_args_dict}
 
         for arg in metadata_args:
-            if arg not in training_args_dict.keys():
+            if arg not in args_dict.keys():
                 logging.warning(
                     f"Required metadata argument {arg} was not found "
                     f"in the training arguments. Setting {arg} to None."
                 )
                 metadata[arg] = None
             else:
-                metadata[arg] = training_args_dict[arg]
+                metadata[arg] = args_dict[arg]
 
         return metadata
 

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -639,6 +639,7 @@ def main():
         recipe_args=data_args.recipe_args,
         teacher=teacher,
         args=training_args,
+        data_args=data_args,
         train_dataset=train_dataset if training_args.do_train else None,
         eval_dataset=eval_dataset if training_args.do_eval else None,
         tokenizer=tokenizer,

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -638,6 +638,7 @@ def main():
         recipe_args=data_args.recipe_args,
         teacher=teacher,
         args=training_args,
+        data_args=data_args,
         train_dataset=train_dataset if training_args.do_train else None,
         eval_dataset=eval_dataset if training_args.do_eval else None,
         tokenizer=tokenizer,


### PR DESCRIPTION
This is my take on the issue reported by @eldarkurtic : https://github.com/neuralmagic/sparseml/issues/742.

@eldarkurtic provided a solution to the problem: https://github.com/neuralmagic/sparseml/pull/743.
However, I would like to close his PR and continue with my patch. The reason is, that we want to change as little as possible inside each pipeline script and delegate as much as possible to the common script `trainer.py`.