### PR TITLE
Add 4  command line callables for yolact

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 recursive-include src/sparseml/yolov5 *.yaml *.sh
+recursive-include src/sparseml/yolact *.sh

--- a/setup.py
+++ b/setup.py
@@ -178,13 +178,16 @@ def _setup_entry_points() -> Dict:
         ]
     )
 
-    # object segmentation integration
+    # instance segmentation integration
+
+    yolact_top_level_callable = "sparseml.instance_segmentation.yolact"
+    yolact_scripts_path = "sparseml.yolact.scripts"
 
     entry_points["console_scripts"].extend(
         [
-            "sparseml.yolact.export_onnx=sparseml.yolact.scripts:export",
-            "sparseml.yolact.train=sparseml.yolact.scripts:train",
-            "sparseml.yolact.validation=sparseml.yolact.scripts:val",
+            f"{yolact_top_level_callable}.export_onnx={yolact_scripts_path}:export",
+            f"{yolact_top_level_callable}.train={yolact_scripts_path}:train",
+            f"{yolact_top_level_callable}.validation={yolact_scripts_path}:val",
         ]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ def _setup_entry_points() -> Dict:
 
     # instance segmentation integration
 
-    yolact_top_level_callable = "sparseml.instance_segmentation.yolact"
+    yolact_top_level_callable = "sparseml.yolact"
     yolact_scripts_path = "sparseml.yolact.scripts"
 
     entry_points["console_scripts"].extend(

--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,7 @@ def _setup_entry_points() -> Dict:
             f"{yolact_top_level_callable}.export_onnx={yolact_scripts_path}:export",
             f"{yolact_top_level_callable}.train={yolact_scripts_path}:train",
             f"{yolact_top_level_callable}.validation={yolact_scripts_path}:val",
+            f"{yolact_top_level_callable}.download={yolact_scripts_path}:download",
         ]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,16 @@ def _setup_entry_points() -> Dict:
         ]
     )
 
+    # object segmentation integration
+
+    entry_points["console_scripts"].extend(
+        [
+            "sparseml.yolact.export_onnx=sparseml.yolact.scripts:export",
+            "sparseml.yolact.train=sparseml.yolact.scripts:train",
+            "sparseml.yolact.validation=sparseml.yolact.scripts:val",
+        ]
+    )
+
     return entry_points
 
 

--- a/src/sparseml/yolact/COCO.sh
+++ b/src/sparseml/yolact/COCO.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Recommended Usage:$sh COCO.sh [DATA_DIRECTORY]
+
+start=`date +%s`
+
+# handle optional download dir
+if [ -z "$1" ]
+  then
+    # navigate to ./data
+    echo "navigating to ./data/ ..."
+    mkdir -p ./data
+    cd ./data/
+    mkdir -p ./coco
+    cd ./coco
+    mkdir -p ./images
+    mkdir -p ./annotations
+  else
+    # check if specified dir is valid
+    if [ ! -d $1 ]; then
+        echo $1 " is not a valid directory"
+        exit 0
+    fi
+    echo "navigating to " $1 " ..."
+    cd $1
+fi
+
+if [ ! -d images ]
+  then
+    mkdir -p ./images
+fi
+
+# Download the image data.
+cd ./images
+echo "Downloading MSCOCO train images ..."
+curl -LO http://images.cocodataset.org/zips/train2017.zip
+echo "Downloading MSCOCO val images ..."
+curl -LO http://images.cocodataset.org/zips/val2017.zip
+
+cd ../
+if [ ! -d annotations ]
+  then
+    mkdir -p ./annotations
+fi
+
+# Download the annotation data.
+cd ./annotations
+echo "Downloading MSCOCO train/val annotations ..."
+curl -LO http://images.cocodataset.org/annotations/annotations_trainval2014.zip
+curl -LO http://images.cocodataset.org/annotations/annotations_trainval2017.zip
+echo "Finished downloading. Now extracting ..."
+
+# Unzip data
+echo "Extracting train images ..."
+unzip -qqjd ../images ../images/train2017.zip
+echo "Extracting val images ..."
+unzip -qqjd ../images ../images/val2017.zip
+echo "Extracting annotations ..."
+unzip -qqd .. ./annotations_trainval2014.zip
+unzip -qqd .. ./annotations_trainval2017.zip
+
+echo "Removing zip files ..."
+rm ../images/train2017.zip
+rm ../images/val2017.zip
+rm ./annotations_trainval2014.zip
+rm ./annotations_trainval2017.zip
+
+
+end=`date +%s`
+runtime=$((end-start))
+
+echo "Completed in " $runtime " seconds"

