### PR TITLE
Image classification : `max train steps`, `one-shot` support

### DIFF
--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -135,13 +135,11 @@ Options:
   --max-train-steps, --max_train_steps INTEGER
                                   The maximum number of training steps to run
                                   per epoch. If negative, will run for the
-                                  entire dataset. Note if max_eval_steps is
-                                  positive then this is ignored  [default: -1]
+                                  entire dataset. [default: -1]
   --max-eval-steps, --max_eval_steps INTEGER
                                   The maximum number of eval steps to run per
                                   epoch. If negative, will run for the entire
-                                  dataset. Note if max_eval_steps is positive
-                                  then this is ignored  [default: -1]
+                                  dataset. [default: -1]
   --one-shot, --one_shot / --no-one-shot, --no_one_shot
                                   Apply recipe in a one-shot fashion and save
                                   the model  [default: no-one-shot]
@@ -471,8 +469,7 @@ METADATA_ARGS = [
     type=int,
     show_default=True,
     help="The maximum number of training steps to run per epoch. If negative, "
-    "will run for the entire dataset. Note if max_eval_steps is positive "
-    "then this is ignored",
+    "will run for the entire dataset",
 )
 @click.option(
     "--max-eval-steps",
@@ -481,8 +478,7 @@ METADATA_ARGS = [
     type=int,
     show_default=True,
     help="The maximum number of eval steps to run per epoch. If negative, "
-    "will run for the entire dataset. Note if max_eval_steps is positive "
-    "then this is ignored",
+    "will run for the entire dataset",
 )
 @click.option(
     "--one-shot/--no-one-shot",

--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -88,9 +88,6 @@ Options:
                                   multiple GPUs using
                                   `DistributedDataParallel` with one GPU per
                                   process
-  --debug-steps, --debug_steps INTEGER
-                                  Amount of steps to run for training and
-                                  testing for when in debug mode
   --pretrained TEXT               The type of pretrained weights to use, loads
                                   default pretrained weights for the model if
                                   not specified or set to `True`. Otherwise,
@@ -135,6 +132,19 @@ Options:
   --recipe-args, --recipe_args TEXT
                                   json parsable dict of recipe variable names
                                   to values to overwrite with
+  --max-train-steps, --max_train_steps INTEGER
+                                  The maximum number of training steps to run
+                                  per epoch. If negative, will run for the
+                                  entire dataset. Note if max_eval_steps is
+                                  positive then this is ignored  [default: -1]
+  --max-eval-steps, --max_eval_steps INTEGER
+                                  The maximum number of eval steps to run per
+                                  epoch. If negative, will run for the entire
+                                  dataset. Note if max_eval_steps is positive
+                                  then this is ignored  [default: -1]
+  --one-shot, --one_shot / --no-one-shot, --no_one_shot
+                                  Apply recipe in a one-shot fashion and save
+                                  the model  [default: no-one-shot]
   --help                          Show this message and exit.
 
 #########
@@ -155,6 +165,18 @@ sparseml.image_classification.train \
     --arch-key mobilenet_v1 --pretrained pruned-moderate \
     --dataset imagefolder --dataset-path ~/datasets/my_imagefolder_dataset \
     --train-batch-size 256 --test-batch-size 1024
+
+##########
+Example command for training resnet50 on imagenette for 100 steps:
+sparseml.image_classification.train \
+    --train_batch_size 32 \
+    --test_batch_size 32 \
+    --dataset imagenette \
+    --dataset-path imagenette \
+    --max-train-steps 100 \
+    --arch-key resnet50 \
+    --recipe-path [RESNET_RECIPE] \
+    --checkpoint-path zoo
 
 ##########
 Template command for running training with this script on multiple GPUs using
@@ -342,13 +364,6 @@ METADATA_ARGS = [
     "`DistributedDataParallel` with one GPU per process",
 )
 @click.option(
-    "--debug-steps",
-    "--debug_steps",
-    type=int,
-    default=-1,
-    help="Amount of steps to run for training and testing for when in " "debug mode",
-)
-@click.option(
     "--pretrained",
     type=str,
     default=True,
@@ -449,6 +464,34 @@ METADATA_ARGS = [
     default=None,
     help="json parsable dict of recipe variable names to values to overwrite with",
 )
+@click.option(
+    "--max-train-steps",
+    "--max_train_steps",
+    default=-1,
+    type=int,
+    show_default=True,
+    help="The maximum number of training steps to run per epoch. If negative, "
+    "will run for the entire dataset. Note if max_eval_steps is positive "
+    "then this is ignored",
+)
+@click.option(
+    "--max-eval-steps",
+    "--max_eval_steps",
+    default=-1,
+    type=int,
+    show_default=True,
+    help="The maximum number of eval steps to run per epoch. If negative, "
+    "will run for the entire dataset. Note if max_eval_steps is positive "
+    "then this is ignored",
+)
+@click.option(
+    "--one-shot/--no-one-shot",
+    "--one_shot/--no_one_shot",
+    default=False,
+    is_flag=True,
+    show_default=True,
+    help="Apply recipe in a one-shot fashion and save the model",
+)
 def main(
     train_batch_size: int,
     test_batch_size: int,
@@ -466,7 +509,6 @@ def main(
     save_best_after: int,
     save_epochs: Tuple[int, ...],
     use_mixed_precision: bool,
-    debug_steps: int,
     pretrained: Union[str, bool],
     pretrained_dataset: Optional[str],
     model_kwargs: Dict[str, Any],
@@ -479,6 +521,9 @@ def main(
     image_size: int,
     ffcv: bool,
     recipe_args: str,
+    max_train_steps: int,
+    max_eval_steps: int,
+    one_shot: bool,
 ):
     """
     PyTorch training integration with SparseML for image classification models
@@ -536,7 +581,7 @@ def main(
         model_kwargs=model_kwargs,
     )
 
-    model, arch_key = helpers.create_model(
+    model, arch_key, checkpoint_path = helpers.create_model(
         checkpoint_path=checkpoint_path,
         recipe_path=recipe_path,
         num_classes=num_classes,
@@ -590,12 +635,14 @@ def main(
         optim_name=optim,
         optim_kwargs=optim_args,
         recipe_args=recipe_args,
+        max_train_steps=max_train_steps,
+        one_shot=one_shot,
     )
 
     train(
         trainer=trainer,
         save_dir=save_dir,
-        debug_steps=debug_steps,
+        max_eval_steps=max_eval_steps,
         eval_mode=eval_mode,
         is_main_process=is_main_process,
         save_best_after=save_best_after,
@@ -607,7 +654,7 @@ def main(
 def train(
     trainer: ImageClassificationTrainer,
     save_dir: str,
-    debug_steps: int,
+    max_eval_steps: int,
     eval_mode: bool,
     is_main_process: bool,
     save_best_after: int,
@@ -619,7 +666,7 @@ def train(
 
     :param trainer: The ImageClassificationTrainer object
     :param save_dir: The directory to save checkpoints to
-    :param debug_steps: The number of steps to run in debug mode
+    :param max_eval_steps: The number of steps to run for validation
     :param eval_mode: Whether to run in evaluation mode
     :param is_main_process: Whether this is the main process
     :param save_best_after: The number of epochs to wait before saving
@@ -628,29 +675,30 @@ def train(
     :param rank: The rank of the process
     """
 
-    # Baseline eval run
-    trainer.run_one_epoch(
-        mode="validation",
-        max_steps=debug_steps,
-        baseline_run=True,
-    )
-
-    if not eval_mode:
+    if not trainer.one_shot:
+        # Baseline eval run
+        trainer.run_one_epoch(
+            mode="validation",
+            max_steps=max_eval_steps,
+            baseline_run=True,
+        )
+    val_res = None
+    if not (eval_mode or trainer.one_shot):
         LOGGER.info(f"Starting training from epoch {trainer.epoch}")
 
-        val_metric = best_metric = val_res = None
+        val_metric = best_metric = None
 
         while trainer.epoch < trainer.max_epochs:
             train_res = trainer.run_one_epoch(
                 mode="train",
-                max_steps=debug_steps,
+                max_steps=trainer.max_train_steps,
             )
             LOGGER.info(f"\nEpoch {trainer.epoch} training results: {train_res}")
             # testing steps
             if is_main_process:
                 val_res = trainer.run_one_epoch(
                     mode="val",
-                    max_steps=debug_steps,
+                    max_steps=max_eval_steps,
                 )
                 val_metric = val_res.result_mean(trainer.target_metric).item()
 
@@ -702,25 +750,24 @@ def train(
             trainer.epoch += 1
 
         # export the final model
-        LOGGER.info("completed...")
-        if is_main_process:
-            # Convert QAT -> quantized ONNX graph for finalized model only
-            helpers.save_model_training(
-                model=trainer.model,
-                optim=trainer.optim,
-                manager=trainer.manager,
-                checkpoint_manager=trainer.checkpoint_manager,
-                save_name="model",
-                save_dir=save_dir,
-                epoch=trainer.epoch - 1,
-                val_res=val_res,
-            )
+    LOGGER.info("completed...")
+    if is_main_process and not eval_mode:
+        # Convert QAT -> quantized ONNX graph for finalized model only
+        save_name = "model" if not trainer.one_shot else "model-one-shot"
+        helpers.save_model_training(
+            model=trainer.model,
+            optim=trainer.optim,
+            manager=trainer.manager,
+            checkpoint_manager=trainer.checkpoint_manager,
+            save_name=save_name,
+            save_dir=save_dir,
+            epoch=trainer.epoch - 1,
+            val_res=val_res,
+        )
 
-            LOGGER.info("layer sparsities:")
-            for (name, layer) in get_prunable_layers(trainer.model):
-                LOGGER.info(
-                    f"{name}.weight: {tensor_sparsity(layer.weight).item():.4f}"
-                )
+        LOGGER.info("layer sparsities:")
+        for (name, layer) in get_prunable_layers(trainer.model):
+            LOGGER.info(f"{name}.weight: {tensor_sparsity(layer.weight).item():.4f}")
 
     # close DDP
     if rank != -1:

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Trainers for image classification.
+Trainers for image classification
 """
 
 import logging
@@ -44,45 +44,48 @@ __all__ = [
 
 class Trainer(ABC):
     """
-    Abstract class for Trainers.
-    Creates a contract that all trainers must have a run_one_epoch method.
+    Abstract class for Trainers
+    Creates a contract that all trainers must have a run_one_epoch method
     """
 
     @abstractmethod
     def run_one_epoch(self):
         """
-        Runs one epoch of training.
+        Runs one epoch of training
         """
         raise NotImplementedError
 
 
 class ImageClassificationTrainer(Trainer):
     """
-    Trainer for image classification.
+    Trainer for image classification
 
-    :param model: The loaded torch model to train.
-    :param key: The arch key of the model.
+    :param model: The loaded torch model to train
+    :param key: The arch key of the model
     :param recipe_path: The path to the yaml file containing the modifiers and
         schedule to apply them with; Can also provide a SparseZoo stub prefixed
-        with 'zoo:'.
-    :param ddp: bool indicating whether to use Distributed Data Parallel.
-    :param device: The device to train on. Defaults to torch default device.
-    :param use_mixed_precision: Whether to use mixed precision FP16 training.
-        Defaults to False.
-    :param val_loader: A DataLoader for validation data.
-    :param train_loader: A DataLoader for training data.
+        with 'zoo:'
+    :param ddp: bool indicating whether to use Distributed Data Parallel
+    :param device: The device to train on Defaults to torch default device
+    :param use_mixed_precision: Whether to use mixed precision FP16 training
+        Defaults to False
+    :param val_loader: A DataLoader for validation data
+    :param train_loader: A DataLoader for training data
     :param is_main_process: Whether the current process is the main process,
-        while training using DDP. Defaults to True.
-    :param loggers: A list of loggers to use during training process.
+        while training using DDP. Defaults to True
+    :param loggers: A list of loggers to use during training process
     :param loss_fn: A Callable loss function for training and validation
-        losses.
+        losses
     :param init_lr: The initial learning rate for the optimizer.Defaults to
-        1e-9.
+        1e-9
     :param optim_name: str representing the optimizer type to use.
-        Defaults to `Adam`.
-    :param optim_kwargs: dict of additional kwargs to pass to the optimizer.
+        Defaults to `Adam`
+    :param optim_kwargs: dict of additional kwargs to pass to the optimizer
     :param recipe_args: json parsable dict of recipe variable names to values
+        to overwrite with
+    :param max_train_steps: The maximum number of training steps to run per epoch
         to overwrite with.
+    :param one_shot: bool indicating whether to apply recipe in one shot manner
     """
 
     def __init__(
@@ -104,9 +107,11 @@ class ImageClassificationTrainer(Trainer):
         optim_name="Adam",
         optim_kwargs: Optional[Dict[str, Any]] = None,
         recipe_args: Optional[str] = None,
+        max_train_steps: int = -1,
+        one_shot: bool = False,
     ):
         """
-        Initializes the module_trainer.
+        Initializes the module_trainer
         """
         self.recipe_path = recipe_path
         self.metadata = metadata
@@ -123,6 +128,8 @@ class ImageClassificationTrainer(Trainer):
         self.train_loader = train_loader
         self.loggers = loggers
         self.recipe_args = recipe_args
+        self.max_train_steps = max_train_steps
+        self.one_shot = one_shot
 
         self.val_loss = loss_fn()
         _LOGGER.info(f"created loss for validation: {self.val_loss}")
@@ -135,7 +142,7 @@ class ImageClassificationTrainer(Trainer):
         self._device_context = ModuleDeviceContext(
             use_mixed_precision=self.use_mixed_precision,
         )
-        if self.train_loader is not None:
+        if self.train_loader is not None and not self.one_shot:
             (
                 self.epoch,
                 self.optim,
@@ -144,6 +151,8 @@ class ImageClassificationTrainer(Trainer):
             self.module_trainer = self._initialize_module_trainer()
         else:
             self.optim = self.manager = self.module_trainer = None
+            if self.one_shot:
+                self._apply_one_shot()
 
         self.checkpoint_manager = (
             self._setup_checkpoint_manager() if self.checkpoint_path else None
@@ -172,7 +181,7 @@ class ImageClassificationTrainer(Trainer):
         baseline_run: bool = False,
     ) -> Any:
         """
-        Runs one epoch of training or validation.
+        Runs one epoch of training or validation
 
         :param mode: str representing the mode to run in, one of
             ['train', 'val']
@@ -204,6 +213,14 @@ class ImageClassificationTrainer(Trainer):
         """
         return self.manager.max_epochs if self.manager is not None else 0
 
+    def _apply_one_shot(self):
+        self.manager = ScheduledModifierManager.from_yaml(
+            self.recipe_path,
+        )
+
+        self.manager.apply(self.model)
+        _LOGGER.info(f"Applied {self.recipe_path} to manager")
+
     def _initialize_module_tester(self):
         tester = ModuleTester(
             module=self.model,
@@ -234,11 +251,14 @@ class ImageClassificationTrainer(Trainer):
             metadata=self.metadata,
         )
 
+        steps_per_epoch = (
+            len(self.train_loader) if self.max_train_steps < 0 else self.max_train_steps
+        )
         optim = ScheduledOptimizer(
             optim,
             self.model.module if is_parallel_model(self.model) else self.model,
             manager,
-            steps_per_epoch=len(self.train_loader),
+            steps_per_epoch=steps_per_epoch,
             loggers=self.loggers,
         )
         _LOGGER.info(f"created manager: {manager}")

--- a/src/sparseml/pytorch/models/registry.py
+++ b/src/sparseml/pytorch/models/registry.py
@@ -98,6 +98,8 @@ class ModelRegistry(object):
         key_copy = key
 
         if key_copy is None:
+            if pretrained_path is None:
+                raise ValueError("Must provide a key or a pretrained_path")
             _checkpoint = torch.load(pretrained_path)
             if "arch_key" in _checkpoint:
                 key_copy = _checkpoint["arch_key"]


### PR DESCRIPTION
The goal of this PR is to add support for 
- `--max-train-steps` 
- `--max-eval-steps`
- `--one-shot`

Arguments for `sparseml.image_classification.train` script. the idea being such args will allow testing shorter runs and help provide stronger validation for shipped models. Noting `max-train-steps` and `max-eval-steps` are run per epoch and no training take place when `one-shot` argument is passed

The PR has been tested locally with the following:

1) Max train steps = 5, Max eval steps = 4
```bash
sparseml.image_classification.train \
    --dataset-path ./datasets/imagenette \
    --max-train-steps 5 \
    --max-eval-steps 4 \
    --arch-key resnet50 \
    --recipe-path zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original \
    --checkpoint-path zoo \
    --train_batch_size 32 \
    --test_batch_size 32 \
    --dataset imagenette
```  
Output:
```bash
Test epoch -1: 100%|██████████████████████████████| 4/4 [00:00<00:00,  5.48it/s]
2022-05-10 16:15:06 __main__     INFO     Starting training from epoch 0
2022-05-10 16:15:06 __main__     INFO     Starting training from epoch 0
/XXXXXXX/projects/sparseml/src/sparseml/pytorch/optim/optimizer.py:186: UserWarning: ScheduledOptimizer is deprecated and will be deleted in the future. adjust_current_step is no longer supported. Please replace with manager.initialize and manager.modify
  warnings.warn(
Train epoch 0: 100%|██████████████████████████████| 5/5 [00:01<00:00,  4.51it/s]
2022-05-10 16:15:08 __main__     INFO     
Epoch 0 training results: ModuleRunResults(__loss__=0.14738957583904266, top1acc=97.39583587646484, top5acc=99.47916412353516)
2022-05-10 16:15:08 __main__     INFO     
Epoch 0 training results: ModuleRunResults(__loss__=0.14738957583904266, top1acc=97.39583587646484, top5acc=99.47916412353516)
Test epoch 0: 100%|███████████████████████████████| 4/4 [00:00<00:00,  7.98it/s]
Train epoch 1: 100%|██████████████████████████████| 5/5 [00:01<00:00,  4.17it/s]
2022-05-10 16:15:09 __main__     INFO     
Epoch 1 training results: ModuleRunResults(__loss__=0.06656134128570557, top1acc=97.91666412353516, top5acc=100.0)
2022-05-10 16:15:09 __main__     INFO     
Epoch 1 training results: ModuleRunResults(__loss__=0.06656134128570557, top1acc=97.91666412353516, top5acc=100.0)
Test epoch 1: 100%|███████████████████████████████| 4/4 [00:00<00:00,  7.55it/s]
Saving model for epoch 1 and top-1 accuracy 96.875 to /XXXXXXX/projects/sparseml/src/sparseml/pytorch/image_classification/pytorch_vision/resnet50_imagenette__09 for checkpoint-best
Train epoch 2: 100%|██████████████████████████████| 5/5 [00:01<00:00,  4.22it/s]
2022-05-10 16:15:11 __main__     INFO     
Epoch 2 training results: ModuleRunResults(__loss__=0.10613694787025452, top1acc=96.875, top5acc=100.0)
2022-05-10 16:15:11 __main__     INFO     
Epoch 2 training results: ModuleRunResults(__loss__=0.10613694787025452, top1acc=96.875, top5acc=100.0)
Test epoch 2: 100%|███████████████████████████████| 4/4 [00:00<00:00,  7.27it/s]
Train epoch 3: 100%|██████████████████████████████| 5/5 [00:01<00:00,  4.18it/s]
2022-05-10 16:15:13 __main__     INFO     
Epoch 3 training results: ModuleRunResults(__loss__=0.15126116573810577, top1acc=95.83333587646484, top5acc=100.0)
2022-05-10 16:15:13 __main__     INFO     
Epoch 3 training results: ModuleRunResults(__loss__=0.15126116573810577, top1acc=95.83333587646484, top5acc=100.0)
Test epoch 3: 100%|███████████████████████████████| 4/4 [00:00<00:00,  7.39it/s]
Train epoch 4: 100%|██████████████████████████████| 5/5 [00:01<00:00,  4.21it/s]
2022-05-10 16:15:15 __main__     INFO     
Epoch 4 training results: ModuleRunResults(__loss__=0.414724200963974, top1acc=90.625, top5acc=97.91666412353516)
2022-05-10 16:15:15 __main__     INFO     
Epoch 4 training results: ModuleRunResults(__loss__=0.414724200963974, top1acc=90.625, top5acc=97.91666412353516)
Test epoch 4: 100%|███████████████████████████████| 4/4 [00:00<00:00,  7.54it/s]
Train epoch 5: 100%|██████████████████████████████| 5/5 [00:01<00:00,  4.31it/s]
2022-05-10 16:15:17 __main__     INFO     
Epoch 5 training results: ModuleRunResults(__loss__=0.37264159321784973, top1acc=93.75, top5acc=100.0)
2022-05-10 16:15:17 __main__     INFO     
Epoch 5 training results: ModuleRunResults(__loss__=0.37264159321784973, top1acc=93.75, top5acc=100.0)
Test epoch 5: 100%|███████████████████████████████| 4/4 [00:00<00:00,  7.24it/s]
Train epoch 6: 100%|██████████████████████████████| 5/5 [00:01<00:00,  4.21it/s]
2022-05-10 16:15:19 __main__     INFO     
Epoch 6 training results: ModuleRunResults(__loss__=0.2325858324766159, top1acc=97.91666412353516, top5acc=99.47916412353516)
2022-05-10 16:15:19 __main__     INFO     
Epoch 6 training results: ModuleRunResults(__loss__=0.2325858324766159, top1acc=97.91666412353516, top5acc=99.47916412353516)
Test epoch 6: 100%|███████████████████████████████| 4/4 [00:00<00:00,  7.21it/s]
Train epoch 7: 100%|██████████████████████████████| 5/5 [00:01<00:00,  4.86it/s]
2022-05-10 16:15:20 __main__     INFO     
Epoch 7 training results: ModuleRunResults(__loss__=0.22111153602600098, top1acc=93.75, top5acc=99.47916412353516)
2022-05-10 16:15:20 __main__     INFO     
Epoch 7 training results: ModuleRunResults(__loss__=0.22111153602600098, top1acc=93.75, top5acc=99.47916412353516)
Test epoch 7: 100%|███████████████████████████████| 4/4 [00:00<00:00,  7.43it/s]
Train epoch 8: 100%|██████████████████████████████| 5/5 [00:01<00:00,  4.89it/s]
2022-05-10 16:15:22 __main__     INFO     
Epoch 8 training results: ModuleRunResults(__loss__=0.11022845655679703, top1acc=98.4375, top5acc=100.0)
2022-05-10 16:15:22 __main__     INFO     
Epoch 8 training results: ModuleRunResults(__loss__=0.11022845655679703, top1acc=98.4375, top5acc=100.0)
Test epoch 8: 100%|███████████████████████████████| 4/4 [00:00<00:00,  7.34it/s]
Train epoch 9: 100%|██████████████████████████████| 5/5 [00:01<00:00,  4.83it/s]
2022-05-10 16:15:24 __main__     INFO     
Epoch 9 training results: ModuleRunResults(__loss__=0.14420939981937408, top1acc=96.875, top5acc=99.47916412353516)
2022-05-10 16:15:24 __main__     INFO     
Epoch 9 training results: ModuleRunResults(__loss__=0.14420939981937408, top1acc=96.875, top5acc=99.47916412353516)
Test epoch 9: 100%|███████████████████████████████| 4/4 [00:00<00:00,  7.38it/s]
2022-05-10 16:15:24 __main__     INFO     completed...
2022-05-10 16:15:24 __main__     INFO     completed...
Saving model for epoch 9 and top-1 accuracy 90.625 to /XXXXXXX/projects/sparseml/src/sparseml/pytorch/image_classification/pytorch_vision/resnet50_imagenette__09 for model
2022-05-10 16:15:25 __main__     INFO     layer sparsities:
2022-05-10 16:15:25 __main__     INFO     layer sparsities:
2022-05-10 16:15:25 __main__     INFO     input.conv.weight: 0.0000
2022-05-10 16:15:25 __main__     INFO     input.conv.weight: 0.0000
2022-05-10 16:15:25 __main__     INFO     sections.0.0.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.0.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.0.conv2.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.0.conv2.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.0.conv3.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.0.conv3.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.0.identity.conv.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.0.identity.conv.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.1.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.1.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.1.conv2.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.0.1.conv2.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.0.1.conv3.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.1.conv3.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.2.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.2.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.2.conv2.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.0.2.conv2.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.0.2.conv3.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.0.2.conv3.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.1.0.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.1.0.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.1.0.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.1.0.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.1.0.conv3.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.1.0.conv3.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.1.0.identity.conv.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.0.identity.conv.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.1.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.1.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.1.conv2.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.1.conv2.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.1.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.1.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.2.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.2.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.2.conv2.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.2.conv2.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.2.conv3.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.1.2.conv3.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.1.3.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.1.3.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.1.3.conv2.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.3.conv2.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.3.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.1.3.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.0.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.2.0.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.2.0.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.0.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.0.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.0.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.0.identity.conv.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.0.identity.conv.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.1.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.1.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.1.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.1.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.1.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.1.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.2.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.2.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.2.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.2.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.2.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.2.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.3.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.3.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.3.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.3.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.3.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.3.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.4.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.4.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.4.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.4.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.4.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.4.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.5.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.5.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.5.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.5.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.2.5.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.2.5.conv3.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.3.0.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.3.0.conv1.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     sections.3.0.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.0.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.0.conv3.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.0.conv3.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.0.identity.conv.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.0.identity.conv.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.1.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.3.1.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.3.1.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.1.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.1.conv3.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.1.conv3.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.2.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.3.2.conv1.weight: 0.8500
2022-05-10 16:15:25 __main__     INFO     sections.3.2.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.2.conv2.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.2.conv3.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     sections.3.2.conv3.weight: 0.9000
2022-05-10 16:15:25 __main__     INFO     classifier.fc.weight: 0.8000
2022-05-10 16:15:25 __main__     INFO     classifier.fc.weight: 0.8000

Process finished with exit code 0

```

2) With one shot using the following command
```bash
sparseml.image_classification.train \
    --train_batch_size 32 \
    --test_batch_size 32 \
    --dataset imagenette \
    --dataset-path ./datasets/imagenette \
    --arch-key resnet50 \
    --recipe-path zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original \
    --checkpoint-path zoo \
    --one-shot
```

Output:

```bash
2022-05-11 13:19:01 __main__     INFO     running on device cuda
2022-05-11 13:19:01 __main__     INFO     running on device cuda
2022-05-11 13:19:02 sparseml.optim.manager INFO     Created recipe manager with metadata: {
 "__metadata__": null
}
2022-05-11 13:19:02 __main__     INFO     completed...
2022-05-11 13:19:02 __main__     INFO     completed...
Saving model for epoch -1 to /XXXXXXX//src/sparseml/pytorch/image_classification/pytorch_vision/resnet50_imagenette__10 for model-one-shot
2022-05-11 13:19:02 __main__     INFO     layer sparsities:
2022-05-11 13:19:02 __main__     INFO     layer sparsities:
2022-05-11 13:19:02 __main__     INFO     input.conv.weight: 0.0000
2022-05-11 13:19:02 __main__     INFO     input.conv.weight: 0.0000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv2.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv2.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.identity.conv.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.identity.conv.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.identity.conv.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.0.identity.conv.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.0.identity.conv.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.0.identity.conv.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.identity.conv.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.identity.conv.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     classifier.fc.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     classifier.fc.weight: 0.8000

Process finished with exit code 0

```

Also noting for easier reviews: Changes for one-shot support have been reviewed from PR #779 and have been merged into this branch (by mistake)