### PR TITLE
[image classification] bug fix - use full zoo stub prefix to determine zoo checkpoint

### DIFF
--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -332,7 +332,7 @@ class ImageClassificationTrainer(Trainer):
         )
 
     def _setup_checkpoint_manager(self):
-        if self.checkpoint_path and self.checkpoint_path.startswith("zoo"):
+        if self.checkpoint_path and self.checkpoint_path.startswith("zoo:"):
             zoo_model = Model(self.checkpoint_path)
             self.checkpoint_path = download_framework_model_by_recipe_type(zoo_model)
 


### PR DESCRIPTION
prior to this fix, IC trainer would recognize any checkpoint starting with "zoo" as a stub, this causes issues if a local path starts with zoo. this PR fixes the issue by matching to the full zoo prefix "zoo:"