### PR TITLE
Extend quantizable layer types

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -454,12 +454,13 @@ def configure_module_default_qconfigs(module: Module):
             submodule.configure_qconfig()
 
 
-def add_quant_dequant(module, name=None, parent_module=None, layer_class_names: Optional[List[str]]=None):
+def add_quant_dequant(module, name=None, parent_module=None, layer_class_names=None):
     """
     Wraps all Conv and Linear submodule with a qconfig with a QuantWrapper
     :param module: the module to modify
     :param name: name of the module to modify; default to None
     :param parent_module: parent module containing the module to modify; default to None
+    :param layer_class_names: list of module class names to be added to the list of quantizable modules
     :return: the modified module
     """
     named_children = module.named_children()
@@ -484,7 +485,7 @@ def add_quant_dequant(module, name=None, parent_module=None, layer_class_names: 
             setattr(parent_module, name, module)
     else:
         for name, child in named_children:
-            setattr(module, name, add_quant_dequant(child))
+            setattr(module, name, add_quant_dequant(child, layer_class_names=layer_class_names))
     return module
 
 

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -454,7 +454,7 @@ def configure_module_default_qconfigs(module: Module):
             submodule.configure_qconfig()
 
 
-def add_quant_dequant(module, name=None, parent_module=None):
+def add_quant_dequant(module, name=None, parent_module=None, layer_class_names: Optional[List[str]]=None):
     """
     Wraps all Conv and Linear submodule with a qconfig with a QuantWrapper
     :param module: the module to modify
@@ -463,8 +463,11 @@ def add_quant_dequant(module, name=None, parent_module=None):
     :return: the modified module
     """
     named_children = module.named_children()
+    is_quantizable = type(module) in _QUANTIZABLE_MODULE_TYPES
+    if layer_class_names:
+        is_quantizable = is_quantizable or module.__class__.__name__ in layer_class_names
     if (
-        type(module) in _QUANTIZABLE_MODULE_TYPES
+        is_quantizable
         and hasattr(module, "qconfig")
         and module.qconfig
     ):

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -135,6 +135,8 @@ class QuantizationModifier(ScheduledModifier):
         batch-normalization modules
     :param exclude_module_types: optional list of module class names
         to not propagate quantization configs to. Default is None
+    :param include_module_types: optional list of module class names
+        to be added to the list of quantizable modules. Default is None
     :param activation_qconfig_kwargs: Additional kwargs for quantization of
         activations.
     :param weight_qconfig_kwargs: Additional kwargs for quantization of
@@ -162,6 +164,7 @@ class QuantizationModifier(ScheduledModifier):
         num_calibration_steps: Optional[int] = None,
         exclude_batchnorm: bool = True,
         exclude_module_types: Optional[List[str]] = None,
+        include_module_types: Optional[List[str]] = None,
         activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
         weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
         tensorrt: bool = False,
@@ -195,6 +198,7 @@ class QuantizationModifier(ScheduledModifier):
         self._weight_bits = weight_bits
         self._exclude_batchnorm = exclude_batchnorm
         self._exclude_module_types = exclude_module_types
+        self._include_module_types = include_module_types
 
         self._modules_to_quantize = None
         self._qat_enabled = False
@@ -388,6 +392,14 @@ class QuantizationModifier(ScheduledModifier):
             return False
         else:
             return self._quantize_embedding_activations
+
+    @ModifierProp()
+    def include_module_types(self) -> Union[List[str], None]:
+        """
+        :return: optional list of module class names to be included
+            in list of quantizable modules. Default is None
+        """
+        return self._include_module_types
 
     @ModifierProp()
     def exclude_module_types(self) -> Union[List[str], None]:
@@ -652,7 +664,7 @@ class QuantizationModifier(ScheduledModifier):
             torch_quantization.propagate_qconfig_(quant_module)
             configure_module_default_qconfigs(quant_module)
 
-            add_quant_dequant(quant_module, name, module)
+            add_quant_dequant(quant_module, name, module, self.include_module_types)
 
             # Remove output quantization from appropriate modules
             remove_activation_qat_by_layer_name(

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -135,7 +135,7 @@ class QuantizationModifier(ScheduledModifier):
         batch-normalization modules
     :param exclude_module_types: optional list of module class names
         to not propagate quantization configs to. Default is None
-    :param include_module_types: optional list of module class names
+    :param add_quantizable_module_types: optional list of module class names
         to be added to the list of quantizable modules. Default is None
     :param activation_qconfig_kwargs: Additional kwargs for quantization of
         activations.
@@ -164,7 +164,7 @@ class QuantizationModifier(ScheduledModifier):
         num_calibration_steps: Optional[int] = None,
         exclude_batchnorm: bool = True,
         exclude_module_types: Optional[List[str]] = None,
-        include_module_types: Optional[List[str]] = None,
+        add_quantizable_module_types: Optional[List[str]] = None,
         activation_qconfig_kwargs: Optional[Dict[str, Any]] = None,
         weight_qconfig_kwargs: Optional[Dict[str, Any]] = None,
         tensorrt: bool = False,
@@ -198,7 +198,7 @@ class QuantizationModifier(ScheduledModifier):
         self._weight_bits = weight_bits
         self._exclude_batchnorm = exclude_batchnorm
         self._exclude_module_types = exclude_module_types
-        self._include_module_types = include_module_types
+        self._add_quantizable_module_types = add_quantizable_module_types
 
         self._modules_to_quantize = None
         self._qat_enabled = False
@@ -394,12 +394,12 @@ class QuantizationModifier(ScheduledModifier):
             return self._quantize_embedding_activations
 
     @ModifierProp()
-    def include_module_types(self) -> Union[List[str], None]:
+    def add_quantizable_module_types(self) -> Union[List[str], None]:
         """
         :return: optional list of module class names to be included
             in list of quantizable modules. Default is None
         """
-        return self._include_module_types
+        return self._add_quantizable_module_types
 
     @ModifierProp()
     def exclude_module_types(self) -> Union[List[str], None]:
@@ -663,7 +663,7 @@ class QuantizationModifier(ScheduledModifier):
             # wrap all conv / linear blocks in with quantization observers
             torch_quantization.propagate_qconfig_(quant_module)
             configure_module_default_qconfigs(quant_module)
-            add_quant_dequant(quant_module, name, module, self.include_module_types)
+            add_quant_dequant(quant_module, name, module, self.add_quantizable_module_types)
 
             # Remove output quantization from appropriate modules
             remove_activation_qat_by_layer_name(

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -663,7 +663,6 @@ class QuantizationModifier(ScheduledModifier):
             # wrap all conv / linear blocks in with quantization observers
             torch_quantization.propagate_qconfig_(quant_module)
             configure_module_default_qconfigs(quant_module)
-
             add_quant_dequant(quant_module, name, module, self.include_module_types)
 
             # Remove output quantization from appropriate modules
@@ -674,7 +673,7 @@ class QuantizationModifier(ScheduledModifier):
         # remove qconfigs for module types in exclude_module_types
         to_exclude = []
         if self._exclude_module_types:
-            to_exclude.extend(self._exclude_module_types)
+            to_exclude.extend(self.exclude_module_types)
 
         # if exclude_batchnorm flag is used, add batch norm layers to list of
         # modules to exclude qconfig


### PR DESCRIPTION
This PR adds a flag to the quantization modifier that allows user to extend the list of quantizable module types. It was motivated by the need to quantize the GELU activation. Since this activation is implemented as a module, the user can quantize it by passing the corresponding module type as an argument