--- a/src/sparseml/yolact/COCO.sh
+++ b/src/sparseml/yolact/COCO.sh
@@ -32,6 +32,7 @@ fi
 
 # Download the image data.
 cd ./images
+images_dir=$(pwd)
 echo "Downloading MSCOCO train images ..."
 curl -LO http://images.cocodataset.org/zips/train2017.zip
 echo "Downloading MSCOCO val images ..."
@@ -45,6 +46,7 @@ fi
 
 # Download the annotation data.
 cd ./annotations
+annotations_dir=$(pwd)
 echo "Downloading MSCOCO train/val annotations ..."
 curl -LO http://images.cocodataset.org/annotations/annotations_trainval2014.zip
 curl -LO http://images.cocodataset.org/annotations/annotations_trainval2017.zip
@@ -70,3 +72,6 @@ end=`date +%s`
 runtime=$((end-start))
 
 echo "Completed in " $runtime " seconds"
+echo "The annotation jsons were downloaded to ${annotations_dir}"
+echo "The train + validation images were downloaded to ${images_dir}"
+

--- a/src/sparseml/yolact/COCO_test.sh
+++ b/src/sparseml/yolact/COCO_test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+start=`date +%s`
+
+# handle optional download dir
+if [ -z "$1" ]
+  then
+    # navigate to ./data
+    echo "navigating to ./data/ ..."
+    mkdir -p ./data
+    cd ./data/
+    mkdir -p ./coco
+    cd ./coco
+    mkdir -p ./images
+    mkdir -p ./annotations
+  else
+    # check if specified dir is valid
+    if [ ! -d $1 ]; then
+        echo $1 " is not a valid directory"
+        exit 0
+    fi
+    echo "navigating to " $1 " ..."
+    cd $1
+fi
+
+if [ ! -d images ]
+  then
+    mkdir -p ./images
+fi
+
+# Download the image data.
+cd ./images
+echo "Downloading MSCOCO test images ..."
+curl -LO http://images.cocodataset.org/zips/test2017.zip
+
+cd ../
+if [ ! -d annotations ]
+  then
+    mkdir -p ./annotations
+fi
+
+# Download the annotation data.
+cd ./annotations
+echo "Downloading MSCOCO test info ..."
+curl -LO http://images.cocodataset.org/annotations/image_info_test2017.zip
+echo "Finished downloading. Now extracting ..."
+
+# Unzip data
+echo "Extracting test images ..."
+unzip -qqjd ../images ../images/test2017.zip
+echo "Extracting info ..."
+unzip -qqd .. ./image_info_test2017.zip
+
+echo "Removing zip files ..."
+rm ../images/test2017.zip
+rm ./image_info_test2017.zip
+
+
+end=`date +%s`
+runtime=$((end-start))
+
+echo "Completed in " $runtime " seconds"

--- a/src/sparseml/yolact/COCO_test.sh
+++ b/src/sparseml/yolact/COCO_test.sh
@@ -30,6 +30,7 @@ fi
 
 # Download the image data.
 cd ./images
+images_dir=$(pwd)
 echo "Downloading MSCOCO test images ..."
 curl -LO http://images.cocodataset.org/zips/test2017.zip
 
@@ -41,6 +42,7 @@ fi
 
 # Download the annotation data.
 cd ./annotations
+annotations_dir=$(pwd)
 echo "Downloading MSCOCO test info ..."
 curl -LO http://images.cocodataset.org/annotations/image_info_test2017.zip
 echo "Finished downloading. Now extracting ..."
@@ -60,3 +62,5 @@ end=`date +%s`
 runtime=$((end-start))
 
 echo "Completed in " $runtime " seconds"
+echo "The test annotation jsons were downloaded to ${annotations_dir}"
+echo "The test images were downloaded to ${images_dir}"

--- a/src/sparseml/yolact/__init__.py
+++ b/src/sparseml/yolact/__init__.py
@@ -56,7 +56,7 @@ def _autoinstall_dependency(dependency: _Dependency):
 
     if _os.getenv("NM_NO_AUTOINSTALL", False):
         _LOGGER.warning(
-            "Unable to import, skipping auto installation " "due to NM_NO_AUTOINSTALL"
+            "Unable to import, skipping auto installation due to NM_NO_AUTOINSTALL"
         )
         # skip any further checks
         return

