### PR TITLE
ignore integrations tests in base `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SPARSEZOO_TEST_MODE := "true"
 
 BUILD_ARGS :=  # set nightly to build nightly release
 TARGETS := ""  # targets for running pytests: deepsparse,keras,onnx,pytorch,pytorch_models,pytorch_datasets,tensorflow_v1,tensorflow_v1_models,tensorflow_v1_datasets
-PYTEST_ARGS ?= ""
+PYTEST_ARGS ?= "--ignore tests/integrations"
 PYTEST_INTEG_ARGS ?= ""
 ifneq ($(findstring deepsparse,$(TARGETS)),deepsparse)
     PYTEST_ARGS := $(PYTEST_ARGS) --ignore tests/sparseml/deepsparse


### PR DESCRIPTION
`tests/integrations` will be picked up by `pytest tests/` otherwise