### PR TITLE
don't save epoch on IC one_shot checkpoints

### DIFF
--- a/src/sparseml/pytorch/image_classification/train.py
+++ b/src/sparseml/pytorch/image_classification/train.py
@@ -785,7 +785,7 @@ def train(
             checkpoint_manager=trainer.checkpoint_manager,
             save_name=save_name,
             save_dir=save_dir,
-            epoch=trainer.epoch - 1,
+            epoch=trainer.epoch - 1 if not trainer.one_shot else None,
             val_res=val_res,
         )
 

--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -409,7 +409,7 @@ def save_model_training(
     manager: BaseManager,
     save_name: str,
     save_dir: str,
-    epoch: int,
+    epoch: Optional[int],
     val_res: Optional[ModuleRunResults],
     checkpoint_manager: Optional[BaseManager] = None,
     arch_key: Optional[str] = None,
@@ -420,7 +420,7 @@ def save_model_training(
     :param manager: manager created from the training recipe
     :param save_name: name to save model to
     :param save_dir: directory to save results in
-    :param epoch: integer representing umber of epochs to
+    :param epoch: integer representing epoch at which model is saved at
     :param val_res: results from validation run
     :param checkpoint_manager: manager created from the checkpoint recipe
     :param arch_key: if provided, the `arch_key` will be saved in the


### PR DESCRIPTION
default saved epoch for `one_shot` in the IC flows is `-1` due to `Trainer` initialization. This will cause issues on model load since the checkpoint recipe will be initialized to epoch `-1`, not applying any of the optimizations. This PR removes saving the epoch for one shot models so the entire one shot recipe will be applied on checkpoint load.

**test_plan:**
@anmarques to verify