### PR TITLE
Add getters to fetch modifier info during recipe creation

### DIFF
--- a/src/sparseml/recipe_template/utils.py
+++ b/src/sparseml/recipe_template/utils.py
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 
+from torch.nn import Module
+
+from sparseml.optim import BaseModifier
 from sparseml.pytorch.sparsification import (
     ACDCPruningModifier,
-    GMPruningModifier,
-    MagnitudePruningModifier,
-    Modifier,
+    EpochRangeModifier, GMPruningModifier,
+    LearningRateFunctionModifier, MagnitudePruningModifier,
     QuantizationModifier,
 )
+from sparseml.pytorch.utils import get_prunable_layers, get_quantizable_layers
 from sparseml.sparsification import ModifierYAMLBuilder
-
 
 __all__ = [
     "ModifierBuildInfo",
@@ -43,7 +45,7 @@ class ModifierBuildInfo:
 
     def __init__(
         self,
-        modifier: Modifier,
+        modifier: BaseModifier,
         modifier_name: str = "mod",
         fields: Optional[Dict[str, Any]] = None,
     ):

--- a/src/sparseml/recipe_template/utils.py
+++ b/src/sparseml/recipe_template/utils.py
@@ -16,18 +16,20 @@ from typing import Any, Dict, List, Optional, Union
 
 from torch.nn import Module
 
-from sparseml.optim import BaseModifier
 from sparseml.pytorch.sparsification import (
     ACDCPruningModifier,
     EpochRangeModifier, GMPruningModifier,
     LearningRateFunctionModifier, MagnitudePruningModifier,
-    QuantizationModifier,
+    Modifier, QuantizationModifier,
 )
 from sparseml.pytorch.utils import get_prunable_layers, get_quantizable_layers
 from sparseml.sparsification import ModifierYAMLBuilder
 
 __all__ = [
     "ModifierBuildInfo",
+    "get_pruning_info",
+    "get_quantization_info",
+    "get_training_info",
 ]
 
 
@@ -45,7 +47,7 @@ class ModifierBuildInfo:
 
     def __init__(
         self,
-        modifier: BaseModifier,
+        modifier: Modifier,
         modifier_name: str = "mod",
         fields: Optional[Dict[str, Any]] = None,
     ):
@@ -144,3 +146,107 @@ _QUANTIZATION_MODIFIER_INFO_REGISTRY = {
         },
     ),
 }
