### PR TITLE
pytorch manager - group modifiers by stage in apply

### DIFF
--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -19,7 +19,8 @@ Also handles loading modifiers from yaml files
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Union
+import math
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import torch
 from torch import Tensor
@@ -373,6 +374,46 @@ class ScheduledModifierManager(BaseManager, Modifier):
 
             modifiers_index[key].load_state_dict(val)
 
+    def apply(
+        self,
+        module: Module,
+        epoch: float = math.inf,
+        loggers: Optional[LoggerManager] = None,
+        finalize: bool = True,
+        **kwargs,
+    ):
+        """
+        Apply the modifier for a given model/module (one shot application).
+        Calls into initialize(module, epoch, loggers, **kwargs) and then
+        finalize(module, **kwargs) immediately after if finalize=True.
+
+        :param module: the PyTorch model/module to modify
+        :param epoch: the epoch to apply the modifier at, defaults to math.inf (end)
+        :param loggers: Optional logger manager to log the modification process to
+        :param finalize: True to invoke finalize after initialize, False otherwise.
+            If training after one shot, set finalize=False to keep modifiers applied.
+        :param kwargs: Optional kwargs to support specific arguments
+            for individual modifiers (passed to initialize and finalize).
+        """
+        if not self.initialized:
+            super().initialize(module, epoch, loggers, **kwargs)
+            self._initialize_epoch = epoch
+
+        modifier_lists = (
+            self._modifiers
+            if isinstance(self._modifiers, List)
+            else list(self._modifiers.values())
+        )
+
+        for modifier_list in modifier_lists:
+
+            self._initialize_modifiers(
+                modifier_list, module, epoch, loggers=loggers, **kwargs
+            )
+
+            if finalize:
+                self._finalize_modifiers(modifier_list, module, **kwargs)
+
     def apply_structure(
         self,
         module: Module,
@@ -422,12 +463,9 @@ class ScheduledModifierManager(BaseManager, Modifier):
         super().initialize(module, epoch, loggers, **kwargs)
         self._initialize_epoch = epoch
 
-        for mod in self.iter_modifiers():
-            if mod.initialized:
-                # check in case modifier was initialized from apply_structure
-                continue
-
-            mod.initialize(module, epoch, loggers, **kwargs)
+        self._initialize_modifiers(
+            self.iter_modifiers(), module, epoch, loggers, **kwargs
+        )
 
     def initialize_loggers(self, loggers: Union[None, LoggerManager, List[BaseLogger]]):
         """
@@ -521,8 +559,7 @@ class ScheduledModifierManager(BaseManager, Modifier):
         """
         super().finalize(module, reset_loggers, **kwargs)
 
-        for mod in self.iter_modifiers():
-            mod.finalize(module, reset_loggers, **kwargs)
+        self._finalize_modifiers(self.iter_modifiers(), module, reset_loggers, **kwargs)
 
     def update(
         self,
@@ -635,3 +672,28 @@ class ScheduledModifierManager(BaseManager, Modifier):
                 continue
 
             mod.optimizer_post_step(module, optimizer, epoch, steps_per_epoch)
+
+    def _initialize_modifiers(
+        self,
+        modifiers: Iterable[Modifier],
+        module: Module,
+        epoch: float = 0,
+        loggers: Union[None, LoggerManager, List[BaseLogger]] = None,
+        **kwargs,
+    ):
+        for mod in modifiers:
+            if mod.initialized:
+                # check in case modifier was initialized from apply_structure
+                continue
+
+            mod.initialize(module, epoch, loggers, **kwargs)
+
+    def _finalize_modifiers(
+        self,
+        modifiers: Iterable[Modifier],
+        module: Optional[Module] = None,
+        reset_loggers: bool = True,
+        **kwargs,
+    ):
+        for mod in modifiers:
+            mod.finalize(module, reset_loggers, **kwargs)

--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -383,9 +383,8 @@ class ScheduledModifierManager(BaseManager, Modifier):
         **kwargs,
     ):
         """
-        Apply the modifier for a given model/module (one shot application).
-        Calls into initialize(module, epoch, loggers, **kwargs) and then
-        finalize(module, **kwargs) immediately after if finalize=True.
+        Applies the lifecycle of each stage in the manager/recipe
+        by calling into initialize and finalize for each modifier for each stage
 
         :param module: the PyTorch model/module to modify
         :param epoch: the epoch to apply the modifier at, defaults to math.inf (end)

--- a/src/sparseml/pytorch/optim/manager.py
+++ b/src/sparseml/pytorch/optim/manager.py
@@ -680,6 +680,9 @@ class ScheduledModifierManager(BaseManager, Modifier):
         loggers: Union[None, LoggerManager, List[BaseLogger]] = None,
         **kwargs,
     ):
+        if isinstance(modifiers, Modifier):
+            modifiers = [modifiers]
+
         for mod in modifiers:
             if mod.initialized:
                 # check in case modifier was initialized from apply_structure
@@ -694,5 +697,8 @@ class ScheduledModifierManager(BaseManager, Modifier):
         reset_loggers: bool = True,
         **kwargs,
     ):
+        if isinstance(modifiers, Modifier):
+            modifiers = [modifiers]
+
         for mod in modifiers:
             mod.finalize(module, reset_loggers, **kwargs)


### PR DESCRIPTION
stages in recipes have the potential to change the structure of models.  This means if the lifecycle of one stage is not completed before the next is started, they may be referring to parts of a model that have structurally changed.  This PR avoids potential conflicts on one-shot application in `manager.apply()` by calling the full apply lifecycle for each stage separately.

Example potential issue - stage 1 includes structured pruning, stage 2 includes quantization.  stage 1 will try to complete a final thinning on finalize (previously called after the initialize of quantization), but the parameters' expected names will no longer exist due to the application of quantization.

This PR fixes this issue by calling the `initialize/finalize` lifecycle for each stage separately so references structural changes are contained within stages