### PR TITLE
Fix typo in bert tutorial

### DIFF
--- a/integrations/huggingface-transformers/tutorials/sparsifying_bert_using_recipes.md
+++ b/integrations/huggingface-transformers/tutorials/sparsifying_bert_using_recipes.md
@@ -134,7 +134,7 @@ The following command evaluates a pruned model and converts it to the ONNX forma
 
 ```bash
 sparseml.transformers.export_onnx \
-  --task question-question
+  --task question-question \
   --model_path MODELS_DIR/bert-base-12layers_prune80
 ```
 

--- a/integrations/huggingface-transformers/tutorials/sparsifying_bert_using_recipes.md
+++ b/integrations/huggingface-transformers/tutorials/sparsifying_bert_using_recipes.md
@@ -134,7 +134,7 @@ The following command evaluates a pruned model and converts it to the ONNX forma
 
 ```bash
 sparseml.transformers.export_onnx \
-  --task question-question \
+  --task question-answering \
   --model_path MODELS_DIR/bert-base-12layers_prune80
 ```
 


### PR DESCRIPTION
This PR add a missing `\` in sparsifying bert tutorial