+
+
+# getters
+
+def get_quantization_info(
+    quantization: Union[str, bool] = False,
+    target: str = "vnni",
+    model: Optional[Module] = None,
+) -> List[ModifierBuildInfo]:
+    """
+    :param quantization: Union[str, bool] flag, if "true" or `True` then quantization
+        info will be added, else not.
+    :param target: A str representing the target deployment hardware. defaults to
+        `vnni`, can also be set to `tensorrt`
+    :param model: An Optional instantiated torch module, that needs to be quantized
+    :returns: a List[ModifierBuildInfo] containing quantization info if any
+    """
+    if isinstance(quantization, bool):
+        quantization = str(quantization)
+
+    quantization_info = _QUANTIZATION_MODIFIER_INFO_REGISTRY.get(quantization.lower())
+    if quantization_info is None:
+        return []
+
+    quantization_info.update({"tensorrt": target == "tensorrt"})
+
+    if model:
+        quantizable_layers = [name for name, _ in get_quantizable_layers(module=model)]
+        quantization_info.update({"submodules": quantizable_layers})
+
+    return [quantization_info]
+
+
+def get_pruning_info(
+    pruning: Union[str, bool] = False,
+    mask_type: str = "unstructured",
+    global_sparsity: bool = False,
+    model: Optional[Module] = None,
+) -> List[ModifierBuildInfo]:
+    """
+    :param pruning: Union[str, bool] flag, if "true" or `True` then pruning
+        info will be added, can also be set to `acdc`, or `gmp`.
+    :param mask_type: A str representing the mask type for pruning modifiers,
+        defaults to "unstructured", can be set to 4-block for `vnni` specific
+        quantization
+    :param global_sparsity: if set then induce sparsity globally rather than layer wise
+    :param model: An Optional instantiated torch module, that needs to be quantized
+    :returns: a List[ModifierBuildInfo] containing pruning info if any
+    """
+    if isinstance(pruning, bool):
+        pruning = str(pruning)
+
+    modifier_info = _PRUNING_MODIFIER_INFO_REGISTRY.get(pruning.lower())
+    if modifier_info is None:
+        return []
+
+    if isinstance(
+        modifier_info.modifier, (MagnitudePruningModifier, GMPruningModifier)
+    ):
+        modifier_info.update(
+            updated_fields={
+                "mask_type": mask_type,
+                "global_sparsity": global_sparsity,
+            }
+        )
+    elif isinstance(modifier_info.modifier, ACDCPruningModifier):
+        modifier_info.update(
+            updated_fields={
+                "global_sparsity": global_sparsity,
+            }
+        )
+
+    if model:
+        prunable_layers = [name for name, module in get_prunable_layers(module=model)]
+        modifier_info.update({"params": prunable_layers})
+
+    return [modifier_info]
+
+
+def get_training_info(lr_func: str = "linear") -> List[ModifierBuildInfo]:
+    """
+    :param lr_func: str representing the learning rate function to use
+    :return: a List[ModifierBuildInfo] containing information on training modifiers
+        to be added
+    """
+    epoch_modifier_info = ModifierBuildInfo(
+        modifier=EpochRangeModifier,
+        modifier_name="epoch_range_mod",
+        fields={
+            "start_epoch": 0.0,
+            "end_epoch": 10,
+        })
+    lr_modifier_info = ModifierBuildInfo(
+        modifier=LearningRateFunctionModifier,
+        modifier_name="lr_function_mod",
+        fields={
+            "start_epoch": 0.0,
+            "end_epoch": 10,
+            "lr_func": lr_func,
+            "init_lr": "1e-3",
+            "final_lr": "1e-8",
+        })
+
+    return [epoch_modifier_info, lr_modifier_info]

--- a/src/sparseml/recipe_template/utils.py
+++ b/src/sparseml/recipe_template/utils.py
@@ -18,12 +18,16 @@ from torch.nn import Module
 
 from sparseml.pytorch.sparsification import (
     ACDCPruningModifier,
-    EpochRangeModifier, GMPruningModifier,
-    LearningRateFunctionModifier, MagnitudePruningModifier,
-    Modifier, QuantizationModifier,
+    EpochRangeModifier,
+    GMPruningModifier,
+    LearningRateFunctionModifier,
+    MagnitudePruningModifier,
+    Modifier,
+    QuantizationModifier,
 )
 from sparseml.pytorch.utils import get_prunable_layers, get_quantizable_layers
 from sparseml.sparsification import ModifierYAMLBuilder
+
 
 __all__ = [
     "ModifierBuildInfo",
@@ -150,6 +154,7 @@ _QUANTIZATION_MODIFIER_INFO_REGISTRY = {
 
 # getters
 
+
 def get_quantization_info(
     quantization: Union[str, bool] = False,
     target: str = "vnni",
@@ -237,7 +242,8 @@ def get_training_info(lr_func: str = "linear") -> List[ModifierBuildInfo]:
         fields={
             "start_epoch": 0.0,
             "end_epoch": 10,
-        })
+        },
+    )
     lr_modifier_info = ModifierBuildInfo(
         modifier=LearningRateFunctionModifier,
         modifier_name="lr_function_mod",
@@ -247,6 +253,7 @@ def get_training_info(lr_func: str = "linear") -> List[ModifierBuildInfo]:
             "lr_func": lr_func,
             "init_lr": "1e-3",
             "final_lr": "1e-8",
-        })
+        },
+    )
 
     return [epoch_modifier_info, lr_modifier_info]


### PR DESCRIPTION
This PR adds getters for fetching `ModifierBuildInfo` objects from registry based off of args specified by user

TODO:
- [ ] Change base to `sparseml.recipe_template.dev` before landing