### PR TITLE
Update recipe arg overwrite to support list types

### DIFF
--- a/src/sparseml/optim/helpers.py
+++ b/src/sparseml/optim/helpers.py
@@ -255,7 +255,7 @@ def _update_recipe_variable(var_name: str, var_value, container):
     key_found = False
 
     for key, value in container.items():
-        if not isinstance(value, list) and not all(
+        if not isinstance(value, list) or not all(
             [isinstance(val, dict) for val in value]
         ):
             if var_name == key:

--- a/src/sparseml/optim/helpers.py
+++ b/src/sparseml/optim/helpers.py
@@ -256,7 +256,7 @@ def _update_recipe_variable(var_name: str, var_value, container):
 
     for key, value in container.items():
         if not isinstance(value, list) or not all(
-            [isinstance(val, dict) for val in value]
+            isinstance(val, dict) for val in value
         ):
             if var_name == key:
                 container[var_name] = var_value

--- a/src/sparseml/optim/helpers.py
+++ b/src/sparseml/optim/helpers.py
@@ -255,7 +255,9 @@ def _update_recipe_variable(var_name: str, var_value, container):
     key_found = False
 
     for key, value in container.items():
-        if not isinstance(value, list):
+        if not isinstance(value, list) and not all(
+            [isinstance(val, dict) for val in value]
+        ):
             if var_name == key:
                 container[var_name] = var_value
                 key_found = True

--- a/tests/sparseml/optim/test_helpers.py
+++ b/tests/sparseml/optim/test_helpers.py
@@ -238,6 +238,7 @@ pruning_start_epoch: eval(num_epochs * 0.2)
 pruning_end_epoch: eval(num_epochs * 0.8)
 init_sparsity: 0.2
 num_pruning_epochs: 6
+pruning_mask_type: [1, 4]
 
 modifiers:
     - !EpochRangeModifier
@@ -250,7 +251,7 @@ modifiers:
         init_sparsity: eval(init_sparsity)
         inter_func: cubic
         leave_enabled: True
-        mask_type: [1, 4]
+        mask_type: eval(pruning_mask_type)
         params: __ALL_PRUNABLE__
         start_epoch: eval(pruning_start_epoch)
         update_frequency: 0.01
@@ -262,6 +263,7 @@ pruning_end_epoch: eval(pruning_start_epoch + num_pruning_epochs)
 pruning_start_epoch: eval(num_epochs * 0.2)
 num_pruning_epochs: 6
 init_sparsity: 0.2
+pruning_mask_type: [1, 4]
 
 modifiers:
     - !EpochRangeModifier
@@ -274,7 +276,7 @@ modifiers:
         init_sparsity: eval(init_sparsity)
         inter_func: cubic
         leave_enabled: True
-        mask_type: [1, 4]
+        mask_type: eval(pruning_mask_type)
         params: __ALL_PRUNABLE__
         start_epoch: eval(pruning_start_epoch)
         update_frequency: 0.01
@@ -286,6 +288,7 @@ init_sparsity: 0.2
 pruning_start_epoch: 2.0
 pruning_end_epoch: 8.0
 num_pruning_epochs: 6
+pruning_mask_type: [1, 4]
 
 modifiers:
 - !EpochRangeModifier


### PR DESCRIPTION
Currently, utilizing `--recipe_args` with a recipe that has a [2, 4] mask or a list-valued entry for any of the fields, will result in an error. This is because the recipe update logic makes the assumption that any list-valued entry is a list of modifiers (represented by dictionaries). This PR fixes this with a minor logic change.

**Testing**
```bash
sparseml.yolov5.train --cfg models_v5.0/yolov5l.yaml --recipe-args '{\"quantization_start_epoch\":1}' --recipe recipes/test_recipe.md
```
Where `recipes/test_recipe.md` is

```yaml
---
# General Hyperparams
init_lr: 0.01
weights_warmup_lr: 0

# Pruning Hyperparams
pruning_update_frequency: 0.5
mask_type: [1, 4]

# Quantization Hyperparams
quantization_start_epoch: 120

training_modifiers:
  - !LearningRateFunctionModifier
    start_epoch: 0
    end_epoch: 3
    lr_func: linear
    init_lr: eval(weights_warmup_lr)
    final_lr: eval(init_lr)
    param_groups: [0, 1]
        
quantization_modifiers:
  - !QuantizationModifier
    start_epoch: eval(quantization_start_epoch)
---
```