### PR TITLE
Revert "[Yolov5] Update in yaml dataset scripts (#869)"

### DIFF
--- a/src/sparseml/yolov5/data/Argoverse.yaml
+++ b/src/sparseml/yolov5/data/Argoverse.yaml
@@ -56,7 +56,7 @@ download: |
 
 
   # Download
-  dir = Path('src/sparseml/yolov5/datasets/Argoverse')  # dataset root dir
+  dir = Path('datasets/Argoverse')  # dataset root dir
   urls = ['https://argoverse-hd.s3.us-east-2.amazonaws.com/Argoverse-HD-Full.zip']
   download(urls, dir=dir, delete=False)
 

--- a/src/sparseml/yolov5/data/GlobalWheat2020.yaml
+++ b/src/sparseml/yolov5/data/GlobalWheat2020.yaml
@@ -32,12 +32,11 @@ names: ['wheat_head']  # class names
 
 # Download script/URL (optional) ---------------------------------------------------------------------------------------
 download: |
-  from utils.general import download, Path, os
+  from utils.general import download, Path
 
 
   # Download
-  root_path = os.path.join("src", "sparseml", "yolov5")
-  dir = Path(os.path.join(root_path, yaml['path']))  # dataset root dir
+  dir = Path(yaml['path'])  # dataset root dir
   urls = ['https://zenodo.org/record/4298502/files/global-wheat-codalab-official.zip',
           'https://github.com/ultralytics/yolov5/releases/download/v1.0/GlobalWheat2020_labels.zip']
   download(urls, dir=dir)

--- a/src/sparseml/yolov5/data/Objects365.yaml
+++ b/src/sparseml/yolov5/data/Objects365.yaml
@@ -63,12 +63,11 @@ download: |
   from pycocotools.coco import COCO
   from tqdm import tqdm
 
-  from utils.general import Path, download, np, xyxy2xywhn, os
+  from utils.general import Path, download, np, xyxy2xywhn
 
 
   # Make Directories
-  root_path = os.path.join("src", "sparseml", "yolov5")
-  dir = Path(os.path.join(root_path, yaml['path']))  # dataset root dir
+  dir = Path(yaml['path'])  # dataset root dir
   for p in 'images', 'labels':
       (dir / p).mkdir(parents=True, exist_ok=True)
       for q in 'train', 'val':

--- a/src/sparseml/yolov5/data/SKU-110K.yaml
+++ b/src/sparseml/yolov5/data/SKU-110K.yaml
@@ -22,12 +22,11 @@ names: ['object']  # class names
 download: |
   import shutil
   from tqdm import tqdm
-  from utils.general import np, pd, Path, download, xyxy2xywh, os
+  from utils.general import np, pd, Path, download, xyxy2xywh
 
 
   # Download
-  root_path = os.path.join("src", "sparseml", "yolov5")
-  dir = Path(os.path.join(root_path, yaml['path']))  # dataset root dirr
+  dir = Path(yaml['path'])  # dataset root dir
   parent = Path(dir.parent)  # download dir
   urls = ['http://trax-geometry.s3.amazonaws.com/cvpr_challenge/SKU110K_fixed.tar.gz']
   download(urls, dir=parent, delete=False)

--- a/src/sparseml/yolov5/data/VOC.yaml
+++ b/src/sparseml/yolov5/data/VOC.yaml
@@ -30,7 +30,7 @@ download: |
   import xml.etree.ElementTree as ET
 
   from tqdm import tqdm
-  from utils.general import download, Path, os
+  from utils.general import download, Path
 
 
   def convert_label(path, lb_path, year, image_id):
@@ -57,8 +57,7 @@ download: |
 
 
   # Download
-  root_path = os.path.join("src", "sparseml", "yolov5")
-  dir = Path(os.path.join(root_path, yaml['path']))  # dataset root dirr
+  dir = Path(yaml['path'])  # dataset root dir
   url = 'https://github.com/ultralytics/yolov5/releases/download/v1.0/'
   urls = [url + 'VOCtrainval_06-Nov-2007.zip',  # 446MB, 5012 images
           url + 'VOCtest_06-Nov-2007.zip',  # 438MB, 4953 images

--- a/src/sparseml/yolov5/data/VisDrone.yaml
+++ b/src/sparseml/yolov5/data/VisDrone.yaml
@@ -49,8 +49,7 @@ download: |
 
 
   # Download
-  root_path = os.path.join("src", "sparseml", "yolov5")
-  dir = Path(os.path.join(root_path, yaml['path']))  # dataset root dirr
+  dir = Path(yaml['path'])  # dataset root dir
   urls = ['https://github.com/ultralytics/yolov5/releases/download/v1.0/VisDrone2019-DET-train.zip',
           'https://github.com/ultralytics/yolov5/releases/download/v1.0/VisDrone2019-DET-val.zip',
           'https://github.com/ultralytics/yolov5/releases/download/v1.0/VisDrone2019-DET-test-dev.zip',

--- a/src/sparseml/yolov5/data/coco.yaml
+++ b/src/sparseml/yolov5/data/coco.yaml
@@ -28,13 +28,12 @@ names: ['person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train', 't
 
 # Download script/URL (optional)
 download: |
-  from utils.general import download, Path, os
+  from utils.general import download, Path
 
 
   # Download labels
-  root_path = os.path.join("src", "sparseml", "yolov5")
   segments = False  # segment or box labels
-  dir = Path(os.path.join(root_path, yaml['path']))  # dataset root dir
+  dir = Path(yaml['path'])  # dataset root dir
   url = 'https://github.com/ultralytics/yolov5/releases/download/v1.0/'
   urls = [url + ('coco2017labels-segments.zip' if segments else 'coco2017labels.zip')]  # labels
   download(urls, dir=dir.parent)

--- a/src/sparseml/yolov5/data/xView.yaml
+++ b/src/sparseml/yolov5/data/xView.yaml
@@ -83,8 +83,7 @@ download: |
 
 
   # Download manually from https://challenge.xviewdataset.org
-  root_path = os.path.join("src", "sparseml", "yolov5")
-  dir = Path(os.path.join(root_path, yaml['path']))  # dataset root dirr
+  dir = Path(yaml['path'])  # dataset root dir
   # urls = ['https://d307kc0mrhucc3.cloudfront.net/train_labels.zip',  # train labels
   #         'https://d307kc0mrhucc3.cloudfront.net/train_images.zip',  # 15G, 847 train images
   #         'https://d307kc0mrhucc3.cloudfront.net/val_images.zip']  # 5G, 282 val images (no labels)


### PR DESCRIPTION
This PR reverts the path changes to the yaml dataset script, as the datasets will now be maintained in `./datasets` relative to the run directory, rather than relative to the `sparseml/yolov5` directory.