### PR TITLE
Add entrypoint for `sparseml.recipe_template`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -194,6 +194,12 @@ def _setup_entry_points() -> Dict:
         ]
     )
 
+    # recipe_template entrypoint
+
+    entry_points["console_scripts"].append(
+        "sparseml.recipe_tempalte=sparseml.recipe_template.cli.main"
+    )
+
     return entry_points
 
 

--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,7 @@ def _setup_entry_points() -> Dict:
     # recipe_template entrypoint
 
     entry_points["console_scripts"].append(
-        "sparseml.recipe_tempalte=sparseml.recipe_template.cli.main"
+        "sparseml.recipe_template=sparseml.recipe_template.cli:main"
     )
 
     return entry_points

--- a/src/sparseml/__init__.py
+++ b/src/sparseml/__init__.py
@@ -53,5 +53,9 @@ try:
     )
 except Exception as err:
     print(
-        f"Need sparsezoo version above 0.9.0 to run Neural Magic's latest-version check\n{err}"
+        f"Need sparsezoo version above 0.9.0 to run Neural Magic's latest-version "
+        f"check\n{err}"
     )
+
+from . import recipe_template as recipe_template_module
+from .recipe_template import recipe_template

--- a/src/sparseml/recipe_template/__init__.py
+++ b/src/sparseml/recipe_template/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa
+
+from .main import recipe_template

--- a/src/sparseml/recipe_template/cli.py
+++ b/src/sparseml/recipe_template/cli.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sparseml import recipe_template
+
+
+def main(*args, **kwargs):
+    """
+    Driver function for sparseml.recipe_template cli
+    """
+    recipe = recipe_template(*args, **kwargs)
+    return recipe
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sparseml/recipe_template/main.py
+++ b/src/sparseml/recipe_template/main.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    "recipe_template",
+]
+
+
+def recipe_template(*args, **kwargs) -> str:
+    """
+    Return a valid recipe given specified args and kwargs
+
+    # TODO: fill params
+    :return: A string representing a valid recipe
+    """
+
+    raise NotImplementedError

--- a/tests/sparseml/recipe_template/test_end_to_end.py
+++ b/tests/sparseml/recipe_template/test_end_to_end.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from subprocess import PIPE, CalledProcessError, run
+
+import pytest
+
+from sparseml import recipe_template
+
+
+def test_cli_entrypoint_invocation():
+    try:
+        output = run(["sparseml.recipe_template"], stdout=PIPE, stderr=PIPE)
+        assert (
+            "NotImplementedError" in output.stdout.decode()
+            or "NotImplementedError" in output.stderr.decode()
+        )
+    except CalledProcessError as e:
+        assert "NotImplementedError" in e.stderr.decode()
+
+
+def test_function_entrypoint():
+    with pytest.raises(NotImplementedError):
+        recipe_template()


### PR DESCRIPTION
The following PR adds an entrypoint to `sparseml.recipe_template` which can be used to generate a valid recipe, (The code for generating a recipe will be added in a follow-up PR)

Invoking the function(either via cli or directly) should throw a `NotImplementedError`

```python
>>> from sparseml import recipe_template, recipe_template_module
>>> type(recipe_template), type(recipe_template_module)
... (function, module)
```

```bash
$sparseml.recipe_template
Traceback (most recent call last):
  File "/home/virtual_environments/sparseml3.8/bin/sparseml.recipe_template", line 8, in <module>
    sys.exit(main())
  File "/home/projects/sparseml/src/sparseml/recipe_template/cli.py", line 22, in main
    recipe = recipe_template(*args, **kwargs)
  File "/home/projects/sparseml/src/sparseml/recipe_template/main.py", line 28, in recipe_template
    raise NotImplementedError
NotImplementedError

```