### PR TITLE
Export sample inputs and outputs for transformers

### DIFF
--- a/src/sparseml/transformers/masked_language_modeling.py
+++ b/src/sparseml/transformers/masked_language_modeling.py
@@ -275,6 +275,14 @@ class DataTrainingArguments:
         default=False,
         metadata={"help": "Whether to apply recipe in a one shot manner."},
     )
+    do_save_sample_outputs: bool = field(
+        default=False,
+        metadata={"help": "Whether to apply recipe in a one shot manner."},
+    )
+    num_export_samples: int = field(
+        default=0,
+        metadata={"help": "Number of sample inputs/outputs to export during eval."},
+    )
 
     def __post_init__(self):
         if (
@@ -745,6 +753,13 @@ def main():
             ] = f"{data_args.dataset_name} {data_args.dataset_config_name}"
         else:
             kwargs["dataset"] = data_args.dataset_name
+
+    # Exporting Samples
+
+    if data_args.do_save_sample_outputs and data_args.num_export_samples > 0:
+        trainer.save_sample_inputs_outputs(
+            num_samples_to_export=data_args.num_export_samples
+        )
 
     if training_args.push_to_hub:
         trainer.push_to_hub(**kwargs)

--- a/src/sparseml/transformers/masked_language_modeling.py
+++ b/src/sparseml/transformers/masked_language_modeling.py
@@ -275,13 +275,9 @@ class DataTrainingArguments:
         default=False,
         metadata={"help": "Whether to apply recipe in a one shot manner."},
     )
-    do_save_sample_outputs: bool = field(
-        default=False,
-        metadata={"help": "Whether to apply recipe in a one shot manner."},
-    )
     num_export_samples: int = field(
         default=0,
-        metadata={"help": "Number of sample inputs/outputs to export during eval."},
+        metadata={"help": "Number of samples (inputs/outputs) to export during eval."},
     )
 
     def __post_init__(self):
@@ -756,7 +752,7 @@ def main():
 
     # Exporting Samples
 
-    if data_args.do_save_sample_outputs and data_args.num_export_samples > 0:
+    if data_args.num_export_samples > 0:
         trainer.save_sample_inputs_outputs(
             num_samples_to_export=data_args.num_export_samples
         )

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -287,13 +287,9 @@ class DataTrainingArguments:
         default=False,
         metadata={"help": "Whether to apply recipe in a one shot manner."},
     )
-    do_save_sample_outputs: bool = field(
-        default=False,
-        metadata={"help": "Whether to apply recipe in a one shot manner."},
-    )
     num_export_samples: int = field(
         default=0,
-        metadata={"help": "Number of sample inputs/outputs to export during eval."},
+        metadata={"help": "Number of samples (inputs/outputs) to export during eval."},
     )
 
     def __post_init__(self):
@@ -857,7 +853,7 @@ def main():
 
     # Exporting Samples
 
-    if data_args.do_save_sample_outputs and data_args.num_export_samples > 0:
+    if data_args.num_export_samples > 0:
         trainer.save_sample_inputs_outputs(
             num_samples_to_export=data_args.num_export_samples
         )

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -287,6 +287,14 @@ class DataTrainingArguments:
         default=False,
         metadata={"help": "Whether to apply recipe in a one shot manner."},
     )
