### PR TITLE
Add flaky decorator to integration tests

### DIFF
--- a/tests/integrations/base_tester.py
+++ b/tests/integrations/base_tester.py
@@ -37,6 +37,7 @@ import pytest
 import yaml
 from pydantic import BaseModel
 
+from flaky import flaky
 from tests.integrations.config import Config
 
 
@@ -248,6 +249,7 @@ def skip_inactive_stage(test):
     return wrapped_test
 
 
+@flaky(max_runs=2, min_passes=1)
 class BaseIntegrationTester:
     """
     Class from which integration test-holding classes should inherit. Tests defined here

--- a/tests/integrations/image_classification/test_image_classification.py
+++ b/tests/integrations/image_classification/test_image_classification.py
@@ -19,6 +19,7 @@ import onnx
 import pytest
 import torch
 
+from flaky import flaky
 from sparseml.pytorch.models import ModelRegistry
 from sparsezoo import Zoo
 from tests.integrations.base_tester import (
@@ -45,6 +46,7 @@ except Exception as e:
     deepsparse_error = e
 
 
+@flaky(max_runs=2, min_passes=1)
 class ImageClassificationManager(BaseIntegrationManager):
 
     command_stubs = {

--- a/tests/integrations/transformers/test_transformers.py
+++ b/tests/integrations/transformers/test_transformers.py
@@ -26,6 +26,7 @@ import torch
 from transformers import AutoConfig, AutoTokenizer
 from transformers.tokenization_utils_base import PaddingStrategy
 
+from flaky import flaky
 from sparseml.pytorch.optim.manager import ScheduledModifierManager
 from sparseml.transformers.export import load_task_model
 from sparseml.transformers.utils import SparseAutoModel
@@ -143,6 +144,7 @@ class TransformersManager(BaseIntegrationManager):
         pass  # not yet implemented
 
 
+@flaky(max_runs=2, min_passes=1)
 class TestTransformers(BaseIntegrationTester):
     @pytest.fixture(
         params=get_configs_with_cadence(

--- a/tests/integrations/yolov5/test_yolov5.py
+++ b/tests/integrations/yolov5/test_yolov5.py
@@ -20,6 +20,7 @@ import pandas as pd
 import pytest
 import torch
 
+from flaky import flaky
 from tests.integrations.base_tester import (
     BaseIntegrationManager,
     BaseIntegrationTester,
@@ -108,6 +109,7 @@ class Yolov5Manager(BaseIntegrationManager):
             self.save_dir.cleanup()
 
 
+@flaky(max_runs=2, min_passes=1)
 class TestYolov5(BaseIntegrationTester):
     @pytest.fixture(
         params=get_configs_with_cadence(


### PR DESCRIPTION
This PR wraps the integrations tests in a flaky decorator to avoid transient issues from failing checks. e.g. connection issues.