### PR TITLE
Add matching for GPT layers

### DIFF
--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -56,6 +56,14 @@ except Exception as _err:
     quant_conv3d_err = _err
     QATConv3d = None
 
+
+try:
+    from transformers.modeling_utils import Conv1D as GPTConv1D
+except Exception as _err:
+    gpt_conv1d_err = _err
+    GPTConv1D = None
+
+
 __all__ = [
     "default_device",
     "device_of",
@@ -761,7 +769,9 @@ def get_conv_layers(module: Module) -> Dict[str, Module]:
     :return: a list of all the conv layers in the module
     """
     return {
-        name: mod for name, mod in module.named_modules() if isinstance(mod, _ConvNd)
+        name: mod
+        for name, mod in module.named_modules()
+        if (isinstance(mod, _ConvNd) or (GPTConv1D and isinstance(mod, GPTConv1D)))
     }
 
 
@@ -790,6 +800,7 @@ def get_prunable_layers(module: Module) -> List[Tuple[str, Module]]:
             or (QATLinear and isinstance(mod, QATLinear))
             or (QATConv2d and isinstance(mod, QATConv2d))
             or (QATConv3d and isinstance(mod, QATConv3d))
+            or (GPTConv1D and isinstance(mod, GPTConv1D))
         )
     ]
 


### PR DESCRIPTION
All layers in GPT-style models are implemented as custom `Conv1D` layers (see https://github.com/huggingface/transformers/blob/c60dd98e87373e7f0f5af29f3d49411c2e81fb69/src/transformers/pytorch_utils.py#L92) and thus are missed when checking for instances of `nn.Linear` or `nn.ConvNd`