### PR TITLE
Transformers refactor

### DIFF
--- a/src/sparseml/transformers/masked_language_modeling.py
+++ b/src/sparseml/transformers/masked_language_modeling.py
@@ -47,14 +47,13 @@ from transformers import (
     AutoTokenizer,
     DataCollatorForLanguageModeling,
     HfArgumentParser,
-    TrainingArguments,
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
-from sparseml.transformers.sparsification import Trainer
+from sparseml.transformers.sparsification import Trainer, TrainingArguments
 from sparseml.transformers.utils import SparseAutoModel, get_shared_tokenizer_src
 
 
@@ -108,10 +107,6 @@ class ModelArguments:
             "n_embd=10,resid_pdrop=0.2,scale_attn_weights=false,summary_type=cls_index"
         },
     )
-    distill_teacher: Optional[str] = field(
-        default=None,
-        metadata={"help": "Teacher model which needs to be a trained QA model"},
-    )
     config_name: Optional[str] = field(
         default=None,
         metadata={
@@ -164,19 +159,6 @@ class DataTrainingArguments:
     training and eval
     """
 
-    recipe: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": (
-                "Path to a SparseML sparsification recipe, see "
-                "https://github.com/neuralmagic/sparseml for more information"
-            ),
-        },
-    )
-    recipe_args: Optional[str] = field(
-        default=None,
-        metadata={"help": "Recipe arguments to be overwritten"},
-    )
     dataset_name: Optional[str] = field(
         default=None,
         metadata={"help": "The name of the dataset to use (via the datasets library)"},
@@ -489,7 +471,7 @@ def main():
             "revision": model_args.model_revision,
             "use_auth_token": True if model_args.use_auth_token else None,
         },
-        teacher_name_or_path=model_args.distill_teacher,
+        teacher_name_or_path=training_args.distill_teacher,
         teacher_kwargs={
             "cache_dir": model_args.cache_dir,
             "use_auth_token": True if model_args.use_auth_token else None,

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -49,8 +49,8 @@ from transformers.utils.versions import require_version
 
 from sparseml.transformers.sparsification import (
     QuestionAnsweringTrainer,
-    postprocess_qa_predictions,
     TrainingArguments,
+    postprocess_qa_predictions,
 )
 from sparseml.transformers.utils import SparseAutoModel, get_shared_tokenizer_src
 
@@ -89,10 +89,6 @@ class ModelArguments:
                 "huggingface.co/models"
             )
         }
-    )
-    distill_teacher: Optional[str] = field(
-        default=None,
-        metadata={"help": "Teacher model which needs to be a trained QA model"},
     )
     config_name: Optional[str] = field(
         default=None,
@@ -141,21 +137,6 @@ class DataTrainingArguments:
     Arguments pertaining to what data to input to our model for training and eval
     """
 
-    recipe: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": (
-                "Path to a SparseML sparsification recipe, see "
-                "https://github.com/neuralmagic/sparseml for more information"
-            )
-        },
-    )
-    recipe_args: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": "Recipe arguments to be overwritten",
-        },
-    )
     dataset_name: Optional[str] = field(
         default=None,
         metadata={
@@ -444,7 +425,7 @@ def main():
             "revision": model_args.model_revision,
             "use_auth_token": True if model_args.use_auth_token else None,
         },
-        teacher_name_or_path=model_args.distill_teacher,
+        teacher_name_or_path=training_args.distill_teacher,
         teacher_kwargs={
             "cache_dir": model_args.cache_dir,
             "use_auth_token": True if model_args.use_auth_token else None,
@@ -771,8 +752,8 @@ def main():
     trainer = QuestionAnsweringTrainer(
         model=model,
         model_state_path=model_args.model_name_or_path,
-        recipe=data_args.recipe,
-        recipe_args=data_args.recipe_args,
+        recipe=training_args.recipe,
+        recipe_args=training_args.recipe_args,
         metadata_args=metadata_args,
         teacher=teacher,
         args=training_args,

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -40,7 +40,6 @@ from transformers import (
     EvalPrediction,
     HfArgumentParser,
     PreTrainedTokenizerFast,
-    TrainingArguments,
     default_data_collator,
     set_seed,
 )
@@ -51,6 +50,7 @@ from transformers.utils.versions import require_version
 from sparseml.transformers.sparsification import (
     QuestionAnsweringTrainer,
     postprocess_qa_predictions,
+    TrainingArguments,
 )
 from sparseml.transformers.utils import SparseAutoModel, get_shared_tokenizer_src
 

--- a/src/sparseml/transformers/sparsification/__init__.py
+++ b/src/sparseml/transformers/sparsification/__init__.py
@@ -21,3 +21,4 @@ Hugging Face transformers flows
 
 from .question_answering import *
 from .trainer import *
+from .training_args import *

--- a/src/sparseml/transformers/sparsification/question_answering.py
+++ b/src/sparseml/transformers/sparsification/question_answering.py
@@ -34,7 +34,10 @@ from tqdm.auto import tqdm
 from transformers import is_torch_tpu_available
 from transformers.trainer_utils import PredictionOutput
 
-from sparseml.transformers.sparsification.trainer import TrainerInterface, TransformersTrainer
+from sparseml.transformers.sparsification.trainer import (
+    TrainerInterface,
+    TransformersTrainer,
+)
 
 
 if is_torch_tpu_available():
@@ -209,30 +212,6 @@ class QuestionAnsweringTrainer(TrainerInterface, _QuestionAnsweringTrainer):
             teacher=teacher,
             **kwargs,
         )
-
-    def _remove_unused_columns(
-        self, dataset: "datasets.Dataset", description: Optional[str] = None
-    ):
-        if (
-            self._signature_columns is None
-            and self.teacher is not None
-            and self.teacher not in ("disable", "self")
-        ):
-            model_signature = inspect.signature(self.model.forward)
-            model_signature_columns = set(model_signature.parameters.keys())
-
-            teacher_signature = inspect.signature(self.teacher.forward)
-            teacher_signature_columns = set(teacher_signature.parameters.keys())
-
-            self._signature_columns = list(
-                model_signature_columns | teacher_signature_columns
-            )
-
-            # Labels may be named label or label_ids, the default data
-            # collator handles that.
-            self._signature_columns += ["label", "label_ids"]
-
-        return super()._remove_unused_columns(dataset, description)
 
 
 def postprocess_qa_predictions(

--- a/src/sparseml/transformers/sparsification/question_answering.py
+++ b/src/sparseml/transformers/sparsification/question_answering.py
@@ -21,13 +21,11 @@ Training and post-processing utilities for question answering.
 """
 
 import collections
-import inspect
 import json
 import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import datasets
 import numpy as np
 from torch.nn import Module
 from tqdm.auto import tqdm

--- a/src/sparseml/transformers/sparsification/question_answering.py
+++ b/src/sparseml/transformers/sparsification/question_answering.py
@@ -31,10 +31,10 @@ import datasets
 import numpy as np
 from torch.nn import Module
 from tqdm.auto import tqdm
-from transformers import Trainer, is_torch_tpu_available
+from transformers import is_torch_tpu_available
 from transformers.trainer_utils import PredictionOutput
 
-from sparseml.transformers.sparsification.trainer import TrainerInterface
+from sparseml.transformers.sparsification.trainer import TrainerInterface, TransformersTrainer
 
 
 if is_torch_tpu_available():
@@ -51,7 +51,7 @@ __all__ = [
 _LOGGER = logging.getLogger(__name__)
 
 
-class _QuestionAnsweringTrainer(Trainer):
+class _QuestionAnsweringTrainer(TransformersTrainer):
     """
     Trainer implementation for Question-Answering processing
     """

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -29,7 +29,7 @@ import torch
 from torch import distributed as dist
 from torch.nn import Module
 from torch.utils.data import RandomSampler
-from transformers import Trainer as TransformersTrainer
+from transformers import Trainer as _TransformersTrainer
 from transformers import TrainerCallback, TrainerControl, TrainingArguments
 from transformers.file_utils import WEIGHTS_NAME
 from transformers.trainer_callback import TrainerState
@@ -51,6 +51,7 @@ __all__ = [
     "TrainerInterface",
     "Trainer",
     "DisableHalfPrecisionCallback",
+    "TransformersTrainer"
 ]
 
 
@@ -831,6 +832,38 @@ class TrainerInterface(RecipeManagerTrainerInterface):
         return checkpoint, epoch
 
 
+class TransformersTrainer(_TransformersTrainer):
+    """
+    A transformers trainer class with customed behaviors that can be shared
+    by all trainers inside SparseML
+    """
+    def _save_checkpoint(self, model, trial, metrics=None):
+        super()._save_checkpoint(model, trial, metrics=metrics)
+        if (
+            self.args.metric_for_best_model is None
+            or self.args.best_model_after_epoch is None
+        ):
+            return
+
+        if (self.state.epoch > self.args.best_model_after_epoch):
+            metric_to_check = self.args.metric_for_best_model
+            if not metric_to_check.startswith("eval_"):
+                metric_to_check = f"eval_{metric_to_check}"
+            metric_value = metrics[metric_to_check]
+
+            operator = np.greater if self.args.greater_is_better else np.less
+            if (
+                self.state.best_metric is None
+                or self.state.best_model_checkpoint is None
+                or operator(metric_value, self.state.best_metric)
+            ):
+                self.state.best_metric = metric_value
+                self.state.best_model_checkpoint = output_dir
+        else:
+            self.state.best_metric = None
+            self.state.best_model_checkpoint = None
+    
+
 class Trainer(TrainerInterface, TransformersTrainer):
     """
     Training implementation for running sparsification recipes with transformers flows.
@@ -900,7 +933,7 @@ class Trainer(TrainerInterface, TransformersTrainer):
             self._signature_columns += ["label", "label_ids"]
 
         return super()._remove_unused_columns(dataset, description)
-
+    
 
 class DisableHalfPrecisionCallback(TrainerCallback):
     """

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -839,6 +839,8 @@ class TransformersTrainer(HFTransformersTrainer):
     """
 
     def _save_checkpoint(self, model, trial, metrics=None):
+        # Call into the save checkpoint by HF Transformers, which saves the
+        # best metric if required
         super()._save_checkpoint(model, trial, metrics=metrics)
         if (
             self.args.metric_for_best_model is None
@@ -846,21 +848,7 @@ class TransformersTrainer(HFTransformersTrainer):
         ):
             return
 
-        if self.state.epoch > self.args.best_model_after_epoch:
-            metric_to_check = self.args.metric_for_best_model
-            if not metric_to_check.startswith("eval_"):
-                metric_to_check = f"eval_{metric_to_check}"
-            metric_value = metrics[metric_to_check]
-
-            operator = np.greater if self.args.greater_is_better else np.less
-            if (
-                self.state.best_metric is None
-                or self.state.best_model_checkpoint is None
-                or operator(metric_value, self.state.best_metric)
-            ):
-                self.state.best_metric = metric_value
-                self.state.best_model_checkpoint = output_dir
-        else:
+        if self.state.epoch <= self.args.best_model_after_epoch:
             self.state.best_metric = None
             self.state.best_model_checkpoint = None
 

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -29,7 +29,7 @@ import torch
 from torch import distributed as dist
 from torch.nn import Module
 from torch.utils.data import RandomSampler
-from transformers import Trainer as _TransformersTrainer
+from transformers import Trainer as HFTransformersTrainer
 from transformers import TrainerCallback, TrainerControl, TrainingArguments
 from transformers.file_utils import WEIGHTS_NAME
 from transformers.trainer_callback import TrainerState
@@ -51,7 +51,7 @@ __all__ = [
     "TrainerInterface",
     "Trainer",
     "DisableHalfPrecisionCallback",
-    "TransformersTrainer"
+    "TransformersTrainer",
 ]
 
 
@@ -832,11 +832,12 @@ class TrainerInterface(RecipeManagerTrainerInterface):
         return checkpoint, epoch
 
 
-class TransformersTrainer(_TransformersTrainer):
+class TransformersTrainer(HFTransformersTrainer):
     """
     A transformers trainer class with customed behaviors that can be shared
     by all trainers inside SparseML
     """
+
     def _save_checkpoint(self, model, trial, metrics=None):
         super()._save_checkpoint(model, trial, metrics=metrics)
         if (
@@ -845,7 +846,7 @@ class TransformersTrainer(_TransformersTrainer):
         ):
             return
 
-        if (self.state.epoch > self.args.best_model_after_epoch):
+        if self.state.epoch > self.args.best_model_after_epoch:
             metric_to_check = self.args.metric_for_best_model
             if not metric_to_check.startswith("eval_"):
                 metric_to_check = f"eval_{metric_to_check}"
@@ -862,41 +863,6 @@ class TransformersTrainer(_TransformersTrainer):
         else:
             self.state.best_metric = None
             self.state.best_model_checkpoint = None
-    
-
-class Trainer(TrainerInterface, TransformersTrainer):
-    """
-    Training implementation for running sparsification recipes with transformers flows.
-    :param model: the model to use with the trainer and apply sparsification to
-    :param model_state_path: the state path to the model,
-        used to load config and tokenizer settings
-    :param recipe: the recipe, if any, to apply to the modle and training
-        process
-    :param recipe_args: A json string, csv key=value string, or dictionary containing
-        arguments to override the root arguments within the recipe such as
-        learning rate or num epochs
-    :param teacher: teacher model for distillation. Set to 'self' to distill
-        from the loaded model or 'disable' to turn of distillation
-    :param kwargs: key word arguments passed to the parent class
-    """
-
-    def __init__(
-        self,
-        model: Module,
-        model_state_path: str,
-        recipe: Optional[str],
-        recipe_args: Optional[Union[Dict[str, Any], str]] = None,
-        teacher: Optional[Union[Module, str]] = None,
-        **kwargs,
-    ):
-        super().__init__(
-            model=model,
-            model_state_path=model_state_path,
-            recipe=recipe,
-            recipe_args=recipe_args,
-            teacher=teacher,
-            **kwargs,
-        )
 
     def _remove_unused_columns(
         self, dataset: "datasets.Dataset", description: Optional[str] = None
@@ -933,7 +899,42 @@ class Trainer(TrainerInterface, TransformersTrainer):
             self._signature_columns += ["label", "label_ids"]
 
         return super()._remove_unused_columns(dataset, description)
-    
+
+
+class Trainer(TrainerInterface, TransformersTrainer):
+    """
+    Training implementation for running sparsification recipes with transformers flows.
+    :param model: the model to use with the trainer and apply sparsification to
+    :param model_state_path: the state path to the model,
+        used to load config and tokenizer settings
+    :param recipe: the recipe, if any, to apply to the modle and training
+        process
+    :param recipe_args: A json string, csv key=value string, or dictionary containing
+        arguments to override the root arguments within the recipe such as
+        learning rate or num epochs
+    :param teacher: teacher model for distillation. Set to 'self' to distill
+        from the loaded model or 'disable' to turn of distillation
+    :param kwargs: key word arguments passed to the parent class
+    """
+
+    def __init__(
+        self,
+        model: Module,
+        model_state_path: str,
+        recipe: Optional[str],
+        recipe_args: Optional[Union[Dict[str, Any], str]] = None,
+        teacher: Optional[Union[Module, str]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            model=model,
+            model_state_path=model_state_path,
+            recipe=recipe,
+            recipe_args=recipe_args,
+            teacher=teacher,
+            **kwargs,
+        )
+
 
 class DisableHalfPrecisionCallback(TrainerCallback):
     """

--- a/src/sparseml/transformers/sparsification/training_args.py
+++ b/src/sparseml/transformers/sparsification/training_args.py
@@ -1,6 +1,21 @@
+# Copyright (c) 2022 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from transformers import TrainingArguments as HFTrainingArgs
 
 __all__ = ["TrainingArguments"]
+
 
 @dataclass
 class TrainingArguments(HFTrainingArgs):
@@ -11,8 +26,8 @@ class TrainingArguments(HFTrainingArgs):
         The epoch after which best model will be saved; used in conjunction with `load_best_model_at_end` and
         `metric_for_best_model` training arguments
     """
+
     best_model_after_epoch: int = field(
         default=None,
         metadata={"help": "Epoch after which best model will be saved."},
     )
-

--- a/src/sparseml/transformers/sparsification/training_args.py
+++ b/src/sparseml/transformers/sparsification/training_args.py
@@ -1,0 +1,18 @@
+from transformers import TrainingArguments as HFTrainingArgs
+
+__all__ = ["TrainingArguments"]
+
+@dataclass
+class TrainingArguments(HFTrainingArgs):
+    """
+    Training arguments specific to SparseML Transformers workflow
+
+    :param best_model_after_epoch (`int`, *optional*, defaults to None):
+        The epoch after which best model will be saved; used in conjunction with `load_best_model_at_end` and
+        `metric_for_best_model` training arguments
+    """
+    best_model_after_epoch: int = field(
+        default=None,
+        metadata={"help": "Epoch after which best model will be saved."},
+    )
+

--- a/src/sparseml/transformers/sparsification/training_args.py
+++ b/src/sparseml/transformers/sparsification/training_args.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 - present / Neuralmagic, Inc. All Rights Reserved.
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass, field
+from typing import Optional
+
 from transformers import TrainingArguments as HFTrainingArgs
+
 
 __all__ = ["TrainingArguments"]
 
@@ -23,11 +27,31 @@ class TrainingArguments(HFTrainingArgs):
     Training arguments specific to SparseML Transformers workflow
 
     :param best_model_after_epoch (`int`, *optional*, defaults to None):
-        The epoch after which best model will be saved; used in conjunction with `load_best_model_at_end` and
-        `metric_for_best_model` training arguments
+        The epoch after which best model will be saved; used in conjunction
+        with `load_best_model_at_end` and `metric_for_best_model` training
+        arguments
     """
 
+    distill_teacher: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Teacher model (a trained text classification model)",
+        },
+    )
     best_model_after_epoch: int = field(
         default=None,
         metadata={"help": "Epoch after which best model will be saved."},
+    )
+    recipe: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Path to a SparseML sparsification recipe, see "
+                "https://github.com/neuralmagic/sparseml for more information"
+            ),
+        },
+    )
+    recipe_args: Optional[str] = field(
+        default=None,
+        metadata={"help": "Recipe arguments to be overwritten"},
     )

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -42,7 +42,6 @@ from transformers import (
     EvalPrediction,
     HfArgumentParser,
     PretrainedConfig,
-    TrainingArguments,
     default_data_collator,
     set_seed,
 )
@@ -50,7 +49,7 @@ from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
-from sparseml.transformers.sparsification import Trainer
+from sparseml.transformers.sparsification import Trainer, TrainingArguments
 from sparseml.transformers.utils import SparseAutoModel, get_shared_tokenizer_src
 
 
@@ -94,19 +93,6 @@ class DataTrainingArguments:
     arguments to be able to specify them on the command line
     """
 
-    recipe: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": (
-                "Path to a SparseML sparsification recipe, see "
-                "https://github.com/neuralmagic/sparseml for more information"
-            ),
-        },
-    )
-    recipe_args: Optional[str] = field(
-        default=None,
-        metadata={"help": "Recipe arguments to be overwritten"},
-    )
     task_name: Optional[str] = field(
         default=None,
         metadata={
@@ -253,12 +239,6 @@ class ModelArguments:
                 "huggingface.co/models"
             )
         }
-    )
-    distill_teacher: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": "Teacher model which must be a trained text classification model"
-        },
     )
     config_name: Optional[str] = field(
         default=None,
@@ -480,7 +460,7 @@ def main():
             "revision": model_args.model_revision,
             "use_auth_token": True if model_args.use_auth_token else None,
         },
