### PR TITLE
Guard against grad collecting during init

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -308,6 +308,9 @@ class MFACPruningModifier(BaseGradualPruningModifier):
     def check_mask_update(
         self, module: Module, epoch: float, steps_per_epoch: int, **kwargs
     ):
+        if steps_per_epoch == 1 and not math.isinf(epoch):
+            return  # not a one-shot run
+
         _LOGGER.debug("Running M-FAC Pruning")
         # create grads for pne-shot pruning
         if self._grad_sampler is not None:


### PR DESCRIPTION
Fixes https://github.com/neuralmagic/sparseml/issues/759 by allowing to collect gradients only when:
1. standard gradual pruning run is invoked (identified as the case with `steps_per_epoch > 1`) but not during the `initialize` call
2. one-shot run identified as the case with `steps_per_epoch = 1` and `epoch = inf` (according to the way how one-shot is called via `.apply()`https://github.com/neuralmagic/sparseml/blob/a6477f900b55afd555734fe6cf784e0137d815a5/src/sparseml/pytorch/sparsification/modifier.py#L154