### PR TITLE
add .MAINTAINERS file and auto review assignment GHA workflow 

### DIFF
--- a/.MAINTAINERS
+++ b/.MAINTAINERS
@@ -1,0 +1,13 @@
+# list of active maintainers
+# uncommented maintainers will be included in code review triage
+# markurtz
+# mgoin
+# natuan
+bfineran
+# spacemanidol
+rahul-tuli
+KSGulin
+dbogunowicz
+# anmarques
+kylesayrs
+# eldarkurtic

--- a/.github/workflows/assign-review.yaml
+++ b/.github/workflows/assign-review.yaml
@@ -1,0 +1,27 @@
+name: Review Assign
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  assign:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch active from .MAINTAINERS
+        id: reviewers
+        run: >-
+          echo "::set-output name=REVIEWERS::$(
+            grep -v '^#' .MAINTAINERS |
+            paste -s -d, -
+          )"
+      - uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }}  # assign PR author to PR
+          reviewers: ${{ steps.reviewers.outputs.REVIEWERS }}
+          max-num-of-reviewers: 1  # randomly selects 1 reviewer
+          ready-comment: '<reviewers> assigned for review'
+          draft-keyword: wip  # will not assign reviewers until WIP removed from title

--- a/.github/workflows/assign-review.yaml
+++ b/.github/workflows/assign-review.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Fetch active from .MAINTAINERS
         id: reviewers
         run: >-


### PR DESCRIPTION
Adds a `.MAINTAINERS` file with list of the active repo maintainers.  Uncommented maintainers will be considered active for random PR review selection by the `assign-review` GHA workflow.

The workflow currently includes:
1. on PR open - assigns the PR opener as the assignee on the PR
2. on ready to review (PR not in draft mode and 'wip' not in PR title) - adds 1 random maintainer-reviewer as the PR reviewer 