### PR TITLE
Average losses before logging is called

### DIFF
--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -386,6 +386,8 @@ class RecipeManagerTrainerInterface:
             teacher_inputs = None
 
         loss = student_outputs["loss"]
+        if self.args.n_gpu > 1:  # DataParallel
+            loss = loss.mean()
         loss = self.manager.loss_update(
             loss,
             model,


### PR DESCRIPTION
Fixes https://github.com/neuralmagic/sparseml/issues/817 by averaging losses before loggers are called.
It's guarded with `n_gpu > 1` to avoid synchronizing processes in DDP runs.