### PR TITLE
update setup.py dependencies to resolve pypi conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ _deepsparse_deps = [
 _onnxruntime_deps = ["onnxruntime>=1.0.0"]
 _pytorch_deps = [
     "torch>=1.1.0,<=1.9.1",
-    "tensorboard>=1.0",
+    "tensorboard>=1.0,<2.9",
     "tensorboardX>=1.0",
     "gputils",
 ]
@@ -93,6 +93,7 @@ _dev_deps = [
     "pytest-mock~=3.6.0",
     "flaky~=3.7.0",
     "sphinx-rtd-theme",
+    "docutils<0.17",
 ]
 
 


### PR DESCRIPTION
attempting to reconcile
```bash
ERROR: sphinx 3.5.4 has requirement docutils<0.17,>=0.12, but you'll have docutils 0.17.1 which is incompatible.
``` 
```bash
ERROR: tensorboard 2.9.1 has requirement protobuf<3.20,>=3.9.2, but you'll have protobuf 3.20.1 which is incompatible.
```
