### PR TITLE
Fix IC integration tests

### DIFF
--- a/tests/integrations/image_classification/test_image_classification.py
+++ b/tests/integrations/image_classification/test_image_classification.py
@@ -75,7 +75,7 @@ class ImageClassificationManager(BaseIntegrationManager):
             self.expected_checkpoint_path = os.path.join(
                 train_args.save_dir,
                 train_args.model_tag,
-                "framework",
+                "training",
                 "model-one-shot.pth" if train_args.one_shot else "model.pth",
             )
 


### PR DESCRIPTION
Search for output model in ./training rather than ./framework