--- a/src/sparseml/yolact/__init__.py
+++ b/src/sparseml/yolact/__init__.py
@@ -20,7 +20,6 @@ import importlib
 import logging as _logging
 from collections import namedtuple
 
-
 _LOGGER = _logging.getLogger(__name__)
 _NM_YOLACT_LINK_TEMPLATE = (
     "https://github.com/neuralmagic/yolact/releases/download/"
@@ -56,7 +55,8 @@ def _autoinstall_dependency(dependency: _Dependency):
 
     if _os.getenv("NM_NO_AUTOINSTALL", False):
         _LOGGER.warning(
-            "Unable to import, skipping auto installation " "due to NM_NO_AUTOINSTALL"
+            "Unable to import, skipping auto installation "
+            "due to NM_NO_AUTOINSTALL"
         )
         # skip any further checks
         return

--- a/src/sparseml/yolact/__init__.py
+++ b/src/sparseml/yolact/__init__.py
@@ -20,6 +20,7 @@ import importlib
 import logging as _logging
 from collections import namedtuple
 
+
 _LOGGER = _logging.getLogger(__name__)
 _NM_YOLACT_LINK_TEMPLATE = (
     "https://github.com/neuralmagic/yolact/releases/download/"
@@ -55,8 +56,7 @@ def _autoinstall_dependency(dependency: _Dependency):
 
     if _os.getenv("NM_NO_AUTOINSTALL", False):
         _LOGGER.warning(
-            "Unable to import, skipping auto installation "
-            "due to NM_NO_AUTOINSTALL"
+            "Unable to import, skipping auto installation " "due to NM_NO_AUTOINSTALL"
         )
         # skip any further checks
         return

--- a/src/sparseml/yolact/scripts.py
+++ b/src/sparseml/yolact/scripts.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+__all__ = [
+    "export",
+    "train",
+    "val",
+]
+
+
+def export():
+    from yolact.export import main as run_export
+
+    run_export()
+
+
+def train():
+    from yolact.train import main as run_train
+
+    run_train()
+
+
+def val():
+    from yolact.eval import main as run_val
+
+    run_val()

--- a/src/sparseml/yolact/scripts.py
+++ b/src/sparseml/yolact/scripts.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pathlib import Path
 
 import click
 
@@ -58,7 +59,7 @@ def download(test: bool = False):
 
     try:
 
-        yolact_folder = "src/sparseml/yolact"
+        yolact_folder = Path(_os.path.abspath(__file__)).parent.resolve()
         bash_script = "COCO_test.sh" if test else "COCO.sh"
         _subprocess.check_call(
             [

--- a/src/sparseml/yolact/scripts.py
+++ b/src/sparseml/yolact/scripts.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import click
+
 
 __all__ = [
     "export",
     "train",
     "val",
+    "download",
 ]
 
 
@@ -36,3 +39,37 @@ def val():
     from yolact.eval import main as run_val
 
     run_val()
+
+
+@click.command()
+@click.option(
+    "--test",
+    default=False,
+    is_flag=True,
+    show_default=True,
+    help="Download COCO test data",
+)
+def download(test: bool = False):
+    """
+    A command line callable to download training/test coco dataset for yolact
+
+    :param test: if True download test data else training + validation data
+    """
+    import os as _os
+    import subprocess as _subprocess
+
+    try:
+
+        yolact_folder = "src/sparseml/yolact"
+        bash_script = "COCO_test.sh" if test else "COCO.sh"
+        _subprocess.check_call(
+            [
+                "bash",
+                _os.path.join(yolact_folder, bash_script),
+            ]
+        )
+    except Exception as data_download_exception:
+        raise ValueError(
+            "Unable to download coco with the "
+            f"following exception {data_download_exception}"
+        )

--- a/src/sparseml/yolact/scripts.py
+++ b/src/sparseml/yolact/scripts.py
@@ -52,8 +52,6 @@ def val():
 def download(test: bool = False):
     """
     A command line callable to download training/test coco dataset for yolact
-
-    :param test: if True download test data else training + validation data
     """
     import os as _os
     import subprocess as _subprocess


### PR DESCRIPTION
This PR adds command line callables for yolact integration (On top of yolact-autoinstall)

Tests: Each of the scripts/callables were invoked with a `--help` option, to check auto installation of yolact wheel, along with invocation of correct scripts

Setup:
1. `git clone git@github.com:neuralmagic/sparseml.git`
2. `git checkout yolact-cli`
3. `pip install -e "./[torchvision]"`

- [X] Download train data, tested by building and installing a local wheel
```bash
❯ sparseml.yolact.download                                                                                                                                                                                                                          17:42:54
Downloading MSCOCO train images ...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  3 18.0G    3  677M    0     0  11.9M      0  0:25:47  0:00:56  0:24:51 12.0M

``` 

- [X] Download test data
```bash
❯ sparseml.yolact.download --test                                                                                                                                                                                                               17:53:20
Downloading MSCOCO test images ...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  3 6339M    3  201M    0     0  11.4M      0  0:09:12  0:00:17  0:08:55 11.7M
```

Quantization recipe used for testing `quant_small-recipe_yolact.yaml`

```yaml
---
# General Hyperparams
num_epochs: 1
init_lr: 0.001
num_quantization_epochs: 0.5
num_pruning_epochs: eval(num_epochs - num_quantization_epochs)
quantization_observer_end_target: 0.5

# Pruning Hyperparams
init_sparsity: 0.2
pruning_start_target: 0
pruning_end_target: 0.5
pruning_update_frequency: 0.2
mask_type: [1, 4]
prune_none_target_sparsity: 0.6
prune_low_target_sparsity: 0.7
prune_mid_target_sparsity: 0.8
prune_high_target_sparsity: 0.85

# quantization hyperparams

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: eval(num_epochs)

  # pruning
  - !SetWeightDecayModifier
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    weight_decay: 0.0005

  - !LearningRateFunctionModifier
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    end_epoch: eval(pruning_end_target * num_pruning_epochs)
    lr_func: linear
    init_lr: eval(init_lr)
    final_lr: eval(0.01 * init_lr)
  # quantization
  - !SetWeightDecayModifier
    start_epoch: eval(num_epochs - num_quantization_epochs)
    weight_decay: 0.0

  - !LearningRateFunctionModifier
    start_epoch: eval(num_epochs - num_quantization_epochs)
    end_epoch: eval(num_epochs)
    lr_func: linear
    init_lr: eval(0.01 * init_lr)
    final_lr: eval(0.001 * init_lr)

pruning_modifiers:
  - !GMPruningModifier
    params:
    - backbone.layers.0.1.conv1.0.weight
    - backbone.layers.0.1.conv2.0.weight
    - backbone.layers.1.0.0.weight
    - backbone.layers.1.1.conv1.0.weight
    - backbone.layers.1.1.conv2.0.weight
    - backbone.layers.1.2.conv1.0.weight
    - backbone.layers.1.2.conv2.0.weight

    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_none_target_sparsity)
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    end_epoch: eval(pruning_end_target * num_pruning_epochs)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)

  - !GMPruningModifier
    params:
      - backbone.layers.2.0.0.weight
      - backbone.layers.2.1.conv1.0.weight
      - backbone.layers.2.1.conv2.0.weight
      - backbone.layers.2.2.conv1.0.weight
      - backbone.layers.2.2.conv2.0.weight
      - backbone.layers.2.3.conv1.0.weight
      - backbone.layers.2.3.conv2.0.weight
      - backbone.layers.2.4.conv1.0.weight
      - backbone.layers.2.4.conv2.0.weight
      - backbone.layers.2.5.conv1.0.weight
      - backbone.layers.2.5.conv2.0.weight
      - backbone.layers.2.6.conv1.0.weight
      - backbone.layers.2.6.conv2.0.weight
      - backbone.layers.2.7.conv1.0.weight
      - backbone.layers.2.7.conv2.0.weight
      - backbone.layers.2.8.conv1.0.weight
      - backbone.layers.2.8.conv2.0.weight
    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_low_target_sparsity)
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    end_epoch: eval(pruning_end_target * num_pruning_epochs)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)

  - !GMPruningModifier
    params:
      - proto_net.0.weight
      - proto_net.2.weight
      - proto_net.4.weight
      - proto_net.8.weight
      - proto_net.10.weight
      - fpn.lat_layers.0.weight
      - fpn.lat_layers.1.weight
      - fpn.lat_layers.2.weight
      - fpn.pred_layers.0.weight
      - fpn.pred_layers.1.weight
      - fpn.pred_layers.2.weight
      - fpn.downsample_layers.0.weight
      - fpn.downsample_layers.1.weight
      - prediction_layers.0.upfeature.0.weight
      - prediction_layers.0.bbox_layer.weight
      - prediction_layers.0.conf_layer.weight
      - prediction_layers.0.mask_layer.weight
      - semantic_seg_conv.weight

    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_mid_target_sparsity)
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    end_epoch: eval(pruning_end_target * num_pruning_epochs)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)

  - !GMPruningModifier
    params:
      - backbone.layers.3.0.0.weight
      - backbone.layers.3.1.conv1.0.weight
      - backbone.layers.3.1.conv2.0.weight
      - backbone.layers.3.2.conv1.0.weight
      - backbone.layers.3.2.conv2.0.weight
      - backbone.layers.3.3.conv1.0.weight
      - backbone.layers.3.3.conv2.0.weight
      - backbone.layers.3.4.conv1.0.weight
      - backbone.layers.3.4.conv2.0.weight
      - backbone.layers.3.5.conv1.0.weight
      - backbone.layers.3.5.conv2.0.weight
      - backbone.layers.3.6.conv1.0.weight
      - backbone.layers.3.6.conv2.0.weight
      - backbone.layers.3.7.conv1.0.weight
      - backbone.layers.3.7.conv2.0.weight
      - backbone.layers.3.8.conv1.0.weight
      - backbone.layers.3.8.conv2.0.weight
      - backbone.layers.4.0.0.weight
      - backbone.layers.4.1.conv1.0.weight
      - backbone.layers.4.1.conv2.0.weight
      - backbone.layers.4.2.conv1.0.weight
      - backbone.layers.4.2.conv2.0.weight
      - backbone.layers.4.3.conv1.0.weight
      - backbone.layers.4.3.conv2.0.weight
      - backbone.layers.4.4.conv1.0.weight
      - backbone.layers.4.4.conv2.0.weight
    init_sparsity: eval(init_sparsity)
    final_sparsity: eval(prune_high_target_sparsity)
    start_epoch: eval(pruning_start_target * num_pruning_epochs)
    end_epoch: eval(pruning_end_target * num_pruning_epochs)
    update_frequency: eval(pruning_update_frequency)
    mask_type: eval(mask_type)

quantization_modifiers:
  - !QuantizationModifier
    start_epoch: eval(num_epochs - num_quantization_epochs)
    disable_quantization_observer_epoch: eval(num_epochs - (quantization_observer_end_target * num_quantization_epochs))
    freeze_bn_stats_epoch: eval(num_epochs - (quantization_observer_end_target * num_quantization_epochs))

```

- [X] Train Script
Test command:
```bash
❯ sparseml.yolact.train --resume \
zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none \
--recipe ./quant_small-recipe_yolact.yaml \
--train_info ~/datasets/coco/annotations/instances_train2017.json \
--validation_info ~/datasets/coco/annotations/instances_val2017.json \
--train_images ~/datasets/coco/images \
--validation_images ~/datasets/coco/images
```

Output(Truncated):
```bash
❯ sparseml.yolact.train --resume \
zoo:cv/segmentation/yolact-darknet53/pytorch/dbolya/coco/base-none \
--recipe ./quant_small-recipe_yolact.yaml \
--train_info ~/datasets/coco/annotations/instances_train2017.json \
--validation_info ~/datasets/coco/annotations/instances_val2017.json \
--train_images ~/datasets/coco/images \
--validation_images ~/datasets/coco/images
loading annotations into memory...
Done (t=11.89s)
creating index...
index created!
loading annotations into memory...
Done (t=13.56s)
creating index...
index created!
Resuming training, loading checkpoint /home/rahul/.cache/sparsezoo/9eb1f165-c111-4d33-8375-ae2db87866c1/pytorch/model.pth...
Begin training!

num epochs: 1
Steps to train: 14659
/home/rahul/virtual_environments/sparseml3.8/lib/python3.8/site-packages/yolact/utils/augmentations.py:309: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  mode = random.choice(self.sample_options)
/home/rahul/virtual_environments/sparseml3.8/lib/python3.8/site-packages/yolact/utils/augmentations.py:309: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  mode = random.choice(self.sample_options)
/home/rahul/virtual_environments/sparseml3.8/lib/python3.8/site-packages/yolact/utils/augmentations.py:309: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  mode = random.choice(self.sample_options)
/home/rahul/virtual_environments/sparseml3.8/lib/python3.8/site-packages/yolact/utils/augmentations.py:309: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  mode = random.choice(self.sample_options)
[  0]       0 || B: 1.272 | C: 1.371 | M: 2.387 | S: 0.110 | T: 5.139 || ETA: 0:00:00 || timer: 3.010
[  0]      10 || B: 1.519 | C: 2.153 | M: 2.517 | S: 0.341 | T: 6.529 || ETA: 1:42:38.587331 || timer: 0.401
[  0]      20 || B: 1.514 | C: 2.231 | M: 2.581 | S: 0.374 | T: 6.699 || ETA: 1:41:59.965052 || timer: 0.408
[  0]      30 || B: 1.653 | C: 2.292 | M: 2.707 | S: 0.393 | T: 7.044 || ETA: 1:41:26.940786 || timer: 0.437
[  0]      40 || B: 1.693 | C: 2.367 | M: 2.771 | S: 0.413 | T: 7.244 || ETA: 1:40:49.617044 || timer: 0.410
[  0]      50 || B: 1.723 | C: 2.306 | M: 2.775 | S: 0.441 | T: 7.246 || ETA: 1:40:42.956530 || timer: 0.419
[  0]      60 || B: 1.741 | C: 2.370 | M: 2.825 | S: 0.457 | T: 7.393 || ETA: 1:40:28.319297 || timer: 0.434
[  0]      70 || B: 1.743 | C: 2.440 | M: 2.829 | S: 0.467 | T: 7.479 || ETA: 1:40:10.551509 || timer: 0.411
[  0]      80 || B: 1.804 | C: 2.447 | M: 2.878 | S: 0.475 | T: 7.605 || ETA: 1:40:12.161766 || timer: 0.415
[  0]      90 || B: 1.793 | C: 2.483 | M: 2.889 | S: 0.489 | T: 7.654 || ETA: 1:40:02.372913 || timer: 0.407

```
Screen session for above command is in progress!

- [X] Export Script
The export flow was tested with an interrupted checkpoint with the following recipe:
`small-quant.yaml`
```yaml
num_epochs: &num_epochs 1

quantization_start_epoch: &quantization_start_epoch 0

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0.0
    end_epoch: *num_epochs

quantization_modifiers:
  - !QuantizationModifier
    start_epoch: *quantization_start_epoch
```
```bash
❯ sparseml.yolact.export_onnx --checkpoint ./yolact_darknet53_0_31_interrupt.pth
/home/rahul/virtual_environments/sparseml3.8/lib/python3.8/site-packages/yolact/yolact.py:223: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if self.last_img_size != (cfg._tmp_img_w, cfg._tmp_img_h):
INFO:root:Model checkpoint exported to yolact_darknet53_0_31_interrupt.onnx

```
the exported checkpoint was validated as follows

- [X] Eval Script
```bash
❯ sparseml.yolact.validation --trained_model ../sparseml/weights/latest/yolact_darknet53_0_31_interrupt.onnx --validation_info ~/datasets/coco/annotations/instances_val2017.json --validation_images ~/datasets/coco/images
loading annotations into memory...
Done (t=0.60s)
creating index...
index created!
DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. version: 1.0.1 (2b0116b5) (release) (optimized) (system=avx512, binary=avx512)
Loading model... Done.

Starting (10) Warm up iterations, with a batch of 1, this might take some time
Processing Images  ██████████████████████████████     10 /     10 (100.00%)
Warm up iterations (10) over, starting FPS calc with a batch of 1
Processing Images  ██████████████████████████████   4952 /   4952 (100.00%)     3.23 fps
Saving data...
Calculating mAP...

       |  all  |  .50  |  .55  |  .60  |  .65  |  .70  |  .75  |  .80  |  .85  |  .90  |  .95  |
-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
   box | 19.26 | 33.77 | 31.91 | 29.71 | 26.99 | 23.57 | 19.90 | 14.59 |  8.68 |  3.20 |  0.24 |
  mask | 17.68 | 30.83 | 28.92 | 26.83 | 24.32 | 21.27 | 17.68 | 13.83 |  8.95 |  3.81 |  0.39 |
-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+-------+
```