### PR TITLE
Fix: allow non-string keys in recipes (#842)

### DIFF
--- a/src/sparseml/optim/helpers.py
+++ b/src/sparseml/optim/helpers.py
@@ -347,7 +347,9 @@ def check_if_staged_recipe(container: dict) -> bool:
     """
     for k, v in container.items():
         if isinstance(v, dict):
-            if any([key for key in v.keys() if "modifiers" in key]):
+            if any(
+                key for key in v.keys() if isinstance(key, str) and "modifiers" in key
+            ):
                 return True
     return False
 


### PR DESCRIPTION
This PR allows non-string modifier keys
* Update: remove deepsparse requirement to run yolov5

* Fix: allow for non-string keys

* Apply suggestions from code review

Co-authored-by: Rahul Tuli <rahul@neuralmagic.com>

Co-authored-by: Benjamin Fineran <bfineran@users.noreply.github.com>
Co-authored-by: Rahul Tuli <rahul@neuralmagic.com>