### PR TITLE
Fix max_train_samples, stratified dataset split

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ _deps = [
     "pydantic>=1.5.0",
     "requests>=2.0.0",
     "scikit-image>=0.15.0",
+    "scikit-learn>=1.0.2",
     "scipy>=1.0.0",
     "tqdm>=4.0.0",
     "toposort>=1.0",


### PR DESCRIPTION
Fix max_train_samples, max_eval_samples for train/val split from using validation_ratio.

Fix stratified split (used currently for IMDB) when the datasets package does not support this feature. Keep the original code for reproducibility of shipped IMDB models.

This is to resolve the ticket: https://app.asana.com/0/1201652400520766/1202932644760687/f