### PR TITLE
Efficientnet v2

### DIFF
--- a/src/sparseml/pytorch/datasets/classification/imagenet.py
+++ b/src/sparseml/pytorch/datasets/classification/imagenet.py
@@ -31,7 +31,7 @@ except Exception as torchvision_error:
     ImageFolder = object  # default for constructor
     torchvision_import_error = torchvision_error
 
-from typing import Union, List
+from typing import List, Union
 
 from sparseml.pytorch.datasets.image_classification.ffcv_dataset import (
     FFCVImageNetDataset,

--- a/src/sparseml/pytorch/datasets/classification/imagenet.py
+++ b/src/sparseml/pytorch/datasets/classification/imagenet.py
@@ -31,7 +31,7 @@ except Exception as torchvision_error:
     ImageFolder = object  # default for constructor
     torchvision_import_error = torchvision_error
 
-from typing import Union
+from typing import Union, List
 
 from sparseml.pytorch.datasets.image_classification.ffcv_dataset import (
     FFCVImageNetDataset,
@@ -76,6 +76,8 @@ class ImageNetDataset(ImageFolder, FFCVImageNetDataset):
         image_size: int = 224,
         resize_scale: float = 1.143,
         resize_mode: Union[str, "transforms.InterpolationMode"] = "bilinear",
+        rgb_means: List[float] = IMAGENET_RGB_MEANS,
+        rgb_stds: List[float] = IMAGENET_RGB_STDS,
     ):
         if torchvision_import_error is not None:
             raise torchvision_import_error
@@ -103,7 +105,7 @@ class ImageNetDataset(ImageFolder, FFCVImageNetDataset):
         trans = [
             *init_trans,
             transforms.ToTensor(),
-            transforms.Normalize(mean=IMAGENET_RGB_MEANS, std=IMAGENET_RGB_STDS),
+            transforms.Normalize(mean=rgb_means, std=rgb_stds),
         ]
         root = os.path.join(
             os.path.abspath(os.path.expanduser(root)), "train" if train else "val"

--- a/src/sparseml/pytorch/models/classification/efficientnet.py
+++ b/src/sparseml/pytorch/models/classification/efficientnet.py
@@ -239,7 +239,7 @@ class _FusedInvertedBottleneckBlock(Module):
         kernel_size: int,
         expansion_ratio: int,
         stride: int,
-        bn_kwargs: Optional[Mapping] = None,
+        bn_kwargs: Optional[Mapping[str, Any]] = None,
     ):
         super().__init__()
         self._in_channels = in_channels

--- a/src/sparseml/pytorch/models/classification/efficientnet.py
+++ b/src/sparseml/pytorch/models/classification/efficientnet.py
@@ -1081,6 +1081,20 @@ def efficientnet_v2_s(
         bn_kwargs={"eps": 1.e-03}
     )
 
+
+@ModelRegistry.register(
+    key=["efficientnet_v2_m", "efficientnet_v2-m", "efficientnetv2-m", "efficientnetv2_m"],
+    input_shape=(3, 480, 480),
+    domain="cv",
+    sub_domain="classification",
+    architecture="efficientnet_v2",
+    sub_architecture="m",
+    default_dataset="imagenet",
+    default_desc="base",
+    def_ignore_error_tensors=["classifier.fc.weight", "classifier.fc.bias"],
+    desc_args={"optim-perf": ("se_mod", True)},
+)
+
 def efficientnet_v2_m(
         num_classes: int = 1000,
         class_type: str = "single",
@@ -1175,6 +1189,19 @@ def efficientnet_v2_m(
         dropout=dropout,
         bn_kwargs={"eps": 1.e-03}
     )
+
+@ModelRegistry.register(
+    key=["efficientnet_v2_l", "efficientnet_v2-l", "efficientnetv2-l", "efficientnetv2_l"],
+    input_shape=(3, 480, 480),
+    domain="cv",
+    sub_domain="classification",
+    architecture="efficientnet_v2",
+    sub_architecture="l",
+    default_dataset="imagenet",
+    default_desc="base",
+    def_ignore_error_tensors=["classifier.fc.weight", "classifier.fc.bias"],
+    desc_args={"optim-perf": ("se_mod", True)},
+)
 
 def efficientnet_v2_l(
         num_classes: int = 1000,

--- a/src/sparseml/pytorch/models/classification/efficientnet.py
+++ b/src/sparseml/pytorch/models/classification/efficientnet.py
@@ -19,7 +19,7 @@ Further info can be found in the paper `here <https://arxiv.org/abs/1905.11946>`
 
 import math
 from collections import OrderedDict
-from typing import List, Mapping, Optional, Tuple
+from typing import List, Mapping, Optional, Tuple, Any
 
 import torch
 from torch import Tensor
@@ -103,7 +103,7 @@ class _InvertedBottleneckBlock(Module):
         stride: int,
         se_ratio: Optional[float],
         se_mod: bool,
-        bn_kwargs: Optional[Mapping] = None,
+        bn_kwargs: Optional[Mapping[str, Any]] = None,
     ):
         super().__init__()
         self._in_channels = in_channels
@@ -326,7 +326,7 @@ class _Classifier(Module):
         classes: int,
         dropout: float,
         class_type: str,
-        bn_kwargs: Optional[Mapping],
+        bn_kwargs: Optional[Mapping[str, Any]] = None,
     ):
         super().__init__()
         self.conv = Conv2d(
@@ -423,7 +423,7 @@ class EfficientNet(Module):
         num_classes: int,
         class_type: str,
         dropout: float,
-        bn_kwargs: Optional[Mapping] = None,
+        bn_kwargs: Optional[Mapping[str, Any]] = None,
     ):
         super().__init__()
 
@@ -481,7 +481,7 @@ class EfficientNet(Module):
     @staticmethod
     def create_section(
         settings: EfficientNetSectionSettings,
-        bn_kwargs: Optional[Mapping],
+        bn_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> Sequential:
         assert settings.num_blocks > 0
 

--- a/src/sparseml/pytorch/models/classification/efficientnet.py
+++ b/src/sparseml/pytorch/models/classification/efficientnet.py
@@ -19,7 +19,7 @@ Further info can be found in the paper `here <https://arxiv.org/abs/1905.11946>`
 
 import math
 from collections import OrderedDict
-from typing import List, Mapping, Optional, Tuple, Union
+from typing import List, Mapping, Optional, Tuple
 
 import torch
 from torch import Tensor

--- a/src/sparseml/pytorch/models/classification/efficientnet.py
+++ b/src/sparseml/pytorch/models/classification/efficientnet.py
@@ -19,7 +19,7 @@ Further info can be found in the paper `here <https://arxiv.org/abs/1905.11946>`
 
 import math
 from collections import OrderedDict
-from typing import List, Mapping, Optional, Tuple, Any
+from typing import Any, List, Mapping, Optional, Tuple
 
 import torch
 from torch import Tensor

--- a/src/sparseml/pytorch/models/classification/efficientnet.py
+++ b/src/sparseml/pytorch/models/classification/efficientnet.py
@@ -1222,8 +1222,8 @@ def efficientnet_v2_l(
     sec_settings = [
         EfficientNetSectionSettings(
             num_blocks=4,
-            in_channels=43,
-            out_channels=43,
+            in_channels=32,
+            out_channels=32,
             kernel_size=3,
             expansion_ratio=1,
             stride=1,

--- a/src/sparseml/pytorch/models/classification/efficientnet.py
+++ b/src/sparseml/pytorch/models/classification/efficientnet.py
@@ -427,10 +427,7 @@ class EfficientNet(Module):
     ):
         super().__init__()
 
-        if bn_kwargs is None:
-            _bn_kwargs = {}
-        else:
-            _bn_kwargs = bn_kwargs
+        _bn_kwargs = bn_kwargs or {}
 
         self.input = Sequential(
             OrderedDict(

--- a/src/sparseml/pytorch/models/classification/efficientnet.py
+++ b/src/sparseml/pytorch/models/classification/efficientnet.py
@@ -320,6 +320,7 @@ class _Classifier(Module):
             classes: int,
             dropout: float,
             class_type: str,
+            bn_kwargs: Optional[Mapping],
     ):
         super().__init__()
         self.conv = Conv2d(
@@ -328,7 +329,9 @@ class _Classifier(Module):
             kernel_size=1,
             bias=False,
         )
-        self.bn = BatchNorm2d(num_features=out_channels)
+        if bn_kwargs is None:
+            bn_kwargs = {}
+        self.bn = BatchNorm2d(num_features=out_channels, **bn_kwargs)
         self.act = SiLU()
         self.pool = AdaptiveAvgPool2d(1)
         self.dropout = Dropout(p=dropout)
@@ -451,6 +454,7 @@ class EfficientNet(Module):
             classes=num_classes,
             dropout=dropout,
             class_type=class_type,
+            bn_kwargs=bn_kwargs,
         )
 
     def forward(self, inp: Tensor) -> Tuple[Tensor, Tensor]:


### PR DESCRIPTION
This PR adds support for EfficientNetV2 models. Summary of changes:
1. Creates the _FusedInvertedBottleneckBlock (used in v2 models)
2. Allows batchnorm configs to be passed to the EfficientNet class (need to set eps value)
3. Create definitions for efficientnet_v2_s, efficientnet_v2_m and efficientnet_v2_l
3. Adds support to set rgb_means and rgb_stds to dataset (needed for efficientnet_v2_l)

Torchvision checkpoints were ported to match these model definitions and accuracy was verified.