### PR TITLE
Image classification/one shot

### DIFF
--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -570,7 +570,7 @@ def main(
             ffcv=ffcv,
             device=device,
         )
-        if is_main_process and not one_shot
+        if is_main_process
         else (None, None)
     )
 

--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -371,6 +371,7 @@ def save_model_training(
         checkpoint
     """
 
+    save_message_shown = False
     recipe = str(
         ScheduledModifierManager.compose_staged(
             base_recipe=checkpoint_manager, additional_recipe=manager
@@ -387,6 +388,7 @@ def save_model_training(
             f"Saving model for epoch {epoch} and {metric_name} "
             f"{metric} to {save_dir} for {save_name}"
         )
+        save_message_shown = True
     exporter = ModuleExporter(model, save_dir)
     exporter.export_pytorch(
         optimizer=optim,
@@ -407,6 +409,9 @@ def save_model_training(
                 info_lines.append(f"{loss}: {val_res.result_mean(loss).item()}")
 
         info_file.write("\n".join(info_lines))
+
+    if not save_message_shown:
+        print(f"Saving model for epoch {epoch} " f"to {save_dir} for {save_name}")
 
 
 def set_seeds(local_rank: int):

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -84,6 +84,8 @@ class ImageClassificationTrainer(Trainer):
     :param recipe_args: json parsable dict of recipe variable names to values
         to overwrite with
     :param max_train_steps: The maximum number of training steps to run per epoch
+        to overwrite with.
+    :param one_shot: bool indicating whether to apply recipe in one shot manner
     """
 
     def __init__(
@@ -106,6 +108,7 @@ class ImageClassificationTrainer(Trainer):
         optim_kwargs: Optional[Dict[str, Any]] = None,
         recipe_args: Optional[str] = None,
         max_train_steps: int = -1,
+        one_shot: bool = False,
     ):
         """
         Initializes the module_trainer
@@ -126,6 +129,7 @@ class ImageClassificationTrainer(Trainer):
         self.loggers = loggers
         self.recipe_args = recipe_args
         self.max_train_steps = max_train_steps
+        self.one_shot = one_shot
 
         self.val_loss = loss_fn()
         _LOGGER.info(f"created loss for validation: {self.val_loss}")
@@ -206,6 +210,13 @@ class ImageClassificationTrainer(Trainer):
         :return: the maximum number of epochs from manager
         """
         return self.manager.max_epochs if self.manager is not None else 0
+
+    def _one_shot(self):
+        self.manager = ScheduledModifierManager.from_yaml(
+            self.recipe_path,
+        )
+
+        self.manager.apply(self.model)
 
     def _initialize_module_tester(self):
         tester = ModuleTester(

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -151,6 +151,8 @@ class ImageClassificationTrainer(Trainer):
             self.module_trainer = self._initialize_module_trainer()
         else:
             self.optim = self.manager = self.module_trainer = None
+            if self.one_shot:
+                self._one_shot()
 
         self.checkpoint_manager = (
             self._setup_checkpoint_manager() if self.checkpoint_path else None
@@ -217,6 +219,7 @@ class ImageClassificationTrainer(Trainer):
         )
 
         self.manager.apply(self.model)
+        _LOGGER.info(f"Applied recipe to manager")
 
     def _initialize_module_tester(self):
         tester = ModuleTester(

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -142,7 +142,7 @@ class ImageClassificationTrainer(Trainer):
         self._device_context = ModuleDeviceContext(
             use_mixed_precision=self.use_mixed_precision,
         )
-        if self.train_loader is not None:
+        if self.train_loader is not None and not self.one_shot:
             (
                 self.epoch,
                 self.optim,
@@ -152,7 +152,7 @@ class ImageClassificationTrainer(Trainer):
         else:
             self.optim = self.manager = self.module_trainer = None
             if self.one_shot:
-                self._one_shot()
+                self._apply_one_shot()
 
         self.checkpoint_manager = (
             self._setup_checkpoint_manager() if self.checkpoint_path else None
@@ -213,13 +213,13 @@ class ImageClassificationTrainer(Trainer):
         """
         return self.manager.max_epochs if self.manager is not None else 0
 
-    def _one_shot(self):
+    def _apply_one_shot(self):
         self.manager = ScheduledModifierManager.from_yaml(
             self.recipe_path,
         )
 
         self.manager.apply(self.model)
-        _LOGGER.info(f"Applied recipe to manager")
+        _LOGGER.info("Applied recipe to manager")
 
     def _initialize_module_tester(self):
         tester = ModuleTester(

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -219,7 +219,7 @@ class ImageClassificationTrainer(Trainer):
         )
 
         self.manager.apply(self.model)
-        _LOGGER.info("Applied recipe to manager")
+        _LOGGER.info(f"Applied {self.recipe_path} to manager")
 
     def _initialize_module_tester(self):
         tester = ModuleTester(


### PR DESCRIPTION
The goal of this PR is to allow easy one-shot application of recipes to image-classification models.

To accomplish this we add a `--one-shot` argument to `sparseml.image_classification.train` script

The new functionality was tested locally with the following:

```bash
sparseml.image_classification.train \
    --train_batch_size 32 \
    --test_batch_size 32 \
    --dataset imagenette \
    --dataset-path ./datasets/imagenette \
    --arch-key resnet50 \
    --recipe-path zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original \
    --checkpoint-path zoo \
    --one-shot
```

The Output is as follows:
```bash
2022-05-11 13:19:01 __main__     INFO     running on device cuda
2022-05-11 13:19:01 __main__     INFO     running on device cuda
2022-05-11 13:19:02 sparseml.optim.manager INFO     Created recipe manager with metadata: {
 "__metadata__": null
}
2022-05-11 13:19:02 __main__     INFO     completed...
2022-05-11 13:19:02 __main__     INFO     completed...
Saving model for epoch -1 to /XXXXXXX//src/sparseml/pytorch/image_classification/pytorch_vision/resnet50_imagenette__10 for model-one-shot
2022-05-11 13:19:02 __main__     INFO     layer sparsities:
2022-05-11 13:19:02 __main__     INFO     layer sparsities:
2022-05-11 13:19:02 __main__     INFO     input.conv.weight: 0.0000
2022-05-11 13:19:02 __main__     INFO     input.conv.weight: 0.0000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv2.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv2.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.identity.conv.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.0.identity.conv.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.1.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.0.2.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.0.identity.conv.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.0.identity.conv.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.1.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.2.conv3.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv2.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.1.3.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.0.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.0.identity.conv.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.0.identity.conv.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.1.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.2.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.3.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.4.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.2.5.conv3.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv1.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.identity.conv.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.0.identity.conv.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.1.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv1.weight: 0.8500
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv2.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     sections.3.2.conv3.weight: 0.9000
2022-05-11 13:19:02 __main__     INFO     classifier.fc.weight: 0.8000
2022-05-11 13:19:02 __main__     INFO     classifier.fc.weight: 0.8000

Process finished with exit code 0

```