### PR TITLE
bug fix for image classificaiton eval whith no recipe provided

### DIFF
--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -545,18 +545,22 @@ def main(
     train_batch_size = train_batch_size // world_size
     helpers.set_seeds(local_rank=local_rank)
 
-    train_dataset, train_loader, = helpers.get_dataset_and_dataloader(
-        dataset_name=dataset,
-        dataset_path=dataset_path,
-        batch_size=train_batch_size,
-        image_size=image_size,
-        dataset_kwargs=dataset_kwargs,
-        training=True,
-        loader_num_workers=loader_num_workers,
-        loader_pin_memory=loader_pin_memory,
-        ffcv=ffcv,
-        device=device,
-    )
+    if not eval_mode:
+        train_dataset, train_loader, = helpers.get_dataset_and_dataloader(
+            dataset_name=dataset,
+            dataset_path=dataset_path,
+            batch_size=train_batch_size,
+            image_size=image_size,
+            dataset_kwargs=dataset_kwargs,
+            training=True,
+            loader_num_workers=loader_num_workers,
+            loader_pin_memory=loader_pin_memory,
+            ffcv=ffcv,
+            device=device,
+        )
+    else:
+        train_dataset = None
+        train_loader = None
 
     val_dataset, val_loader = (
         helpers.get_dataset_and_dataloader(

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -195,7 +195,11 @@ class ImageClassificationTrainer(Trainer):
         if not (train_mode or validation_mode):
             raise ValueError(f"Invalid train mode '{mode}', must be 'train' or 'val'")
 
-        if torch.__version__ < "1.9" and self.manager.qat_active(epoch=self.epoch):
+        if (
+            torch.__version__ < "1.9"
+            and self.manager
+            and (self.manager.qat_active(epoch=self.epoch))
+        ):
             # switch off fp16
             self._device_context.use_mixed_precision = False
 


### PR DESCRIPTION
this PR addresses an with `eval_mode` in the ic training script where a train dataset would always be created even in `eval_mode`, requiring a training recipe to be provided during `eval_mode` even though this should not be necessary. This led to a runtime error that is addressed by this PR