### PR TITLE
make sparseml Docker fix conditional

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu18.04 as base
 # Source: https://github.com/NVIDIA/nvidia-docker/issues/1632
 
 RUN if [ -f /etc/apt/sources.list.d/cuda.list ] ; then rm /etc/apt/sources.list.d/cuda.list ; fi
-RUN if [ -f /etc/apt/sources.list.d/nvidia-ml.list ] ; rm /etc/apt/sources.list.d/nvidia-ml.list ; fi
+RUN if [ -f /etc/apt/sources.list.d/nvidia-ml.list ] ; then rm /etc/apt/sources.list.d/nvidia-ml.list ; fi
 
 RUN : \
     && apt-get update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,11 @@ ARG CUDA_VERSION
 
 # Setup the base image & install dependencies
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu18.04 as base
+# As of 05/05/22 nvidia images are broken. Two lines below are a temporary fix.
+# Source: https://github.com/NVIDIA/nvidia-docker/issues/1632
+
+RUN if [ -f /etc/apt/sources.list.d/cuda.list ] ; then rm /etc/apt/sources.list.d/cuda.list ; fi
+RUN if [ -f /etc/apt/sources.list.d/nvidia-ml.list ] ; rm /etc/apt/sources.list.d/nvidia-ml.list ; fi
 
 RUN : \
     && apt-get update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,6 @@ ARG CUDA_VERSION
 
 # Setup the base image & install dependencies
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu18.04 as base
-# As of 05/05/22 nvidia images are broken. Two lines below are a temporary fix.
-# Source: https://github.com/NVIDIA/nvidia-docker/issues/1632
-
-RUN rm /etc/apt/sources.list.d/cuda.list
-RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 
 RUN : \
     && apt-get update \


### PR DESCRIPTION
the affected patch in the dockerfile is only relevant to the 11.4 container which causes file not found issues on the 10.2 build. this PR makes the patch optional pending the existence of the files

**test_plan**
build passes locally (second rm command gets a no such file error previously)