### PR TITLE
Relax click dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ _deps = [
     "toposort>=1.0",
     "GPUtil>=1.4.0",
     "protobuf>=3.12.2,<4",
-    "click==8.0",
+    "click~=8.0.0",
 ]
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}"]
 _deepsparse_deps = [


### PR DESCRIPTION
Because click~=8.0.0 is explicitly not allowed by wandb, this PR allows minor version updates to click.

Tested by testing with dev dependencies (black) and the following command
sparseml.image_classification.pr_sensitivity \
    --arch-key ssd300_resnet50 --dataset coco \
    --dataset-path ~/datasets/coco-detection