+    do_save_sample_outputs: bool = field(
+        default=False,
+        metadata={"help": "Whether to apply recipe in a one shot manner."},
+    )
+    num_export_samples: int = field(
+        default=0,
+        metadata={"help": "Number of sample inputs/outputs to export during eval."},
+    )
 
     def __post_init__(self):
         if (
@@ -847,6 +855,12 @@ def main():
         else:
             kwargs["dataset"] = data_args.dataset_name
 
+    # Exporting Samples
+
+    if data_args.do_save_sample_outputs and data_args.num_export_samples > 0:
+        trainer.save_sample_inputs_outputs(
+            num_samples_to_export=data_args.num_export_samples
+        )
     if training_args.push_to_hub:
         trainer.push_to_hub(**kwargs)
     else:

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -16,7 +16,6 @@
 SparseML transformers trainer classes and interfaces to be plugged in with
 existing or similiar HF trainer flows
 """
-
 import inspect
 import logging
 import math
@@ -25,6 +24,7 @@ from dataclasses import asdict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import datasets
+import numpy
 import torch
 from torch import distributed as dist
 from torch.nn import Module
@@ -465,6 +465,54 @@ class RecipeManagerTrainerInterface:
             f"{model_type} model detected, "
             f"all sparsification info: {sparsification_info}"
         )
+
+    def save_sample_inputs_outputs(
+        self, num_samples_to_export: int = 100, output_dir: Optional[str] = None
+    ):
+        """
+        Save sample inputs/outputs/labels in save_dir as .npz arrays
+
+        :param num_samples_to_export: Number of samples to export.
+            Defaults to 100
+        :param output_dir: The directory to store sample inputs and outputs in
+        """
+        num_samples = 0
+
+        potential_output_dir = (
+            self.args.output_dir if hasattr(self.args, "output_dir") else ""
+        )
+        output_dir = output_dir or potential_output_dir or ""
+
+        sample_inputs = os.path.join(output_dir, "sample-inputs")
+        sample_outputs = os.path.join(output_dir, "sample-outputs")
+        os.makedirs(sample_inputs, exist_ok=True)
+        os.makedirs(sample_outputs, exist_ok=True)
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        dataloader = self.get_train_dataloader()
+        _LOGGER.info(f"Exporting {num_samples_to_export} samples to {output_dir}")
+        for _, sample_batch in enumerate(dataloader):
+            sample_batch.pop("labels", None)
+            input_names = list(sample_batch.keys())
+
+            for input_vals in zip(*sample_batch.values()):
+                input_feed = {k: v.to("cpu") for k, v in zip(input_names, input_vals)}
+                model_inputs = {
+                    k: input_feed[k].to(device).reshape(1, -1) for k in input_feed
+                }
+                output_vals = self.model(**model_inputs)
+
+                output_dict = {
+                    name: torch.squeeze(val).detach().to("cpu")
+                    for name, val in output_vals.items()
+                }
+                file_idx = f"{num_samples}".zfill(4)
+                numpy.savez(f"{sample_inputs}/inp-{file_idx}.npz", **input_feed)
+                numpy.savez(f"{sample_outputs}/out-{file_idx}.npz", **output_dict)
+                num_samples += 1
+                if num_samples >= num_samples_to_export:
+                    break
+        _LOGGER.info(f"Exported {num_samples_to_export} samples to {output_dir}")
 
     def _extract_metadata(
         self,

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -208,6 +208,14 @@ class DataTrainingArguments:
         default=False,
         metadata={"help": "Whether to apply recipe in a one shot manner."},
     )
+    do_save_sample_outputs: bool = field(
+        default=False,
+        metadata={"help": "Whether to apply recipe in a one shot manner."},
+    )
+    num_export_samples: int = field(
+        default=0,
+        metadata={"help": "Number of sample inputs/outputs to export during eval."},
+    )
 
     def __post_init__(self):
         if self.task_name is not None:
@@ -785,6 +793,13 @@ def main():
         kwargs["dataset_tags"] = "glue"
         kwargs["dataset_args"] = data_args.task_name
         kwargs["dataset"] = f"GLUE {data_args.task_name.upper()}"
+
+    # Exporting Samples
+
+    if data_args.do_save_sample_outputs and data_args.num_export_samples > 0:
+        trainer.save_sample_inputs_outputs(
+            num_samples_to_export=data_args.num_export_samples
+        )
 
     if training_args.push_to_hub:
         trainer.push_to_hub(**kwargs)

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -208,13 +208,9 @@ class DataTrainingArguments:
         default=False,
         metadata={"help": "Whether to apply recipe in a one shot manner."},
     )
-    do_save_sample_outputs: bool = field(
-        default=False,
-        metadata={"help": "Whether to apply recipe in a one shot manner."},
-    )
     num_export_samples: int = field(
         default=0,
-        metadata={"help": "Number of sample inputs/outputs to export during eval."},
+        metadata={"help": "Number of samples (inputs/outputs) to export during eval."},
     )
 
     def __post_init__(self):
@@ -796,7 +792,7 @@ def main():
 
     # Exporting Samples
 
-    if data_args.do_save_sample_outputs and data_args.num_export_samples > 0:
+    if data_args.num_export_samples > 0:
         trainer.save_sample_inputs_outputs(
             num_samples_to_export=data_args.num_export_samples
         )

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -245,6 +245,14 @@ class DataTrainingArguments:
         default=False,
         metadata={"help": "Whether to apply recipe in a one shot manner."},
     )
+    do_save_sample_outputs: bool = field(
+        default=False,
+        metadata={"help": "Whether to apply recipe in a one shot manner."},
+    )
+    num_export_samples: int = field(
+        default=0,
+        metadata={"help": "Number of sample inputs/outputs to export during eval."},
+    )
 
     def __post_init__(self):
         if (
@@ -729,6 +737,13 @@ def main():
             ] = f"{data_args.dataset_name} {data_args.dataset_config_name}"
         else:
             kwargs["dataset"] = data_args.dataset_name
+
+    # Exporting Samples
+
+    if data_args.do_save_sample_outputs and data_args.num_export_samples > 0:
+        trainer.save_sample_inputs_outputs(
+            num_samples_to_export=data_args.num_export_samples
+        )
 
     if training_args.push_to_hub:
         trainer.push_to_hub(**kwargs)

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -245,13 +245,9 @@ class DataTrainingArguments:
         default=False,
         metadata={"help": "Whether to apply recipe in a one shot manner."},
     )
-    do_save_sample_outputs: bool = field(
-        default=False,
-        metadata={"help": "Whether to apply recipe in a one shot manner."},
-    )
     num_export_samples: int = field(
         default=0,
-        metadata={"help": "Number of sample inputs/outputs to export during eval."},
+        metadata={"help": "Number of samples (inputs/outputs) to export during eval."},
     )
 
     def __post_init__(self):
@@ -740,7 +736,7 @@ def main():
 
     # Exporting Samples
 
-    if data_args.do_save_sample_outputs and data_args.num_export_samples > 0:
+    if data_args.num_export_samples > 0:
         trainer.save_sample_inputs_outputs(
             num_samples_to_export=data_args.num_export_samples
         )


### PR DESCRIPTION
The goal of this PR is to add in support to export sample inputs and outputs to our transformers train integrations.

To this end we add two new arguments, namely `--do_save_sample_outputs`,
`--num_export_samples` to the following scripts:
* `question_answering.py`
* `masked_language_modeling.py`
* `text_classification.py`
* `token_classification.py`


Usage (tested-locally for all 4 scripts):

```bash
sparseml.transformers.train.text_classification \
    --output_dir test-models/sparse_quantized \
    --model_name_or_path zoo:nlp/masked_language_modeling/bert-base/pytorch/huggingface/wikipedia_bookcorpus/12layer_pruned80_quant-none-vnni \
    --recipe zoo:nlp/masked_language_modeling/bert-base/pytorch/huggingface/wikipedia_bookcorpus/12layer_pruned80_quant-none-vnni?recipe_type=transfer-text_classification \
    --recipe_args "{\"init_lr\":6e-5}" --distill_teacher disable \
    --task_name sst2 --max_seq_length 128 \
    --per_device_train_batch_size 12 --per_device_eval_batch_size 12 \
    --preprocessing_num_workers 6 --do_train --do_eval \
    --evaluation_strategy epoch --fp16 --seed 2819 --save_strategy epoch \
    --save_total_limit 1 --overwrite_output_dir --one_shot \
    --do_save_sample_outputs \
    --num_export_samples 100
```

Relevant Output:
```bash
2022-05-18 20:17:11 sparseml.transformers.sparsification.trainer INFO     Loaded SparseML recipe variable into manager for recipe: zoo:nlp/masked_language_modeling/bert-base/pytorch/huggingface/wikipedia_bookcorpus/12layer_pruned80_quant-none-vnni?recipe_type=transfer-text_classification, recipe_variables: {"init_lr":6e-5} and metadata {'per_device_train_batch_size': 12, 'per_device_eval_batch_size': 12, 'fp16': True}
2022-05-18 20:17:11 sparseml.transformers.sparsification.trainer WARNING  Overriding num_train_epochs from Recipe to 13
[INFO|trainer.py:457] 2022-05-18 20:17:13,833 >> Using amp half precision backend
2022-05-18 20:17:13 sparseml.pytorch.sparsification.distillation.modifier_distillation WARNING  distillation_teacher set to disable, disabling distillation modifier
2022-05-18 20:17:14 sparseml.transformers.sparsification.trainer INFO     Applied one shot recipe zoo:nlp/masked_language_modeling/bert-base/pytorch/huggingface/wikipedia_bookcorpus/12layer_pruned80_quant-none-vnni?recipe_type=transfer-text_classification to the manager
2022-05-18 20:17:14 sparseml.transformers.sparsification.trainer INFO     Skipping Training due to one-shot: True
2022-05-18 20:17:14 sparseml.transformers.sparsification.trainer INFO     Sparsification info for /XXXXXXXX/.cache/sparsezoo/03af0342-d7d0-470b-8958-80230ff0af10/pytorch: 109483778 total params. Of those there are 85526016 prunable params which have 79.44684807953641 avg sparsity.
2022-05-18 20:17:14 sparseml.transformers.sparsification.trainer INFO     sparse model detected, all sparsification info: {"params_summary": {"total": 109483778, "sparse": 67948494, "sparsity_percent": 62.06261351339191, "prunable": 85526016, "prunable_sparse": 67947724, "prunable_sparsity_percent": 79.44684807953641, "quantizable": 85609730, "quantized": 85609730, "quantized_percent": 100.0}, "params_info": {"bert.encoder.layer.0.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.6953192949295044, "quantized": true}, "bert.encoder.layer.0.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.7052341103553772, "quantized": true}, "bert.encoder.layer.0.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.9171278476715088, "quantized": true}, "bert.encoder.layer.0.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.8984646201133728, "quantized": true}, "bert.encoder.layer.0.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.8580034375190735, "quantized": true}, "bert.encoder.layer.0.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8947075605392456, "quantized": true}, "bert.encoder.layer.1.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.7061496376991272, "quantized": true}, "bert.encoder.layer.1.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.7080891728401184, "quantized": true}, "bert.encoder.layer.1.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.9004923701286316, "quantized": true}, "bert.encoder.layer.1.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.889512836933136, "quantized": true}, "bert.encoder.layer.1.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.7904154658317566, "quantized": true}, "bert.encoder.layer.1.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8658599853515625, "quantized": true}, "bert.encoder.layer.2.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.645616352558136, "quantized": true}, "bert.encoder.layer.2.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.66632080078125, "quantized": true}, "bert.encoder.layer.2.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.8987562656402588, "quantized": true}, "bert.encoder.layer.2.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.8934122920036316, "quantized": true}, "bert.encoder.layer.2.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.7772098183631897, "quantized": true}, "bert.encoder.layer.2.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8573048710823059, "quantized": true}, "bert.encoder.layer.3.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.70172119140625, "quantized": true}, "bert.encoder.layer.3.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.70062255859375, "quantized": true}, "bert.encoder.layer.3.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.8335300087928772, "quantized": true}, "bert.encoder.layer.3.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.8549262285232544, "quantized": true}, "bert.encoder.layer.3.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.7627665400505066, "quantized": true}, "bert.encoder.layer.3.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8491176962852478, "quantized": true}, "bert.encoder.layer.4.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.6901923418045044, "quantized": true}, "bert.encoder.layer.4.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.6963636875152588, "quantized": true}, "bert.encoder.layer.4.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.7606201171875, "quantized": true}, "bert.encoder.layer.4.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.8030598759651184, "quantized": true}, "bert.encoder.layer.4.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.7465870976448059, "quantized": true}, "bert.encoder.layer.4.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8364613652229309, "quantized": true}, "bert.encoder.layer.5.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.6834648847579956, "quantized": true}, "bert.encoder.layer.5.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.6836819052696228, "quantized": true}, "bert.encoder.layer.5.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.762986958026886, "quantized": true}, "bert.encoder.layer.5.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.8077324628829956, "quantized": true}, "bert.encoder.layer.5.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.7496185302734375, "quantized": true}, "bert.encoder.layer.5.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8431617021560669, "quantized": true}, "bert.encoder.layer.6.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.689561665058136, "quantized": true}, "bert.encoder.layer.6.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.6937527060508728, "quantized": true}, "bert.encoder.layer.6.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.7919243574142456, "quantized": true}, "bert.encoder.layer.6.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.8399454951286316, "quantized": true}, "bert.encoder.layer.6.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.7459242343902588, "quantized": true}, "bert.encoder.layer.6.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8525390625, "quantized": true}, "bert.encoder.layer.7.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.7118327021598816, "quantized": true}, "bert.encoder.layer.7.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.70855712890625, "quantized": true}, "bert.encoder.layer.7.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.7705281376838684, "quantized": true}, "bert.encoder.layer.7.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.8154500126838684, "quantized": true}, "bert.encoder.layer.7.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.7986043095588684, "quantized": true}, "bert.encoder.layer.7.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8714633584022522, "quantized": true}, "bert.encoder.layer.8.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.6654120683670044, "quantized": true}, "bert.encoder.layer.8.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.6618788242340088, "quantized": true}, "bert.encoder.layer.8.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.7354533076286316, "quantized": true}, "bert.encoder.layer.8.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.7885063886642456, "quantized": true}, "bert.encoder.layer.8.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.8084377646446228, "quantized": true}, "bert.encoder.layer.8.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8724382519721985, "quantized": true}, "bert.encoder.layer.9.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.6499362587928772, "quantized": true}, "bert.encoder.layer.9.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.6517673134803772, "quantized": true}, "bert.encoder.layer.9.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.7551947832107544, "quantized": true}, "bert.encoder.layer.9.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.7963799238204956, "quantized": true}, "bert.encoder.layer.9.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.8072594404220581, "quantized": true}, "bert.encoder.layer.9.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8551856279373169, "quantized": true}, "bert.encoder.layer.10.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.6656630039215088, "quantized": true}, "bert.encoder.layer.10.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.6718071699142456, "quantized": true}, "bert.encoder.layer.10.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.7371758222579956, "quantized": true}, "bert.encoder.layer.10.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.7690836787223816, "quantized": true}, "bert.encoder.layer.10.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.8190731406211853, "quantized": true}, "bert.encoder.layer.10.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8712107539176941, "quantized": true}, "bert.encoder.layer.11.attention.self.query.module.weight": {"numel": 589824, "sparsity": 0.6551649570465088, "quantized": true}, "bert.encoder.layer.11.attention.self.key.module.weight": {"numel": 589824, "sparsity": 0.6703152060508728, "quantized": true}, "bert.encoder.layer.11.attention.self.value.module.weight": {"numel": 589824, "sparsity": 0.7454155683517456, "quantized": true}, "bert.encoder.layer.11.attention.output.dense.module.weight": {"numel": 589824, "sparsity": 0.7777167558670044, "quantized": true}, "bert.encoder.layer.11.intermediate.dense.module.weight": {"numel": 2359296, "sparsity": 0.7969936728477478, "quantized": true}, "bert.encoder.layer.11.output.dense.module.weight": {"numel": 2359296, "sparsity": 0.8892008662223816, "quantized": true}, "bert.pooler.dense.module.weight": {"numel": 589824, "sparsity": 0.0, "quantized": true}, "classifier.module.weight": {"numel": 1536, "sparsity": 0.0, "quantized": true}}}
[INFO|trainer.py:2156] 2022-05-18 20:17:14,394 >> Saving model checkpoint to test-models/sparse_quantized
[INFO|configuration_utils.py:439] 2022-05-18 20:17:14,395 >> Configuration saved in test-models/sparse_quantized/config.json
[INFO|modeling_utils.py:1084] 2022-05-18 20:17:15,162 >> Model weights saved in test-models/sparse_quantized/pytorch_model.bin
[INFO|tokenization_utils_base.py:2094] 2022-05-18 20:17:15,164 >> tokenizer config file saved in test-models/sparse_quantized/tokenizer_config.json
[INFO|tokenization_utils_base.py:2100] 2022-05-18 20:17:15,164 >> Special tokens file saved in test-models/sparse_quantized/special_tokens_map.json
2022-05-18 20:17:15 sparseml.transformers.sparsification.trainer INFO     Saved SparseML recipe with model state to test-models/sparse_quantized/recipe.yaml
[INFO|trainer.py:570] 2022-05-18 20:17:15,200 >> The following columns in the training set  don't have a corresponding argument in `BertForSequenceClassification.forward` and have been ignored: sentence, idx. If sentence, idx are not expected by `BertForSequenceClassification.forward`,  you can safely ignore this message.
2022-05-18 20:17:15 sparseml.transformers.sparsification.trainer INFO     Exporting 100 samples to test-models/sparse_quantized
2022-05-18 20:20:10 sparseml.transformers.sparsification.trainer INFO     Exported 100 samples to test-models/sparse_quantized
[INFO|modelcard.py:460] 2022-05-18 20:20:11,057 >> Dropping the following result as it does not have all the necessary fields:
{'task': {'name': 'Text Classification', 'type': 'text-classification'}, 'dataset': {'name': 'GLUE SST2', 'type': 'glue', 'args': 'sst2'}}
```

The sample-inputs directory has 100 samples exported now
