### PR TITLE
Feature branch for ModuleExporter Refactor

### DIFF
--- a/src/sparseml/onnx/simplify/__init__.py
+++ b/src/sparseml/onnx/simplify/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/sparseml/onnx/simplify/model_simplifier.py
+++ b/src/sparseml/onnx/simplify/model_simplifier.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+from typing import Generic, Iterable, TypeVar
+
+import onnx
+
+
+Match = TypeVar("Match")
+
+
+class ModelSimplifier(Generic[Match]):
+    def simplify(self, model: onnx.ModelProto):
+        onnx.checker.check_model(model)
+
+        matches = []
+        for match in self.iter_matches(model):
+            self.modify_match(model, match)
+            matches.append(match)
+
+        for match in match:
+            self.cleanup(model, match)
+
+        onnx.checker.check_model(model)
+
+    @abc.abstractmethod
+    def iter_matches(self, model: onnx.ModelProto) -> Iterable[Match]:
+        ...
+
+    @abc.abstractmethod
+    def modify_match(self, model: onnx.ModelProto, match: Match):
+        ...
+
+    @abc.abstractmethod
+    def cleanup_match(self, model: onnx.ModelProto, match: Match):
+        ...

--- a/src/sparseml/onnx/simplify/node_match.py
+++ b/src/sparseml/onnx/simplify/node_match.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+from typing import Optional
+
+from onnx import ModelProto, NodeProto
+
+
+class NodeMatch(abc.ABC):
+    def __init__(self, node: NodeProto) -> None:
+        super().__init__()
+        self.node = node
+
+    @abc.abstractmethod
+    @staticmethod
+    def maybe_from_node(model: ModelProto, node: NodeProto) -> Optional["NodeMatch"]:
+        ...
+
+
+class ConvNode(NodeMatch):
+    @staticmethod
+    def maybe_from_node(model: ModelProto, node: NodeProto) -> Optional["ConvNode"]:
+        if node.op_type != "Conv":
+            return None
+        return ConvNode(node)
+
+
+class DivNode(NodeMatch):
+    @staticmethod
+    def maybe_from_node(model: ModelProto, node: NodeProto) -> Optional["DivNode"]:
+        if node.op_type != "Div":
+            return None
+        return DivNode(node)
+
+
+class BatchNormNode(NodeMatch):
+    @staticmethod
+    def maybe_from_node(
+        model: ModelProto, node: NodeProto
+    ) -> Optional["BatchNormNode"]:
+        if node.op_type != "BatchNormalization":
+            return None
+        return BatchNormNode(node)
+
+
+class Quant(NodeMatch):
+    @staticmethod
+    def maybe_from_node(model: ModelProto, node: NodeProto) -> Optional["Quant"]:
+        if node.op_type != "QuantizeLinear":
+            return None
+        return Quant(node)
+
+
+class Dequant(NodeMatch):
+    @staticmethod
+    def maybe_from_node(model: ModelProto, node: NodeProto) -> Optional["Dequant"]:
+        if node.op_type != "DequantizeLinear":
+            return None
+        return Dequant(node)
+
+
+class Gather(NodeMatch):
+    @staticmethod
+    def maybe_from_node(model: ModelProto, node: NodeProto) -> Optional["Gather"]:
+        if node.op_type != "Gather":
+            return None
+        return Gather(node)


### PR DESCRIPTION
# TODOS
- [ ] Add unit tests for existing passes
- [ ] Add utility `match_sequences` which will return all sequences of specified NodeMatches. For example the following would iterate all sequences of Conv->Div->BatchNorm nodes:
```python
match_sequences(model, [Conv, Div, BatchNorm])
```
- [ ] Add helper properties for `NodeMatch` with params in attributes (Conv/BatchNorm/etc)
- [ ] Add new passes:
    - [ ] fold transpose with initializer
- [ ] Combine Add/Cast/Mul passes (QDQ -> Gemm + bias, MatMul -> Add, Conv + bias -> QDQ)
- [ ] Combine Gemm/Conv passes (QDQ -> Gemm, Conv -> QDQ)
- [ ] use `List[ModelSimplifier]` in `export_onnx`
    - [ ] if convert_qat=True, then extend the list of simplifiers with QAT passes

# Summary

The main goals of this refactor are:
1. Harden onnx export pipeline (tests, etc)
2. Simplify matching logic of passes
3. Simplify logic of passes
4. Combine as many passes as possible

There are two new main base classes to support this:
1. `NodeMatch`, which will match against specific nodes in the graph, and also make it easy to access expected attributes from onnx nodes
2. `ModelSimplifier` which represents a single optimization pass
