### PR TITLE
Setting max python version in setup.py to 3.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ setup(
     install_requires=_setup_install_requires(),
     extras_require=_setup_extras(),
     entry_points=_setup_entry_points(),
-    python_requires=">=3.6.0",
+    python_requires=">=3.6.0,<=3.9.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This will give an error like:
```
ERROR: Package 'sparseml-nightly' requires a different Python: 3.10.5 not in '<=3.9.0,>=3.6.0'
```
if someone tries to install with unsupported python version