### PR TITLE
Changing click version dependency due to conflict with wandb

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ _deps = [
     "toposort>=1.0",
     "GPUtil>=1.4.0",
     "protobuf>=3.12.2,<4",
-    "click==8.0",
+    "click>7.0,!=8.0.0",
 ]
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}"]
 _deepsparse_deps = [


### PR DESCRIPTION
Changing the click dependency version to be the same as wandb's click version https://github.com/wandb/wandb/blob/0b8243f8f8b107ec18f4638cc5ab0abccd7315c2/requirements.txt#L1.

Wandb's requirements file states that 8.0 is broken, but I didn't not look into why this is.

Tested the following on python versions: 3.7, 3.8, 3.9

```bash
pip install ./sparsezoo ./sparseml ./deepsparse
pip install wandb
```