### PR TITLE
Fixed bug with extra batch being run, unwrapped combined operators fo…

### DIFF
--- a/src/sparseml/pytorch/utils/module.py
+++ b/src/sparseml/pytorch/utils/module.py
@@ -693,6 +693,9 @@ class ModuleRunner(ABC):
         epoch_timer = time.time()
 
         for batch, data in data_iter:
+            if 0 < max_steps and batch >= max_steps:
+                break
+
             step_timer = time.time()
             batch_size = self._run_funcs.batch_size(data)  # type: int
 
@@ -750,9 +753,6 @@ class ModuleRunner(ABC):
 
             if results is not None:
                 results.append(batch_results, batch_size)
-
-            if 0 < max_steps <= batch:
-                break
 
         should_log = self._loggers and self._log_summary and results
         log_step = counter  # log under the counter step for the summaries


### PR DESCRIPTION
This bug was caused by a break statement being placed at the end the batch for loop, allowing an extra batch to be processed, which led to the epoch_num being miscalculated in later steps.

Test epoch -1/-1: 100%|| 8/8 [00:06<00:00,  1.19it/s]
Train epoch 0/15: 100%|| 1/1 [00:01<00:00,  1.25s/it]
Test epoch 0/15: 100%| 8/8 [00:01<00:00,  7.42it/s]
Train epoch 1/15: 100%|| 1/1 [00:00<00:00,  1.09it/s]
Test epoch 1/15: 100%| 8/8 [00:01<00:00,  7.53it/s]
Train epoch 2/15: 100%|| 1/1 [00:00<00:00,  1.46it/s]
**mask setter True (incorrect, should start on epoch 5)**
Train epoch 2/15: 100%|| 1/1 [00:00<00:00,  1.08it/s]
Test epoch 2/15: 100%| 8/8 [00:01<00:00,  6.72it/s]
Train epoch 3/15: 100%|| 1/1 [00:00<00:00,  1.08it/s]
Test epoch 3/15: 100%| 8/8 [00:01<00:00,  7.30it/s]
Train epoch 4/15: 100%|| 1/1 [00:01<00:00,  1.09s/it]
Test epoch 4/15: 100%| 8/8 [00:02<00:00,  3.13it/s]
Train epoch 5/15: 100%|| 1/1 [00:01<00:00,  1.50s/it]
Test epoch 5/15: 100%| 8/8 [00:01<00:00,  4.58it/s]
Train epoch 6/15: 100%|| 1/1 [00:00<00:00,  1.07it/s]
**pruning_end True (incorrect, should end on epoch 13)**
Train epoch 6/15: 100%|| 1/1 [00:02<00:00,  2.58s/it]
Test epoch 6/15: 100%| 8/8 [00:01<00:00,  4.55it/s]
Train epoch 7/15: 100%|| 1/1 [00:01<00:00,  1.26s/it]
Test epoch 7/15: 100%| 8/8 [00:01<00:00,  4.37it/s]
Train epoch 8/15: 100%|| 1/1 [00:01<00:00,  1.18s/it]
Test epoch 8/15: 100%| 8/8 [00:01<00:00,  4.39it/s]
Train epoch 9/15: 100%|| 1/1 [00:01<00:00,  1.17s/it]
Test epoch 9/15: 100%| 8/8 [00:01<00:00,  4.35it/s]
Train epoch 10/15: 100%|| 1/1 [00:01<00:00,  1.17s/it]
Test epoch 10/15: 100%|| 8/8 [00:01<00:00,  4.33it/s]
Train epoch 11/15: 100%|| 1/1 [00:01<00:00,  1.18s/it]
Test epoch 11/15: 100%|| 8/8 [00:01<00:00,  4.36it/s]
Train epoch 12/15: 100%|| 1/1 [00:01<00:00,  1.29s/it]
Test epoch 12/15: 100%|| 8/8 [00:01<00:00,  4.52it/s]
Train epoch 13/15: 100%|| 1/1 [00:01<00:00,  1.27s/it]
Test epoch 13/15: 100%|| 8/8 [00:01<00:00,  4.53it/s]
Train epoch 14/15: 100%|| 1/1 [00:01<00:00,  1.27s/it]
Test epoch 14/15: 100%|| 8/8 [00:01<00:00,  4.32it/s]
**mask setter False**

Now: 
Test epoch -1/-1: 100%|| 8/8 [00:06<00:00,  1.19it/s]
Train epoch 0/15: 100%|| 1/1 [00:01<00:00,  1.06s/it]
Test epoch 0/15: 100%|| 8/8 [00:01<00:00,  7.03it/s]
Train epoch 1/15: 100%|| 1/1 [00:00<00:00,  1.14it/s]
Test epoch 1/15: 100%|| 8/8 [00:01<00:00,  7.59it/s]
Train epoch 2/15: 100%|| 1/1 [00:00<00:00,  1.19it/s]
Test epoch 2/15: 100%|| 8/8 [00:01<00:00,  6.85it/s]
Train epoch 3/15: 100%|| 1/1 [00:00<00:00,  1.13it/s]
Test epoch 3/15: 100%|| 8/8 [00:01<00:00,  7.44it/s]
Train epoch 4/15: 100%|| 1/1 [00:00<00:00,  1.16it/s]
Test epoch 4/15: 100%|| 8/8 [00:01<00:00,  7.19it/s]
Train epoch 5/15:   0%|| 0/1 [00:00<?, ?it/s]
**mask setter True**
Train epoch 5/15: 100%|| 1/1 [00:00<00:00,  1.06it/s]
Test epoch 5/15: 100%|| 8/8 [00:01<00:00,  6.81it/s]
Train epoch 6/15: 100%|| 1/1 [00:00<00:00,  1.09it/s]
Test epoch 6/15: 100%|| 8/8 [00:01<00:00,  7.22it/s]
Train epoch 7/15: 100%|| 1/1 [00:00<00:00,  1.12it/s]
Test epoch 7/15: 100%|| 8/8 [00:01<00:00,  7.12it/s]
Train epoch 8/15: 100%|| 1/1 [00:00<00:00,  1.12it/s]
Test epoch 8/15: 100%|| 8/8 [00:01<00:00,  6.89it/s]
Train epoch 9/15: 100%|| 1/1 [00:00<00:00,  1.19it/s]
Train epoch 9/15: 100%|| 1/1 [00:01<00:00,  1.00s/it]
Test epoch 9/15: 100%|| 8/8 [00:02<00:00,  3.21it/s]
Train epoch 10/15: 100%|| 1/1 [00:01<00:00,  1.36s/it]
Test epoch 10/15: 100%|| 8/8 [00:01<00:00,  4.54it/s]
Train epoch 11/15: 100%|| 1/1 [00:01<00:00,  1.12s/it]
Test epoch 11/15: 100%|| 8/8 [00:01<00:00,  4.46it/s]
Train epoch 12/15: 100%|| 1/1 [00:01<00:00,  1.03s/it]
Test epoch 12/15: 100%|| 8/8 [00:01<00:00,  4.40it/s]
Train epoch 13/15:   0%|| 0/1 [00:00<?, ?it/s]
**pruning_end True**
Train epoch 13/15: 100%|| 1/1 [00:02<00:00,  2.36s/it]
Test epoch 13/15: 100%|| 8/8 [00:01<00:00,  4.36it/s]
Train epoch 14/15: 100%|| 1/1 [00:01<00:00,  1.02s/it]
Test epoch 14/15: 100%|| 8/8 [00:01<00:00,  4.40it/s]
**mask setter False**