### PR TITLE
`YOLOv5` Export Sample inputs/outputs

### DIFF
--- a/src/sparseml/pytorch/object_detection/train.py
+++ b/src/sparseml/pytorch/object_detection/train.py
@@ -450,9 +450,19 @@ def train(hyp, opt, device, callbacks):  # path/to/hyp.yaml or hyp dictionary
         one_shot_checkpoint_name = w / "checkpoint-one-shot.pt"
         torch.save(ckpt, one_shot_checkpoint_name)
         LOGGER.info(f"One shot checkpoint saved to {one_shot_checkpoint_name}")
+
+        if opt.num_export_samples > 0:
+            dataloader = val_loader or train_loader
+            sparseml_wrapper.save_sample_inputs_outputs(
+                dataloader=dataloader,
+                num_export_samples=opt.num_export_samples,
+                save_dir=w / "samples",
+            )
+
         torch.cuda.empty_cache()
         return results
 
+    # Continue as expected
     if RANK in [-1, 0]:
         sparseml_wrapper.initialize_loggers(loggers.logger, loggers.tb, loggers.wandb)
     scaler = sparseml_wrapper.modify(scaler, optimizer, model, train_loader)
@@ -735,6 +745,13 @@ def train(hyp, opt, device, callbacks):  # path/to/hyp.yaml or hyp dictionary
         callbacks.run("on_train_end", last, best, plots, epoch, results)
         LOGGER.info(f"Results saved to {colorstr('bold', save_dir)}")
 
+    if opt.num_export_samples > 0:
+        sparseml_wrapper.save_sample_inputs_outputs(
+            dataloader=val_loader or train_loader,
+            num_export_samples=opt.num_export_samples,
+            save_dir=w / "samples",
+        )
+
     torch.cuda.empty_cache()
     return results
 
@@ -927,6 +944,12 @@ def parse_opt(known=False):
         action="store_true",
         default=False,
         help="Apply recipe in one shot manner",
+    )
+    parser.add_argument(
+        "--num-export-samples",
+        type=int,
+        default=0,
+        help="The number of sample inputs/outputs to export, default=0",
     )
 
     opt = parser.parse_known_args()[0] if known else parser.parse_args()

--- a/src/sparseml/pytorch/object_detection/train.py
+++ b/src/sparseml/pytorch/object_detection/train.py
@@ -456,7 +456,7 @@ def train(hyp, opt, device, callbacks):  # path/to/hyp.yaml or hyp dictionary
             sparseml_wrapper.save_sample_inputs_outputs(
                 dataloader=dataloader,
                 num_export_samples=opt.num_export_samples,
-                save_dir=w / "samples",
+                save_dir=str(w),
             )
 
         torch.cuda.empty_cache()
@@ -749,7 +749,7 @@ def train(hyp, opt, device, callbacks):  # path/to/hyp.yaml or hyp dictionary
         sparseml_wrapper.save_sample_inputs_outputs(
             dataloader=val_loader or train_loader,
             num_export_samples=opt.num_export_samples,
-            save_dir=w / "samples",
+            save_dir=str(w),
         )
 
     torch.cuda.empty_cache()


### PR DESCRIPTION
The goal of this PR is to add support for exporting sample inputs and outputs for SparseML's YOLOv5 integration

To this end, A new CLI arg `--num-export-samples` has been added, the functionality has been tested locally using the following command:
```bash
sparseml.object_detection.train \
    --weights " " \
    --data coco128.yaml \
    --epochs 5 --cfg models_v5.0/yolov5s.yaml \
    --recipe zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned-aggressive_96?recipe_type=transfer_learn \
    --one-shot \
    --num-export-samples 10
```

Relevant Output:

```bash
Image sizes 640 train, 640 val
Using 8 dataloader workers
Logging results to /XXXXXX/projects/sparseml/src/sparseml/pytorch/object_detection/runs/train/exp46
Starting training for 5 epochs...
Skipped training due to one-shot: True
One shot checkpoint saved to /XXXXXX/projects/sparseml/src/sparseml/pytorch/object_detection/runs/train/exp46/weights/checkpoint-one-shot.pt
Exported 10 samples to /XXXXXX/projects/sparseml/src/sparseml/pytorch/object_detection/runs/train/exp46/weights/samples
```

The directory contains the following:
```bash
.
├── sample-inputs
│   ├── inp-0000.npz
│   ├── inp-0001.npz
│   ├── inp-0002.npz
│   ├── inp-0003.npz
│   ├── inp-0004.npz
│   ├── inp-0005.npz
│   ├── inp-0006.npz
│   ├── inp-0007.npz
│   ├── inp-0008.npz
│   └── inp-0009.npz
└── sample-outputs
    ├── out-0000.npz
    ├── out-0001.npz
    ├── out-0002.npz
    ├── out-0003.npz
    ├── out-0004.npz
    ├── out-0005.npz
    ├── out-0006.npz
    ├── out-0007.npz
    ├── out-0008.npz
    └── out-0009.npz
```

TODO:
- [ ] Change base branch to main before landing
- [ ] Land [this PR](https://github.com/neuralmagic/yolov5/pull/48) on YOLOv5 side and push latest wheel