### PR TITLE
use correct zoo download dir param in onnx tests

### DIFF
--- a/src/sparseml/onnx/benchmark/info.py
+++ b/src/sparseml/onnx/benchmark/info.py
@@ -290,9 +290,11 @@ def load_model(model: Any, **kwargs) -> ModelProto:
         raise ValueError("Model must not be None type")
 
     if isinstance(model, str) and model.startswith("zoo:"):
-        model = Model(model)
-        if "path" in kwargs:
-            model.path = kwargs["path"]
+        model = (
+            Model(model, download_path=kwargs["path"])
+            if "path" in kwargs
+            else Model(model)
+        )
 
     if isinstance(model, Model):
         # default to the main onnx file for the model

--- a/tests/sparseml/onnx/benchmark/test_info.py
+++ b/tests/sparseml/onnx/benchmark/test_info.py
@@ -37,8 +37,7 @@ MOCK_BENCHMARK_RETURN_VALUE = 0.5
 @pytest.fixture(scope="module")
 def mobilenet_fixture() -> Model:
     with tempfile.TemporaryDirectory() as onnx_dir:
-        model = Model(TEST_STUB)
-        model.path = onnx_dir
+        model = Model(TEST_STUB, download_path=onnx_dir)
         yield model
 
 


### PR DESCRIPTION
previously failing due to an API change

**test_plan:**
unblocks unit tests locally