### PR TITLE
[BugFix] AttributeError when fetching val loader for transformers sample input/output exports

### DIFF
--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -499,7 +499,11 @@ class RecipeManagerTrainerInterface:
         os.makedirs(sample_out_dir, exist_ok=True)
         device = self.model.device
 
-        dataloader = self.get_val_dataloader() or self.get_train_dataloader()
+        try:
+            dataloader = self.get_val_dataloader()
+        except Exception:
+            dataloader = self.get_train_dataloader()
+
         _LOGGER.info(f"Exporting {num_samples_to_export} samples to {output_dir}")
         for _, sample_batch in enumerate(dataloader):
             sample_batch.pop("labels", None)


### PR DESCRIPTION
Wrap getting val data loader in a try except clause to deal with errors while fetching val data loader, rely on train_loader if can't get the val loader