### PR TITLE
Log status while collecting grads

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -340,8 +340,10 @@ class MFACPruningModifier(BaseGradualPruningModifier):
         module.eval()
 
         _LOGGER.debug(f"Starting to collect {num_grads} grads with GradSampler")
-        for _ in grad_sampler.iter_module_backwards(module, num_grads):
+        for i in grad_sampler.iter_module_backwards(module, num_grads):
             self._module_masks.pre_optim_step_update()
+            if i % 100 == 0:
+                _LOGGER.debug(f"GradSampler collected {i} gradients")
         _LOGGER.debug("GradSampler grad collection complete")
 
         if is_training:


### PR DESCRIPTION
A solution to https://github.com/neuralmagic/sparseml/issues/763
It's currently hardcoded to report every 100 steps, as printing at each step might clutter the stdout completely. 
We can also add it as a recipe argument so that it's configurable, but I think it will just introduce a new param that has to be explained/set while creating recipes so probably better to leave it hardcoded to some reasonable value. 