### PR TITLE
Fix: allow non-string keys in recipes

### DIFF
--- a/src/sparseml/optim/helpers.py
+++ b/src/sparseml/optim/helpers.py
@@ -348,7 +348,7 @@ def check_if_staged_recipe(container: dict) -> bool:
     for k, v in container.items():
         if isinstance(v, dict):
             if any(
-                [key for key in v.keys() if isinstance(key, str) and "modifiers" in key]
+                key for key in v.keys() if isinstance(key, str) and "modifiers" in key
             ):
                 return True
     return False

--- a/src/sparseml/optim/helpers.py
+++ b/src/sparseml/optim/helpers.py
@@ -347,7 +347,9 @@ def check_if_staged_recipe(container: dict) -> bool:
     """
     for k, v in container.items():
         if isinstance(v, dict):
-            if any([key for key in v.keys() if "modifiers" in key]):
+            if any(
+                [key for key in v.keys() if isinstance(key, str) and "modifiers" in key]
+            ):
                 return True
     return False
 

--- a/src/sparseml/yolov5/scripts.py
+++ b/src/sparseml/yolov5/scripts.py
@@ -20,9 +20,14 @@ from yolov5.train import parse_opt as parse_train_args
 from yolov5.train import run as train_run
 from yolov5.val import parse_opt as parse_val_args
 from yolov5.val import val_run
-from yolov5.val_onnx import parse_opt as parse_val_onnx_args
-from yolov5.val_onnx import val_onnx_run
 
+
+val_onnx_error = None
+try:
+    from yolov5.val_onnx import parse_opt as parse_val_onnx_args
+    from yolov5.val_onnx import val_onnx_run
+except Exception as deepsparse_error:
+    val_onnx_error = deepsparse_error
 
 __all__ = [
     "train",
@@ -63,5 +68,8 @@ def val_onnx():
     """
     Hook to call into val_onnx.py in YOLOv5 fork
     """
+    if val_onnx_error:
+        raise RuntimeError(val_onnx_error)
+
     opt = parse_val_onnx_args()
     val_onnx_run(**vars(opt))


### PR DESCRIPTION
This fix adds back compatibility for numeric recipe keys, as seen in the following example:

```
target_sparsities: &target_sparsities
  0.90: ['sections.1.0.point.conv.weight', 'sections.1.1.point.conv.weight', 'sections.2.0.point.conv.weight']
  0.95: ['sections.2.1.point.conv.weight', 'sections.3.0.point.conv.weight', 'sections.3.1.point.conv.weight', 'sections.3.5.point.conv.weight']
  0.97: ['sections.3.2.point.conv.weight', 'sections.3.3.point.conv.weight', 'sections.3.4.point.conv.weight', 'sections.4.0.point.conv.weight', 'sections.4.1.point.conv.weight']
```