### PR TITLE
Fix IC quant model load issue

### DIFF
--- a/src/sparseml/pytorch/utils/model.py
+++ b/src/sparseml/pytorch/utils/model.py
@@ -80,7 +80,6 @@ def load_model(
     if path.startswith("zoo:"):
         path = download_framework_model_by_recipe_type(Model(path))
     model_dict = torch.load(path, map_location="cpu")
-    current_dict = model.state_dict()
     recipe = model_dict.get("recipe")
 
     if recipe:
@@ -90,6 +89,7 @@ def load_model(
         checkpoint_manager = ScheduledModifierManager.from_yaml(recipe)
         checkpoint_manager.apply_structure(module=model, epoch=epoch)
 
+    current_dict = model.state_dict()
     if "state_dict" in model_dict:
         model_dict = model_dict["state_dict"]
 


### PR DESCRIPTION
Currently, the IC flow can fail when exporting a quantized model. The failure happens upon model load and is introduced when layers to ignore are being processed, because the model state dict from being structure application is used for comparison. This simple fix solves the issue by moving the model state dict definition to after structure application.

Testing:
With the fix above, this autosparse command runs as expected:
`autosparse --task image_classification --dataset ~/data/imagenette-160  --base_model zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned90_quant-none --save_directory ./pytest_output --kwargs {'max_train_steps': 2, 'save_dir': './pytest_save'}"`

Automated testing - covered by intergrations tests