### PR TITLE
set end_comparator of LayerPruningModifier to -1

### DIFF
--- a/src/sparseml/keras/optim/modifier.py
+++ b/src/sparseml/keras/optim/modifier.py
@@ -135,7 +135,7 @@ class ScheduledModifier(Modifier, BaseScheduled):
     :param end_comparator: integer value representing how the end_epoch should be
         compared to start_epoch.
         if == None, then end_epoch can only be set to what its initial value was.
-        if == -1, then end_epoch can be less than, equal, or greater than start_epoch.
+        if == -1, then end_epoch can be -1, equal, or greater than start_epoch.
         if == 0, then end_epoch can be equal to or greater than start_epoch.
         if == 1, then end_epoch can only be greater than start_epoch.
     :param kwargs: standard key word args, used to support multi inheritance

--- a/src/sparseml/optim/modifier.py
+++ b/src/sparseml/optim/modifier.py
@@ -627,7 +627,7 @@ class BaseScheduled(BaseObject):
     :param end_comparator: integer value representing how the end_epoch should be
         compared to start_epoch.
         if == None, then end_epoch can only be set to what its initial value was.
-        if == -1, then end_epoch can be less than, equal, or greater than start_epoch.
+        if == -1, then end_epoch can be -1, equal to, or greater than start_epoch.
         if == 0, then end_epoch can be equal to or greater than start_epoch.
         if == 1, then end_epoch can only be greater than start_epoch.
     :param kwargs: standard key word args, used to support multi inheritance
@@ -709,6 +709,18 @@ class BaseScheduled(BaseObject):
                 "end_epoch of {} must be equal the init value of {} for {}".format(
                     self._end_epoch, self._init_end, self.__class__.__name__
                 )
+            )
+
+        if (
+            self._end_comparator == -1
+            and self._end_epoch < self._start_epoch
+            and (self._end_epoch != -1)
+        ):
+            raise ValueError(
+                (
+                    "end_epoch of {} must be greater than"
+                    " or equal to start_epoch of {} for {} or equal to -1"
+                ).format(self._end_epoch, self._start_epoch, self.__class__.__name__)
             )
 
         if self._end_comparator == 0 and self._start_epoch > self._end_epoch:

--- a/src/sparseml/pytorch/sparsification/modifier.py
+++ b/src/sparseml/pytorch/sparsification/modifier.py
@@ -411,7 +411,7 @@ class ScheduledModifier(Modifier, BaseScheduled):
     :param end_comparator: integer value representing how the end_epoch should be
         compared to start_epoch.
         if == None, then end_epoch can only be set to what its initial value was.
-        if == -1, then end_epoch can be less than, equal, or greater than start_epoch.
+        if == -1, then end_epoch can be -1, equal, or greater than start_epoch.
         if == 0, then end_epoch can be equal to or greater than start_epoch.
         if == 1, then end_epoch can only be greater than start_epoch.
     :param kwargs: standard key word args, used to support multi inheritance
@@ -779,7 +779,7 @@ class ScheduledUpdateModifier(ScheduledModifier, BaseUpdate):
     :param end_comparator: integer value representing how the end_epoch should be
         compared to start_epoch.
         if == None, then end_epoch can only be set to what its initial value was.
-        if == -1, then end_epoch can be less than, equal, or greater than start_epoch.
+        if == -1, then end_epoch can be -1, equal, or greater than start_epoch.
         if == 0, then end_epoch can be equal to or greater than start_epoch.
         if == 1, then end_epoch can only be greater than start_epoch.
     :param min_frequency: The minimum acceptable value for update_frequency, default -1

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_base.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_base.py
@@ -92,7 +92,7 @@ class BasePruningModifier(ABC, ScheduledUpdateModifier):
     :param end_comparator: integer value representing how the end_epoch should be
         compared to start_epoch.
         if == None, then end_epoch can only be set to what its initial value was.
-        if == -1, then end_epoch can be less than, equal, or greater than start_epoch.
+        if == -1, then end_epoch can be -1, equal, or greater than start_epoch.
         if == 0, then end_epoch can be equal to or greater than start_epoch.
         if == 1, then end_epoch can only be greater than start_epoch.
     :param update_frequency: The number of epochs or fraction of epochs to
@@ -581,7 +581,7 @@ class BaseGradualPruningModifier(BasePruningModifier):
     :param end_comparator: integer value representing how the end_epoch should be
         compared to start_epoch.
         if == None, then end_epoch can only be set to what its initial value was.
-        if == -1, then end_epoch can be less than, equal, or greater than start_epoch.
+        if == -1, then end_epoch can be -1, equal, or greater than start_epoch.
         if == 0, then end_epoch can be equal to or greater than start_epoch.
         if == 1, then end_epoch can only be greater than start_epoch.
     :param update_frequency: The number of epochs or fraction of epochs to

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_layer.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_layer.py
@@ -70,6 +70,7 @@ class LayerPruningModifier(ScheduledUpdateModifier):
             start_epoch=start_epoch,
             end_epoch=end_epoch,
             update_frequency=-1.0,
+            end_comparator=-1,
         )
         self._layers = validate_str_iterable(
             layers, "{} for layers".format(self.__class__.__name__)

--- a/src/sparseml/tensorflow_v1/optim/modifier.py
+++ b/src/sparseml/tensorflow_v1/optim/modifier.py
@@ -261,7 +261,7 @@ class ScheduledModifier(Modifier, BaseScheduled):
     :param end_comparator: integer value representing how the end_epoch should be
         compared to start_epoch.
         if == None, then end_epoch can only be set to what its initial value was.
-        if == -1, then end_epoch can be less than, equal, or greater than start_epoch.
+        if == -1, then end_epoch can be -1, equal, or greater than start_epoch.
         if == 0, then end_epoch can be equal to or greater than start_epoch.
         if == 1, then end_epoch can only be greater than start_epoch.
     :param kwargs: standard key word args, used to support multi inheritance
@@ -342,7 +342,7 @@ class ScheduledUpdateModifier(ScheduledModifier, BaseUpdate):
     :param min_end: The minimum acceptable value for end_epoch, default 0
     :param end_comparator: integer value representing how the end_epoch should be
         compared to start_epoch.
-        if == -1, then end_epoch can be less than, equal, or greater than start_epoch.
+        if == -1, then end_epoch can be -1, equal, or greater than start_epoch.
         if == 0, then end_epoch can be equal to or greater than start_epoch.
         if == 1, then end_epoch can only be greater than start_epoch.
     :param update_frequency: The number of epochs or fraction of epochs to


### PR DESCRIPTION
Under the current `end_comparator` the end epoch of `LayerPruningModifier` must be greater than the start epoch. This would make a schedule like `start_epoch=2.0, end_epoch=-1` invalid which is a bug, since we should be able to start at an arbitrary epoch (`start_epoch=2.0`) and run indefinitely (`end_epoch=-1.0`)

`end_comparator` specs: 
https://github.com/neuralmagic/sparseml/blob/29119f73596fbea01a0b82133696305995a5b72c/src/sparseml/optim/modifier.py#L630
https://github.com/neuralmagic/sparseml/blob/29119f73596fbea01a0b82133696305995a5b72c/src/sparseml/optim/modifier.py#L631
