### PR TITLE
pin protobuf version for onnx 1.12 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ _deps = [
     "tqdm>=4.0.0",
     "toposort>=1.0",
     "GPUtil>=1.4.0",
-    "protobuf>=3.12.2,<4",
+    "protobuf>=3.12.2,<=3.20.1",
     "click~=8.0.0",
 ]
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}"]


### PR DESCRIPTION
onnx 1.12 restricts protobuf to a maximum version. this was causing conflicts in some recent builds. this PR aligns the target versions