### PR TITLE
Make global_sparsity prop serializable

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_base.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_base.py
@@ -222,6 +222,13 @@ class BasePruningModifier(ABC, ScheduledUpdateModifier):
         """
         return self._leave_enabled
 
+    @ModifierProp()
+    def global_sparsity(self) -> bool:
+        """
+        :return: value of global_sparsity that is passed to mask_creator methods
+        """
+        return self._global_sparsity
+
     @property
     def module_masks(self) -> Optional[ModuleParamPruningMask]:
         """
@@ -251,13 +258,6 @@ class BasePruningModifier(ABC, ScheduledUpdateModifier):
         :return: param scorer object used by this pruning algorithm
         """
         return self._scorer
-
-    @property
-    def global_sparsity(self) -> bool:
-        """
-        :return: value of global_sparsity that is passed to mask_creator methods
-        """
-        return self._global_sparsity
 
     @property
     def allow_reintroduction(self) -> bool:

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_constant.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_constant.py
@@ -159,3 +159,10 @@ class ConstantPruningModifier(BasePruningModifier, BaseConstantPruningModifier):
         immediately after or doing some other prune.
         """
         return self._leave_enabled
+
+    @ModifierProp(serializable=False)
+    def global_sparsity(self) -> bool:
+        """
+        :return: value of global_sparsity that is passed to mask_creator methods
+        """
+        return self._global_sparsity


### PR DESCRIPTION
`global_sparsity` is unused in ConstantPruningModifier so I had to explicitly make it non-serializable in this specific class.

Fixes https://github.com/neuralmagic/sparseml/issues/916
