### PR TITLE
Using torch.linalg.vector_norm over norm

### DIFF
--- a/src/sparseml/pytorch/optim/mask_creator_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_creator_pruning.py
@@ -287,7 +287,7 @@ class GroupedPruningMaskCreator(UnstructuredPruningMaskCreator):
         """
         reduce_fn_name = reduce_fn_name.lower()
         if reduce_fn_name == "l2":
-            return torch.linalg.norm(input=tensor, dim=dim, keepdim=keepdim)
+            return torch.linalg.vector_norm(input=tensor, dim=dim, keepdim=keepdim)
         if reduce_fn_name == "mean":
             return torch.mean(input=tensor, dim=dim, keepdim=keepdim)
         if reduce_fn_name == "max":

--- a/src/sparseml/pytorch/sparsification/distillation/modifier_distillation.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_distillation.py
@@ -18,6 +18,7 @@ Modifier for performing model distillation
 
 
 import logging
+from collections.abc import Mapping
 from copy import deepcopy
 from typing import Any, Dict, Iterable, List, Optional, Union
 
@@ -387,7 +388,7 @@ class DistillationModifier(ScheduledUpdateModifier):
             distill_head_output_losses.append(
                 self._calc_distill_head_output_loss(student_outputs, teacher_outputs)
             )
-        elif isinstance(student_outputs, Dict):
+        elif isinstance(student_outputs, Mapping):
             for key in self._distill_output_keys or student_outputs:
                 distill_head_output_losses.append(
                     self._calc_distill_head_output_loss(

--- a/src/sparseml/pytorch/sparsification/distillation/modifier_distillation.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_distillation.py
@@ -18,7 +18,6 @@ Modifier for performing model distillation
 
 
 import logging
-from collections import Mapping
 from copy import deepcopy
 from typing import Any, Dict, Iterable, List, Optional, Union
 
@@ -388,7 +387,7 @@ class DistillationModifier(ScheduledUpdateModifier):
             distill_head_output_losses.append(
                 self._calc_distill_head_output_loss(student_outputs, teacher_outputs)
             )
-        elif isinstance(student_outputs, Mapping):
+        elif isinstance(student_outputs, Dict):
             for key in self._distill_output_keys or student_outputs:
                 distill_head_output_losses.append(
                     self._calc_distill_head_output_loss(

--- a/src/sparseml/pytorch/sparsification/pruning/mask_creator.py
+++ b/src/sparseml/pytorch/sparsification/pruning/mask_creator.py
@@ -290,7 +290,7 @@ class GroupedPruningMaskCreator(UnstructuredPruningMaskCreator):
         """
         reduce_fn_name = reduce_fn_name.lower()
         if reduce_fn_name == "l2":
-            return torch.linalg.norm(input=tensor, dim=dim, keepdim=keepdim)
+            return torch.linalg.vector_norm(input=tensor, dim=dim, keepdim=keepdim)
         if reduce_fn_name == "mean":
             return torch.mean(input=tensor, dim=dim, keepdim=keepdim)
         if reduce_fn_name == "max":


### PR DESCRIPTION
Progress on upgrades to torch 1.12. Main pr is #964.

Testing was done by running unit tests in python 3.10 and torch 1.12.