### PR TITLE
[BugFix] Pin protobuff version due to breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ _deps = [
     "tqdm>=4.0.0",
     "toposort>=1.0",
     "GPUtil>=1.4.0",
+    "protobuf>=3.12.2,<4",
 ]
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}"]
 _deepsparse_deps = [


### PR DESCRIPTION
This PR pins protobuff version in SparseML to prevent breaking changes introduced in newer versions

Fix taken from : [DeepSparse PR #389](https://github.com/neuralmagic/deepsparse/pull/389)