### PR TITLE
Let modifiers implement epoch adjustment when composing recipes

### DIFF
--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -238,36 +238,7 @@ class BaseManager(BaseObject):
 
             for additional_modifiers in additional_stages.values():
                 for additional_modifier in additional_modifiers:
-                    if (
-                        hasattr(additional_modifier, "end_epoch")
-                        and additional_modifier.end_epoch != -1
-                    ):
-                        # if end_epoch == -1, the .end_epoch is being
-                        # assumed implicitly and does not need to be
-                        # incremented
-                        additional_modifier.end_epoch += base_end_epoch
-                    if hasattr(additional_modifier, "start_epoch"):
-                        additional_modifier.start_epoch = max(
-                            0.0, additional_modifier.start_epoch
-                        )
-                        additional_modifier.start_epoch += base_end_epoch
-
-                    # increment epoch-dependent attributes
-                    for attr in dir(additional_modifier):
-                        if (
-                            "epoch" in attr
-                            and attr not in ("start_epoch", "end_epoch")
-                            and not attr.startswith("_")
-                            and not attr.startswith("__")
-                            and not callable(getattr(additional_modifier, attr))
-                            and getattr(additional_modifier, attr) is not None
-                        ):
-                            setattr(
-                                additional_modifier,
-                                attr,
-                                max(0.0, getattr(additional_modifier, attr))
-                                + base_end_epoch,
-                            )
+                    additional_modifier.advance_epochs(ref_start_epoch=base_end_epoch)
 
         combined_stages = base_stages
         combined_stages.update(additional_stages)

--- a/src/sparseml/optim/modifier.py
+++ b/src/sparseml/optim/modifier.py
@@ -685,6 +685,27 @@ class BaseScheduled(BaseObject):
         self._end_epoch = value
         self.validate_schedule()
 
+    def advance_epochs(self, ref_start_epoch: float = None):
+        """
+        Advance epoch attributes given a reference start epoch
+        Derived modifiers might override this method for their specific attributes
+
+        :param ref_start_epoch: the reference, i.e. new, start epoch
+        """
+        if ref_start_epoch is not None:
+            self._start_epoch = max(0.0, self._start_epoch) + ref_start_epoch
+            self._init_end = (
+                self._init_end + ref_start_epoch
+                if self._init_end != -1
+                else self._init_end
+            )
+            self._end_epoch = (
+                self._end_epoch + ref_start_epoch
+                if self._end_epoch != -1
+                else self._end_epoch
+            )
+            self.validate_schedule()
+
     def validate_schedule(self):
         """
         Validate the schedule values of the params for the current instance are valid

--- a/src/sparseml/pytorch/sparsification/modifier_thinning.py
+++ b/src/sparseml/pytorch/sparsification/modifier_thinning.py
@@ -107,6 +107,7 @@ class LayerThinningModifier(ScheduledModifier):
         return [SparsificationTypes.pruning, SparsificationTypes.structured]
 
     def _validate(self):
+        self.validate_schedule()
         if self._structure_type not in ["filter", "channel"]:
             raise ValueError(
                 f"invalid structure_type {self._structure_type}. "
@@ -234,6 +235,19 @@ class LayerThinningModifier(ScheduledModifier):
                 self._structure_type,
                 strict=self._strict,
             )
+
+    def advance_epochs(self, ref_start_epoch: float = None):
+        """
+        Advance epoch attributes given a reference start epoch
+
+        :param ref_start_epoch: the reference, i.e. new, start epoch
+        """
+        if ref_start_epoch is None:
+            return
+
+        super().advance_epochs(ref_start_epoch=ref_start_epoch)
+        self._update_epochs = [e + ref_start_epoch for e in self._update_epochs]
+        self._validate()
 
     def _check_update_epoch(self, epoch) -> bool:
         return any(

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -600,7 +600,7 @@ class QuantizationModifier(ScheduledModifier):
             self._freeze_bn_stats_epoch = (
                 max(0.0, self._freeze_bn_stats_epoch) + ref_start_epoch
             )
-        self.validate_schedule()
+        self._validate_params()
 
     def _check_quantization_update(
         self, module: Module, epoch: float, steps_per_epoch: int
@@ -797,6 +797,7 @@ class QuantizationModifier(ScheduledModifier):
                 submodule.qconfig = None
 
     def _validate_params(self):
+        self.validate_schedule()
         if (
             self._disable_quantization_observer_epoch is not None
             and self._disable_quantization_observer_epoch < self._start_epoch

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -581,6 +581,27 @@ class QuantizationModifier(ScheduledModifier):
 
         return pending
 
+    def advance_epochs(self, ref_start_epoch: float = None):
+        """
+        Advance epoch attributes given a reference start epoch
+
+        :param ref_start_epoch: the reference, i.e. new, start epoch
+        """
+        if ref_start_epoch is None:
+            return
+
+        super().advance_epochs(ref_start_epoch=ref_start_epoch)
+
+        if self._disable_quantization_observer_epoch is not None:
+            self._disable_quantization_observer_epoch = (
+                max(0.0, self._disable_quantization_observer_epoch) + ref_start_epoch
+            )
+        if self._freeze_bn_stats_epoch is not None:
+            self._freeze_bn_stats_epoch = (
+                max(0.0, self._freeze_bn_stats_epoch) + ref_start_epoch
+            )
+        self.validate_schedule()
+
     def _check_quantization_update(
         self, module: Module, epoch: float, steps_per_epoch: int
     ):

--- a/tests/sparseml/pytorch/optim/test_manager.py
+++ b/tests/sparseml/pytorch/optim/test_manager.py
@@ -435,6 +435,8 @@ pruning_modifiers:
 quantization_modifiers:
   - !QuantizationModifier
     start_epoch: 50
+    disable_quantization_observer_epoch: 51
+    freeze_bn_stats_epoch: 51
     submodules: ['model.0']
 """
 
@@ -456,8 +458,10 @@ stage_0:
   
       - !QuantizationModifier
           activation_bits: 8
+          disable_quantization_observer_epoch: 51
           end_epoch: 52
           exclude_batchnorm: True
+          freeze_bn_stats_epoch: 51
           model_fuse_fn_name: conv_bn_relus
           quantize_conv_activations: True
           quantize_embedding_activations: True
@@ -492,8 +496,10 @@ stage_1:
   
       - !QuantizationModifier
           activation_bits: 8
+          disable_quantization_observer_epoch: 103
           end_epoch: -1.0
           exclude_batchnorm: True
+          freeze_bn_stats_epoch: 103
           model_fuse_fn_name: conv_bn_relus
           quantize_conv_activations: True
           quantize_embedding_activations: True
@@ -694,7 +700,6 @@ def test_lifecycle_manager_staged(
                 base_recipe=checkpoint_recipe,
                 additional_recipe=recipe_manager,
             )
-
     final_recipe = str(recipe_manager)
     assert final_recipe == expected_recipe
 


### PR DESCRIPTION
This change simplifies the manager's recipe combination, also fixes a bug that the current code at the manager level does not account for all epoch related attributes from the quantization modifiers. 