### PR TITLE
[M-FAC] Logging Update

### DIFF
--- a/src/sparseml/pytorch/sparsification/modifier.py
+++ b/src/sparseml/pytorch/sparsification/modifier.py
@@ -701,18 +701,17 @@ class ScheduledModifier(Modifier, BaseScheduled):
         loggers: Optional[LoggerManager] = None,
         epoch: Optional[float] = None,
         steps_per_epoch: Optional[int] = None,
+        level: Optional[int] = None,
     ):
-        if not tag:
-            tag = type(self).__name__
-        if not loggers:
-            loggers = self.loggers
-        if epoch and steps_per_epoch:
-            step = loggers.epoch_to_step(epoch, steps_per_epoch)
-        else:
-            step = None
-        loggers.log_string(
-            tag=tag, string=string, step=step, level=LOGGING_LEVELS["debug"]
+        tag = tag or type(self).__name__
+        loggers = loggers or self.loggers
+        level = level or LOGGING_LEVELS["debug"]
+        step = (
+            loggers.epoch_to_step(epoch, steps_per_epoch)
+            if (epoch and steps_per_epoch)
+            else None
         )
+        loggers.log_string(tag=tag, string=string, step=step, level=level)
 
     def log_scalar(
         self,
@@ -723,14 +722,13 @@ class ScheduledModifier(Modifier, BaseScheduled):
         steps_per_epoch: Optional[int] = None,
         level: Optional[int] = None,
     ):
-        if not tag:
-            tag = type(self).__name__
-        if not loggers:
-            loggers = self.loggers
-        if epoch and steps_per_epoch:
-            step = loggers.epoch_to_step(epoch, steps_per_epoch)
-        else:
-            step = None
+        tag = tag or type(self).__name__
+        loggers = loggers or self.loggers
+        step = (
+            loggers.epoch_to_step(epoch, steps_per_epoch)
+            if (epoch and steps_per_epoch)
+            else None
+        )
         loggers.log_scalar(tag=tag, value=value, step=step, level=level)
 
     def log_named_scalars(

--- a/src/sparseml/pytorch/sparsification/modifier.py
+++ b/src/sparseml/pytorch/sparsification/modifier.py
@@ -701,17 +701,18 @@ class ScheduledModifier(Modifier, BaseScheduled):
         loggers: Optional[LoggerManager] = None,
         epoch: Optional[float] = None,
         steps_per_epoch: Optional[int] = None,
-        level: Optional[int] = None,
     ):
-        tag = tag or type(self).__name__
-        loggers = loggers or self.loggers
-        level = level or LOGGING_LEVELS["debug"]
-        step = (
-            loggers.epoch_to_step(epoch, steps_per_epoch)
-            if (epoch and steps_per_epoch)
-            else None
+        if not tag:
+            tag = type(self).__name__
+        if not loggers:
+            loggers = self.loggers
+        if epoch and steps_per_epoch:
+            step = loggers.epoch_to_step(epoch, steps_per_epoch)
+        else:
+            step = None
+        loggers.log_string(
+            tag=tag, string=string, step=step, level=LOGGING_LEVELS["debug"]
         )
-        loggers.log_string(tag=tag, string=string, step=step, level=level)
 
     def log_scalar(
         self,
@@ -722,13 +723,14 @@ class ScheduledModifier(Modifier, BaseScheduled):
         steps_per_epoch: Optional[int] = None,
         level: Optional[int] = None,
     ):
-        tag = tag or type(self).__name__
-        loggers = loggers or self.loggers
-        step = (
-            loggers.epoch_to_step(epoch, steps_per_epoch)
-            if (epoch and steps_per_epoch)
-            else None
-        )
+        if not tag:
+            tag = type(self).__name__
+        if not loggers:
+            loggers = self.loggers
+        if epoch and steps_per_epoch:
+            step = loggers.epoch_to_step(epoch, steps_per_epoch)
+        else:
+            step = None
         loggers.log_scalar(tag=tag, value=value, step=step, level=level)
 
     def log_named_scalars(

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -52,8 +52,8 @@ __all__ = [
     "FisherInverseFastPageSwap",
     "FisherInverseFastSmallBlocks",
 ]
-
 _LOGGER = logging.getLogger(__name__)
+
 BYTES_IN_MIB = 1024 ** 2
 
 
@@ -255,7 +255,7 @@ class MFACPruningModifier(BaseGradualPruningModifier):
         :param kwargs: Optional kwargs to support specific arguments
             for individual modifiers.
         """
-        _LOGGER.debug("Initializing MFACPruningModifier")
+        self.log_string("Initializing MFACPruningModifier")
         if "grad_sampler" in kwargs and self._use_gradient_buffering is not True:
             # set grad sampler, must be done before initialize in case pruning step
             # occurs on initialize epoch
@@ -265,7 +265,7 @@ class MFACPruningModifier(BaseGradualPruningModifier):
                     "grad_sampler must be an instance of the GradSampler class"
                 )
             self._grad_sampler = grad_sampler
-            _LOGGER.debug("Using provided GradSampler")
+            self.log_string("Using provided GradSampler")
 
         elif self._use_gradient_buffering is False:
             raise RuntimeError(
@@ -273,7 +273,7 @@ class MFACPruningModifier(BaseGradualPruningModifier):
                 "to False"
             )
         else:
-            _LOGGER.debug("Using gradient buffering")
+            self.log_string("Using gradient buffering")
 
         super().initialize(module, epoch, loggers, **kwargs)
 
@@ -335,14 +335,18 @@ class MFACPruningModifier(BaseGradualPruningModifier):
             self._num_grads, self._applied_sparsity or 0.0
         )
 
+<<<<<<< HEAD
         is_training = module.training
         _LOGGER.debug("Setting the model in the eval mode")
         module.eval()
 
         _LOGGER.debug(f"Starting to collect {num_grads} grads with GradSampler")
+=======
+        self.log_string("Starting to collect {num_grads} grads with GradSampler")
+>>>>>>> Update: More informative M-FAC logging
         for _ in grad_sampler.iter_module_backwards(module, num_grads):
             self._module_masks.pre_optim_step_update()
-        _LOGGER.debug("GradSampler grad collection complete")
+        self.log_string("GradSampler grad collection complete")
 
         if is_training:
             _LOGGER.debug("Setting the model back to the train mode")
@@ -1187,7 +1191,7 @@ class FisherInverseFastSmallBlocks(FisherInverse):
         # As a failsafe for a memory issue, try again with half the number of blocks
         # This condition has not been encountered in testing as of yet
         except Exception as error_msg:
-            _LOGGER.debug(
+            _LOGGER.warning(
                 f"{error_msg}"
                 f"Initialization of H^-1 for {num_blocks} blocks on {device} failed"
                 f"Retrying with {num_blocks//2} blocks"
@@ -1204,7 +1208,7 @@ class FisherInverseFastSmallBlocks(FisherInverse):
 
         # build hinv_g values from grad samples
         _LOGGER.debug(
-            f"Calculating H^-1 with {self._num_samples} samples for call {call_idx}"
+            "Calculating H^-1 with {self._num_samples} samples for call {call_idx}"
         )
         for sample_idx in range(self._num_samples):
             self._add(grads[sample_idx, :], device, call_idx)

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -52,8 +52,8 @@ __all__ = [
     "FisherInverseFastPageSwap",
     "FisherInverseFastSmallBlocks",
 ]
-_LOGGER = logging.getLogger(__name__)
 
+_LOGGER = logging.getLogger(__name__)
 BYTES_IN_MIB = 1024 ** 2
 
 
@@ -1204,7 +1204,7 @@ class FisherInverseFastSmallBlocks(FisherInverse):
 
         # build hinv_g values from grad samples
         _LOGGER.debug(
-            "Calculating H^-1 with {self._num_samples} samples for call {call_idx}"
+            f"Calculating H^-1 with {self._num_samples} samples for call {call_idx}"
         )
         for sample_idx in range(self._num_samples):
             self._add(grads[sample_idx, :], device, call_idx)

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -335,15 +335,11 @@ class MFACPruningModifier(BaseGradualPruningModifier):
             self._num_grads, self._applied_sparsity or 0.0
         )
 
-<<<<<<< HEAD
         is_training = module.training
         _LOGGER.debug("Setting the model in the eval mode")
         module.eval()
 
         _LOGGER.debug(f"Starting to collect {num_grads} grads with GradSampler")
-=======
-        self.log_string("Starting to collect {num_grads} grads with GradSampler")
->>>>>>> Update: More informative M-FAC logging
         for _ in grad_sampler.iter_module_backwards(module, num_grads):
             self._module_masks.pre_optim_step_update()
         self.log_string("GradSampler grad collection complete")

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_mfac.py
@@ -255,7 +255,7 @@ class MFACPruningModifier(BaseGradualPruningModifier):
         :param kwargs: Optional kwargs to support specific arguments
             for individual modifiers.
         """
-        self.log_string("Initializing MFACPruningModifier")
+        super().initialize(module, epoch, loggers, **kwargs)
         if "grad_sampler" in kwargs and self._use_gradient_buffering is not True:
             # set grad sampler, must be done before initialize in case pruning step
             # occurs on initialize epoch
@@ -274,8 +274,6 @@ class MFACPruningModifier(BaseGradualPruningModifier):
             )
         else:
             self.log_string("Using gradient buffering")
-
-        super().initialize(module, epoch, loggers, **kwargs)
 
         if self._grad_sampler is not None:
             # disable gradient buffering until sampler is invoked

--- a/src/sparseml/pytorch/utils/sparsification.py
+++ b/src/sparseml/pytorch/utils/sparsification.py
@@ -219,12 +219,11 @@ class GradSampler:
             of the gradient sample number
         """
         computed_grads = 0
-        # if progress bar is turned off, use nullcontext which has no effect on loop
-        context = tqdm(
+        pbar = tqdm(
             total=num_grads, desc="Collecting gradients", disable=not progress_bar
         )
 
-        with context as pbar:
+        with pbar:
             while computed_grads < num_grads:
                 for forward_args, forward_kwargs, loss_target in self._data_loader:
                     module.zero_grad()

--- a/src/sparseml/pytorch/utils/sparsification.py
+++ b/src/sparseml/pytorch/utils/sparsification.py
@@ -17,7 +17,6 @@ Helper functions for retrieving information related to model sparsification
 """
 
 import json
-from contextlib import nullcontext
 from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Tuple
 
 import torch
@@ -221,8 +220,8 @@ class GradSampler:
         """
         computed_grads = 0
         # if progress bar is turned off, use nullcontext which has no effect on loop
-        context = (
-            tqdm(total=num_grads, desc="Collecting gradients", disable = not progress_bar)
+        context = tqdm(
+            total=num_grads, desc="Collecting gradients", disable=not progress_bar
         )
 
         with context as pbar:

--- a/src/sparseml/pytorch/utils/sparsification.py
+++ b/src/sparseml/pytorch/utils/sparsification.py
@@ -221,9 +221,13 @@ class GradSampler:
         """
         computed_grads = 0
         # if progress bar is turned off, use nullcontext which has no effect on loop
-        context = tqdm(total=num_grads) if progress_bar else nullcontext
+        context = (
+            tqdm(total=num_grads, desc="Collecting gradients")
+            if progress_bar
+            else nullcontext()
+        )
+
         with context as pbar:
-            pbar.set_description("Collecting gradients")
             while computed_grads < num_grads:
                 for forward_args, forward_kwargs, loss_target in self._data_loader:
                     module.zero_grad()

--- a/src/sparseml/pytorch/utils/sparsification.py
+++ b/src/sparseml/pytorch/utils/sparsification.py
@@ -222,9 +222,7 @@ class GradSampler:
         computed_grads = 0
         # if progress bar is turned off, use nullcontext which has no effect on loop
         context = (
-            tqdm(total=num_grads, desc="Collecting gradients")
-            if progress_bar
-            else nullcontext()
+            tqdm(total=num_grads, desc="Collecting gradients", disable = not progress_bar)
         )
 
         with context as pbar:


### PR DESCRIPTION
M-FAC Modifier logging update to address #753 and #763

Changes:
- Optional progress bar for the GradSampler, which is turned on by default
- Log M-FAC modifier debug messages as modifier logs

Not changed:
- Woodfisher calculation logs. The classes containing these calculations are separate from the modifier and are also invoked by the scorer rather than the modifier. It's non-trivial to have their logs included in the modifier logging. Potential future solution is to include a more global access to modifier logging so that auxiliary routines can make use of them as well. 
