### PR TITLE
delay onnxruntime import error until invocation of dependent functions

### DIFF
--- a/src/sparseml/base.py
+++ b/src/sparseml/base.py
@@ -239,6 +239,7 @@ def check_version(
     max_version: Optional[str] = None,
     raise_on_error: bool = True,
     alternate_package_names: Optional[List[str]] = None,
+    extra_error_message: Optional[str] = None,
 ) -> bool:
     """
     :param package_name: the name of the package to check the version of
@@ -255,6 +256,9 @@ def check_version(
     :param alternate_package_names: List of alternate names to look for the package
         under if package_name is not found. Useful for nightly builds.
     :type alternate_package_names: Optional[List[str]]
+    :param extra_error_message: optional string to append to error message if error
+        is raised
+    :type extra_error_message: Optional[str]
     :return: If raise_on_error, will return False if the package is not installed
         or the version is outside the accepted bounds and True if everything is correct.
     :rtype: bool
@@ -273,6 +277,7 @@ def check_version(
             raise ImportError(
                 f"required min {package_name} version {min_version}, "
                 f"found {current_version}"
+                + (f". {extra_error_message}" if extra_error_message else "")
             )
         return False
 
@@ -281,6 +286,7 @@ def check_version(
             raise ImportError(
                 f"required max {package_name} version {max_version}, "
                 f"found {current_version}"
+                + (f". {extra_error_message}" if extra_error_message else "")
             )
         return False
 

--- a/src/sparseml/onnx/base.py
+++ b/src/sparseml/onnx/base.py
@@ -115,7 +115,13 @@ def check_onnxruntime_install(
             raise onnxruntime_err
         return False
 
-    return check_version("onnxruntime", min_version, max_version, raise_on_error)
+    return check_version(
+        "onnxruntime",
+        min_version,
+        max_version,
+        raise_on_error,
+        extra_error_message="Try installing sparseml[onnxruntime] or onnxruntime",
+    )
 
 
 def require_onnx(

--- a/src/sparseml/onnx/base.py
+++ b/src/sparseml/onnx/base.py
@@ -32,11 +32,7 @@ try:
 
     onnxruntime_err = None
 
-except ModuleNotFoundError as error:
-    raise error.__class__(
-        f"{error.msg}. To fix this error, install sparseml[onnxruntime]."
-    )
-
+except Exception as error:
     onnxruntime = object()  # TODO: populate with fake object for necessary imports
     onnxruntime_err = error
 

--- a/src/sparseml/onnx/utils/helpers.py
+++ b/src/sparseml/onnx/utils/helpers.py
@@ -24,10 +24,10 @@ from typing import Any, Dict, List, NamedTuple, Tuple, Union
 
 import numpy
 import onnx
-import onnxruntime
 from onnx import ModelProto, NodeProto, TensorProto, numpy_helper
 from onnx.helper import get_attribute_value, make_empty_tensor_value_info
 
+from sparseml.onnx.base import require_onnxruntime
 from sparseml.utils import clean_path
 
 
@@ -234,6 +234,7 @@ NodeShape = NamedTuple(
 )
 
 
+@require_onnxruntime()
 def extract_nodes_shapes_ort(model: ModelProto) -> Dict[str, List[List[int]]]:
     """
     Creates a modified model to expose intermediate outputs and runs an ONNX Runtime
@@ -242,6 +243,8 @@ def extract_nodes_shapes_ort(model: ModelProto) -> Dict[str, List[List[int]]]:
     :param model: an ONNX model
     :return: a list of NodeArg with their shape exposed
     """
+    import onnxruntime  # import protected by @require_onnxruntime()
+
     model_copy = deepcopy(model)
 
     for node in model_copy.graph.node:

--- a/src/sparseml/onnx/utils/model.py
+++ b/src/sparseml/onnx/utils/model.py
@@ -26,7 +26,6 @@ from copy import deepcopy
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 import numpy
-import onnxruntime
 import psutil
 from onnx import ModelProto
 from tqdm import auto
@@ -462,6 +461,8 @@ class ORTModelRunner(ModelRunner):
         providers: List[str] = None,
         **kwargs,
     ):
+        import onnxruntime  # import protected by @require_onnxruntime()
+
         super().__init__(loss)
         self._model = check_load_model(model)
 


### PR DESCRIPTION
#789 makes `onnxruntime` an optional dependency of sparseml. This PR fixes two issues that led to import of non ORT dependent functions (such as `sparseml.pytorch.optim.ScheduledModifierManager`) run into import errors

1) removes the addition of a hard check of ORT import on any import of `sparseml.onnx`
2) moves onnxruntime import in the two `src/` functions that require ORT to inside the functions, using the `require_onnxruntime` decorator as a checker