-        teacher_name_or_path=model_args.distill_teacher,
+        teacher_name_or_path=training_args.distill_teacher,
         teacher_kwargs={
             "cache_dir": model_args.cache_dir,
             "use_auth_token": True if model_args.use_auth_token else None,
@@ -719,9 +699,9 @@ def main():
     trainer = Trainer(
         model=model,
         model_state_path=model_args.model_name_or_path,
-        recipe=data_args.recipe,
+        recipe=training_args.recipe,
         metadata_args=metadata_args,
-        recipe_args=data_args.recipe_args,
+        recipe_args=training_args.recipe_args,
         teacher=teacher,
         args=training_args,
         data_args=data_args,

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -40,14 +40,13 @@ from transformers import (
     HfArgumentParser,
     PretrainedConfig,
     PreTrainedTokenizerFast,
-    TrainingArguments,
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint
 from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
-from sparseml.transformers.sparsification import Trainer
+from sparseml.transformers.sparsification import Trainer, TrainingArguments
 from sparseml.transformers.utils import SparseAutoModel, get_shared_tokenizer_src
 
 
@@ -83,10 +82,6 @@ class ModelArguments:
                 "huggingface.co/models"
             )
         }
-    )
-    distill_teacher: Optional[str] = field(
-        default=None,
-        metadata={"help": "Teacher model which needs to be a trained NER model"},
     )
     config_name: Optional[str] = field(
         default=None,
@@ -127,19 +122,6 @@ class DataTrainingArguments:
     training and eval
     """
 
-    recipe: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": (
-                "Path to a SparseML sparsification recipe, see "
-                "https://github.com/neuralmagic/sparseml for more information"
-            ),
-        },
-    )
-    recipe_args: Optional[str] = field(
-        default=None,
-        metadata={"help": "Recipe arguments to be overwritten"},
-    )
     task_name: Optional[str] = field(
         default="ner", metadata={"help": "The name of the task (ner, pos...)."}
     )
@@ -440,7 +422,7 @@ def main():
             "revision": model_args.model_revision,
             "use_auth_token": True if model_args.use_auth_token else None,
         },
-        teacher_name_or_path=model_args.distill_teacher,
+        teacher_name_or_path=training_args.distill_teacher,
         teacher_kwargs={
             "cache_dir": model_args.cache_dir,
             "use_auth_token": True if model_args.use_auth_token else None,


### PR DESCRIPTION
Currently it's not possible for the two trainers in sparseml transformers both extending a functionality from the upstream HuggingFace Trainer and sharing common code. This PR is to fix that, for now enabling them share saving best model after a specified epoch and removing unused column.

Additionally, create common training args for different training flow, and let them share distill teacher and recipe args. Same things could be done when needed for data and model args.