### PR TITLE
add export instructions to classification_sparse_transfer_learning_tutorial.md

### DIFF
--- a/integrations/pytorch/tutorials/classification_sparse_transfer_learning_tutorial.md
+++ b/integrations/pytorch/tutorials/classification_sparse_transfer_learning_tutorial.md
@@ -106,6 +106,7 @@ sparseml.image_classification.train \
     --loader-num-workers 0 \
     --optim Adam \
     --optim-args '{}' \
+    --save-dir sparse-transfer-models
     --model-tag mobilenet-imagenette-sparse-transfer-learned
 ```
 The `--checkpoint-path` argument can take in path to a model checkpoint, or a SpareZoo model stub,
@@ -114,7 +115,18 @@ the `checkpoint-path` can be set to `zoo` for auto-downloading corresponding che
 To learn more about the usage, run script with `-h` option to see help. 
 
 The script automatically saves model checkpoints after each epoch and reports the validation loss along with layer sparsities. 
-The model is saved in [ONNX](https://onnx.ai/) format and can be loaded later for inference or other experiments.
+
+### ONNX Export
+The model can be saved to [ONNX](https://onnx.ai/) format to be loaded later for inference or other experiments using
+the `sparseml.image_classification.export` script.
+
+```
+sparseml.image_classification.export_onnx \
+    --arch-key mobilenet \
+    --dataset imagenette \
+    --dataset-path /PATH/TO/IMAGENETTE \
+    --checkpoint-path sparse-transfer-models/mobilenet-imagenette-sparse-transfer-learned/pytorch/model.pth
+```
 
 ## Wrap-Up
 

--- a/integrations/pytorch/tutorials/classification_sparse_transfer_learning_tutorial.md
+++ b/integrations/pytorch/tutorials/classification_sparse_transfer_learning_tutorial.md
@@ -118,7 +118,7 @@ The script automatically saves model checkpoints after each epoch and reports th
 
 ### ONNX Export
 The model can be saved to [ONNX](https://onnx.ai/) format to be loaded later for inference or other experiments using
-the `sparseml.image_classification.export` script.
+the `sparseml.image_classification.export_onnx` script.
 
 ```
 sparseml.image_classification.export_onnx \

--- a/integrations/pytorch/tutorials/sparsifying_pytorch_models_using_recipes.md
+++ b/integrations/pytorch/tutorials/sparsifying_pytorch_models_using_recipes.md
@@ -113,7 +113,7 @@ After, the training pruned model and training log files will be found under
 an inference engine such as [DeepSparse](https://github.com/neuralmagic/deepsparse), the pruned model must be
 exported to the ONNX format.
 
-This step can be completed using `sparseml/integrations/pytorch/export.py` script which uses the
+This step can be completed using `sparseml.image_classificaiton.export` script which uses the
 `sparseml.pytorch.utils.ModuleExporter` class. Run the script with `--help` option to see usage.
 
 The DeepSparse Engine is explicitly coded to support running sparsified models for significant improvements in

--- a/integrations/pytorch/tutorials/sparsifying_pytorch_models_using_recipes.md
+++ b/integrations/pytorch/tutorials/sparsifying_pytorch_models_using_recipes.md
@@ -113,7 +113,7 @@ After, the training pruned model and training log files will be found under
 an inference engine such as [DeepSparse](https://github.com/neuralmagic/deepsparse), the pruned model must be
 exported to the ONNX format.
 
-This step can be completed using `sparseml.image_classificaiton.export` script which uses the
+This step can be completed using `sparseml.image_classificaiton.export_onnx` script which uses the
 `sparseml.pytorch.utils.ModuleExporter` class. Run the script with `--help` option to see usage.
 
 The DeepSparse Engine is explicitly coded to support running sparsified models for significant improvements in


### PR DESCRIPTION
this tutorial mentions onnx export available for a model, however the onnx export was broken into a separate script a few releases ago. updating documentation to include an export script example

also update sparsifying_pytorch_models_using_recipes.md