### PR TITLE
Do not pass data_args to upstream Trainer

### DIFF
--- a/src/sparseml/transformers/sparsification/question_answering.py
+++ b/src/sparseml/transformers/sparsification/question_answering.py
@@ -182,6 +182,7 @@ class QuestionAnsweringTrainer(TrainerInterface, _QuestionAnsweringTrainer):
         learning rate or num epochs
     :param metadata_args A list of arguments to be extracted from training_args
         and passed as metadata for the final, saved recipe.
+    :param data_args: A list of arguments for dataset specification.
     :param teacher: teacher model for distillation. Set to 'self' to distill
         from the loaded model or 'disable' to turn of distillation
     :param kwargs: key word arguments passed to the parent class
@@ -194,6 +195,7 @@ class QuestionAnsweringTrainer(TrainerInterface, _QuestionAnsweringTrainer):
         recipe: str,
         recipe_args: Optional[Union[Dict[str, Any], str]] = None,
         metadata_args: Optional[List[str]] = None,
+        data_args: Optional[List[str]] = None,
         teacher: Optional[Module] = None,
         **kwargs,
     ):
@@ -203,6 +205,7 @@ class QuestionAnsweringTrainer(TrainerInterface, _QuestionAnsweringTrainer):
             recipe=recipe,
             recipe_args=recipe_args,
             metadata_args=metadata_args,
+            data_args=data_args,
             teacher=teacher,
             **kwargs,
         )

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -100,6 +100,7 @@ class RecipeManagerTrainerInterface:
         recipe: Optional[str],
         recipe_args: Optional[Union[Dict[str, Any], str]] = None,
         metadata_args: Optional[List[str]] = None,
+        data_args: Optional[List[str]] = None,
         teacher: Optional[Union[Module, str]] = None,
         **kwargs,
     ):
@@ -110,15 +111,14 @@ class RecipeManagerTrainerInterface:
         self.recipe_args = recipe_args
         self.teacher = teacher
 
-        training_args, data_args = kwargs.get("args"), kwargs.get("data_args")
-
+        training_args = kwargs.get("args")
         self.metadata = (
             self._extract_metadata(
                 metadata_args=metadata_args,
                 training_args_dict=training_args.to_dict(),
                 data_args_dict=asdict(data_args),
             )
-            if (training_args or data_args)
+            if training_args
             else None
         )
 


### PR DESCRIPTION
Transformers training scripts are broken because passing data_args into the upstream Trainer fails (it does not have that arg).