### PR TITLE
Limit Python requires version to <3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ setup(
     install_requires=_setup_install_requires(),
     extras_require=_setup_extras(),
     entry_points=_setup_entry_points(),
-    python_requires=">=3.6.0",
+    python_requires=">=3.6.0,<3.10",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
The goal of this PR is to limit Python versions allowed in `setup.py` to supported versions,

Before this PR if a user tried to install `sparseml-nightly` from source using `Python3.10` the error message would be:

```bash
ERROR: Could not find a version that satisfies the requirement torch<=1.9.1,>=1.1.0; extra == "torchvision" (from sparseml-nightly[dev,torchvision]) (from versions: 1.11.0, 1.12.0)
ERROR: No matching distribution found for torch<=1.9.1,>=1.1.0; extra == "torchvision"
```
Which could be percieved as misleading,
After this PR we get an error message which is closer to the real error

```bash
  Using cached flake8-3.9.2-py2.py3-none-any.whl (73 kB)
Collecting wheel>=0.36.2
  Using cached wheel-0.37.1-py2.py3-none-any.whl (35 kB)
ERROR: Ignored the following versions that require a different python version: 1.6.2 Requires-Python >=3.7,<3.10; 1.6.3 Requires-Python >=3.7,<3.10; 1.7.0 Requires-Python >=3.7,<3.10; 1.7.0rc1 Requires-Python >=3.7,<3.10; 1.7.0rc2 Requires-Python >=3.7,<3.10; 1.7.1 Requires-Python >=3.7,<3.10
ERROR: Could not find a version that satisfies the requirement torch<=1.9.1,>=1.1.0; extra == "torchvision" (from sparseml-nightly[dev,torchvision]) (from versions: 1.11.0, 1.12.0)
ERROR: No matching distribution found for torch<=1.9.1,>=1.1.0; extra == "torchvision"

```