### PR TITLE
Cherry-pick ONNX export update into release 1.0

### DIFF
--- a/src/sparseml/version.py
+++ b/src/sparseml/version.py
@@ -19,7 +19,7 @@ Functionality for storing and setting the version info for SparseML
 from datetime import date
 
 
-version_base = "1.0.0"
+version_base = "1.0.1"
 is_release = False  # change to True to set the generated version as a release version
 
 


### PR DESCRIPTION
- Fix ONNX export for BERT models (removes quantization from identity branch of FFN block)
- Bumps version number up to 1.0.1