### PR TITLE
[BugFix]: Exporting when `--do_train` and `--do_eval` are not set

### DIFF
--- a/src/sparseml/transformers/masked_language_modeling.py
+++ b/src/sparseml/transformers/masked_language_modeling.py
@@ -635,7 +635,8 @@ def main():
             train_dataset = train_dataset.select(range(data_args.max_train_samples))
 
     compute_metrics = None
-    if training_args.do_eval:
+    make_eval_dataset = training_args.do_eval or data_args.num_export_samples > 0
+    if make_eval_dataset:
         if "validation" not in tokenized_datasets:
             raise ValueError("--do_eval requires a validation dataset")
         eval_dataset = tokenized_datasets["validation"]
@@ -687,7 +688,7 @@ def main():
         args=training_args,
         data_args=data_args,
         train_dataset=train_dataset if training_args.do_train else None,
-        eval_dataset=eval_dataset if training_args.do_eval else None,
+        eval_dataset=eval_dataset if make_eval_dataset else None,
         tokenizer=tokenizer,
         data_collator=data_collator,
         compute_metrics=compute_metrics if training_args.do_eval else None,

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -477,7 +477,7 @@ def main():
     # Preprocessing is slighlty different for training and evaluation.
     if training_args.do_train:
         column_names = raw_datasets["train"].column_names
-    elif training_args.do_eval:
+    elif training_args.do_eval or data_args.num_export_samples > 0:
         column_names = raw_datasets["validation"].column_names
     else:
         column_names = raw_datasets["test"].column_names
@@ -666,7 +666,7 @@ def main():
 
         return tokenized_examples
 
-    if training_args.do_eval:
+    if training_args.do_eval or data_args.num_export_samples > 0:
         if "validation" not in raw_datasets:
             raise ValueError("--do_eval requires a validation dataset")
         eval_examples = raw_datasets["validation"]
@@ -777,7 +777,9 @@ def main():
         args=training_args,
         data_args=data_args,
         train_dataset=train_dataset if training_args.do_train else None,
-        eval_dataset=eval_dataset if training_args.do_eval else None,
+        eval_dataset=eval_dataset
+        if training_args.do_eval or data_args.num_export_samples > 0
+        else None,
         eval_examples=eval_examples if training_args.do_eval else None,
         tokenizer=tokenizer,
         data_collator=data_collator,

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -475,9 +475,10 @@ def main():
 
     # Preprocessing the datasets.
     # Preprocessing is slighlty different for training and evaluation.
+    make_eval_dataset = training_args.do_eval or data_args.num_export_samples > 0
     if training_args.do_train:
         column_names = raw_datasets["train"].column_names
-    elif training_args.do_eval or data_args.num_export_samples > 0:
+    elif make_eval_dataset:
         column_names = raw_datasets["validation"].column_names
     else:
         column_names = raw_datasets["test"].column_names
@@ -666,7 +667,7 @@ def main():
 
         return tokenized_examples
 
-    if training_args.do_eval or data_args.num_export_samples > 0:
+    if make_eval_dataset:
         if "validation" not in raw_datasets:
             raise ValueError("--do_eval requires a validation dataset")
         eval_examples = raw_datasets["validation"]
@@ -777,9 +778,7 @@ def main():
         args=training_args,
         data_args=data_args,
         train_dataset=train_dataset if training_args.do_train else None,
-        eval_dataset=eval_dataset
-        if training_args.do_eval or data_args.num_export_samples > 0
-        else None,
+        eval_dataset=eval_dataset if make_eval_dataset else None,
         eval_examples=eval_examples if training_args.do_eval else None,
         tokenizer=tokenizer,
         data_collator=data_collator,

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -502,7 +502,7 @@ class RecipeManagerTrainerInterface:
         device = self.model.device
 
         try:
-            dataloader = self.get_val_dataloader()
+            dataloader = self.get_eval_dataloader()
         except Exception:
             dataloader = self.get_train_dataloader()
 

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -649,7 +649,8 @@ def main():
         if data_args.max_train_samples is not None:
             train_dataset = train_dataset.select(range(data_args.max_train_samples))
 
-    if training_args.do_eval:
+    make_eval_dataset = training_args.do_eval or data_args.num_export_samples > 0
+    if make_eval_dataset:
         if (
             "validation" not in raw_datasets
             and "validation_matched" not in raw_datasets
@@ -725,7 +726,7 @@ def main():
         args=training_args,
         data_args=data_args,
         train_dataset=train_dataset if training_args.do_train else None,
-        eval_dataset=eval_dataset if training_args.do_eval else None,
+        eval_dataset=eval_dataset if make_eval_dataset else None,
         tokenizer=tokenizer,
         data_collator=data_collator,
         compute_metrics=compute_metrics,

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -560,7 +560,8 @@ def main():
                 desc="Running tokenizer on train dataset",
             )
 
-    if training_args.do_eval:
+    make_eval_dataset = training_args.do_eval or data_args.num_export_samples > 0
+    if make_eval_dataset:
         if "validation" not in raw_datasets:
             raise ValueError("--do_eval requires a validation dataset")
         eval_dataset = raw_datasets["validation"]
@@ -648,7 +649,7 @@ def main():
         args=training_args,
         data_args=data_args,
         train_dataset=train_dataset if training_args.do_train else None,
-        eval_dataset=eval_dataset if training_args.do_eval else None,
+        eval_dataset=eval_dataset if make_eval_dataset else None,
         tokenizer=tokenizer,
         data_collator=data_collator,
         compute_metrics=compute_metrics,


### PR DESCRIPTION
[BugFixes]: To supported exporting when `--do_train` and `--do_eval` are not set

* Use `get_eval_dataloader()` instead of `get_val_dataloader`
* Always create a eval_dataset if num_export_samples>0

Test commands

- [X] Question answering

```bash
sparseml.transformers.train.question_answering \
--output_dir models/sparse_quantized --model_name_or_path "zoo:nlp/masked_language_modeling/bert-base/pytorch/huggingface/wikipedia_bookcorpus/12layer_pruned80_quant-none-vnni" --recipe "zoo:nlp/masked_language_modeling/bert-base/pytorch/huggingface/wikipedia_bookcorpus/12layer_pruned80_quant-none-vnni?recipe_type=transfer-question_answering" --distill_teacher "disable" --dataset_name squad --overwrite_output_dir --one_shot --num_export_samples 100
```

Relevant OutPut:
```bash
2022-06-02 15:37:39 sparseml.transformers.sparsification.trainer INFO     Exporting 100 samples to models/sparse_quantized
2022-06-02 15:37:40 sparseml.transformers.sparsification.trainer INFO     Exported 100 samples to models/sparse_quantized
[INFO|modelcard.py:460] 2022-06-02 15:37:40,391 >> Dropping the following result as it does not have all the necessary fields:
{'task': {'name': 'Question Answering', 'type': 'question-answering'}, 'dataset': {'name': 'squad', 'type': 'squad', 'args': 'plain_text'}}
```

Noting testing was done locally for all 4 scripts omitting the `--do_eval` and `--do_train` args