### PR TITLE
[image_classification] fix bug in usage of latest helpers.create_model

### DIFF
--- a/src/sparseml/pytorch/image_classification/export.py
+++ b/src/sparseml/pytorch/image_classification/export.py
@@ -317,7 +317,7 @@ def main(
         model_kwargs=model_kwargs,
     )
 
-    model, arch_key = helpers.create_model(
+    model, arch_key, _ = helpers.create_model(
         checkpoint_path=checkpoint_path if recipe is None else None,
         recipe_path=recipe,
         num_classes=num_classes,

--- a/src/sparseml/pytorch/image_classification/lr_analysis.py
+++ b/src/sparseml/pytorch/image_classification/lr_analysis.py
@@ -360,7 +360,7 @@ def main(
         dataset=dataset,
         model_kwargs=model_kwargs,
     )
-    model, arch_key = helpers.create_model(
+    model, arch_key, _ = helpers.create_model(
         checkpoint_path=checkpoint_path,
         recipe_path=None,
         num_classes=num_classes,

--- a/src/sparseml/pytorch/image_classification/pr_sensitivity.py
+++ b/src/sparseml/pytorch/image_classification/pr_sensitivity.py
@@ -335,7 +335,7 @@ def main(
         model_kwargs=model_kwargs,
     )
 
-    model, arch_key = helpers.create_model(
+    model, arch_key, _ = helpers.create_model(
         checkpoint_path=checkpoint_path,
         recipe_path=None,
         num_classes=num_classes,

--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -248,7 +248,7 @@ def create_model(
     pretrained_dataset: Optional[str] = None,
     local_rank: int = -1,
     **model_kwargs,
-) -> Tuple[Module, str]:
+) -> Tuple[Module, str, str]:
     """
     :param checkpoint_path: Path to the checkpoint to load. `zoo` for
         downloading weights with respect to a SparseZoo recipe


### PR DESCRIPTION
`helpers.create_model` was updated to have an extra output but not all usages of it were updated to account for it. This PR addresses the bug.

Bug found manually by @anmarques, #796 will add support for catching this on commit once added to GHA