### PR TITLE
fix None type propagation issue when ConstantPruningModifier start_epoch > 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SPARSEZOO_TEST_MODE := "true"
 
 BUILD_ARGS :=  # set nightly to build nightly release
 TARGETS := ""  # targets for running pytests: deepsparse,keras,onnx,pytorch,pytorch_models,pytorch_datasets,tensorflow_v1,tensorflow_v1_models,tensorflow_v1_datasets
-PYTEST_ARGS ?= "--ignore tests/integrations"
+PYTEST_ARGS ?= --ignore tests/integrations
 PYTEST_INTEG_ARGS ?= ""
 ifneq ($(findstring deepsparse,$(TARGETS)),deepsparse)
     PYTEST_ARGS := $(PYTEST_ARGS) --ignore tests/sparseml/deepsparse

--- a/src/sparseml/pytorch/sparsification/pruning/mask_params.py
+++ b/src/sparseml/pytorch/sparsification/pruning/mask_params.py
@@ -357,6 +357,8 @@ class ModuleParamPruningMask(object):
             target = [target] * len(self._params)
         if self.adjust_target_sparsity_for_thinning:
             for idx, sparsity_val in enumerate(target):
+                if sparsity_val is None:
+                    continue  # ie constant pruning
                 applied_thinning = self._params_applied_thinning[idx]
                 if applied_thinning > 0.0:
                     # adjust sparsity for thinned (compressed) layer param


### PR DESCRIPTION
this bug was exposed due to the rare case of `ConstantPruningModifier`'s `start_epoch` being greater than zero in staged recipes.