### PR TITLE
[Yolov5] Fix export format error

### DIFF
--- a/src/sparseml/pytorch/object_detection/export.py
+++ b/src/sparseml/pytorch/object_detection/export.py
@@ -24,6 +24,7 @@ import time
 import warnings
 from copy import deepcopy
 from pathlib import Path
+import pandas as pd
 
 import torch
 import torch.nn as nn
@@ -289,6 +290,20 @@ def load_state_dict(model, state_dict, train, exclude_anchors):
     model.load_state_dict(state_dict, strict=not train)  # load
 
     return state_dict
+
+def export_formats():
+    x = [['PyTorch', '-', '.pt', True],
+         ['TorchScript', 'torchscript', '.torchscript', True],
+         ['ONNX', 'onnx', '.onnx', True],
+         ['OpenVINO', 'openvino', '_openvino_model', False],
+         ['TensorRT', 'engine', '.engine', True],
+         ['CoreML', 'coreml', '.mlmodel', False],
+         ['TensorFlow SavedModel', 'saved_model', '_saved_model', True],
+         ['TensorFlow GraphDef', 'pb', '.pb', True],
+         ['TensorFlow Lite', 'tflite', '.tflite', False],
+         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False],
+         ['TensorFlow.js', 'tfjs', '_web_model', False]]
+    return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'GPU'])
 
 
 @torch.no_grad()

--- a/src/sparseml/pytorch/object_detection/export.py
+++ b/src/sparseml/pytorch/object_detection/export.py
@@ -24,8 +24,8 @@ import time
 import warnings
 from copy import deepcopy
 from pathlib import Path
-import pandas as pd
 
+import pandas as pd
 import torch
 import torch.nn as nn
 
@@ -291,19 +291,22 @@ def load_state_dict(model, state_dict, train, exclude_anchors):
 
     return state_dict
 
+
 def export_formats():
-    x = [['PyTorch', '-', '.pt', True],
-         ['TorchScript', 'torchscript', '.torchscript', True],
-         ['ONNX', 'onnx', '.onnx', True],
-         ['OpenVINO', 'openvino', '_openvino_model', False],
-         ['TensorRT', 'engine', '.engine', True],
-         ['CoreML', 'coreml', '.mlmodel', False],
-         ['TensorFlow SavedModel', 'saved_model', '_saved_model', True],
-         ['TensorFlow GraphDef', 'pb', '.pb', True],
-         ['TensorFlow Lite', 'tflite', '.tflite', False],
-         ['TensorFlow Edge TPU', 'edgetpu', '_edgetpu.tflite', False],
-         ['TensorFlow.js', 'tfjs', '_web_model', False]]
-    return pd.DataFrame(x, columns=['Format', 'Argument', 'Suffix', 'GPU'])
+    x = [
+        ["PyTorch", "-", ".pt", True],
+        ["TorchScript", "torchscript", ".torchscript", True],
+        ["ONNX", "onnx", ".onnx", True],
+        ["OpenVINO", "openvino", "_openvino_model", False],
+        ["TensorRT", "engine", ".engine", True],
+        ["CoreML", "coreml", ".mlmodel", False],
+        ["TensorFlow SavedModel", "saved_model", "_saved_model", True],
+        ["TensorFlow GraphDef", "pb", ".pb", True],
+        ["TensorFlow Lite", "tflite", ".tflite", False],
+        ["TensorFlow Edge TPU", "edgetpu", "_edgetpu.tflite", False],
+        ["TensorFlow.js", "tfjs", "_web_model", False],
+    ]
+    return pd.DataFrame(x, columns=["Format", "Argument", "Suffix", "GPU"])
 
 
 @torch.no_grad()


### PR DESCRIPTION
export_formats() was removed from the sparseml internal integration of yolov5 as part of a larger change to remove support for non-onnx exports. However, this support is maintained in the integration fork to keep it as close in alignment to the upstream as is reasonable. 

This causes an error when calling val.py directly (as opposed to using the sparseml.object_detection alias). This PR re-introduces the function to fix the error.