### PR TITLE
[QuantizationModifier] pydantic classes for defining quantization schemes to generate QConfigs

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/__init__.py
+++ b/src/sparseml/pytorch/sparsification/quantization/__init__.py
@@ -16,4 +16,5 @@
 
 from .helpers import *
 from .modifier_quantization import *
+from .quantize import *
 from .quantize_qat_export import *

--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tooling for applying quantization to pytorch modules via
+structured configurations
+"""
+
+from typing import Any, Dict, Optional
+
+import torch
+from pydantic import BaseModel, Field
+
+from sparseml.pytorch.sparsification.quantization.helpers import compute_range
+
+
+try:
+    from torch import quantization as torch_quantization
+except Exception:
+    torch_quantization = None
+
+
+__all__ = [
+    "QuantizationArgs",
+    "QuantizationScheme",
+]
+
+
+class QuantizationArgs(BaseModel):
+    """
+    Class representing user facing arguments to define quantization Observers of
+    activations or weights in a network
+    """
+
+    num_bits: int = Field(default=8, help="number of bits to target for quantization")
+    symmetric: bool = Field(
+        default=False, help="set True to use symmetric quantization. Default False"
+    )
+    kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        help=(
+            "optional dict of kwargs to be passed directly to torch quantization "
+            "Observers constructor excluding quantization range or symmetry"
+        ),
+    )
+
+    @classmethod
+    def default_activation_args(cls):
+        """
+        :return: default 8 bits asymmetric settings
+        """
+        return cls(num_bits=8, symmetric=False)
+
+    @classmethod
+    def default_weight_args(cls):
+        """
+        :return: default 8 bits symmetric settings
+        """
+        return cls(num_bits=8, symmetric=True)
+
+    def get_observer(self) -> "torch.quantization.FakeQuantize":
+        """
+        :return: torch quantization FakeQuantize built based on these QuantizationArgs
+        """
+        qscheme = (
+            torch.per_tensor_symmetric if self.symmetric else torch.per_tensor_affine
+        )
+        target_dtype = torch.qint8
+        quant_min, quant_max = compute_range(target_dtype, self.num_bits)
+        return torch_quantization.FakeQuantize.with_args(
+            observer=torch_quantization.MovingAverageMinMaxObserver,
+            quant_min=quant_min,
+            quant_max=quant_max,
+            dtype=target_dtype,
+            qscheme=qscheme,
+            **self.kwargs,
+        )
+
+
+class QuantizationScheme(BaseModel):
+    """
+    Class composed of QuantizationArgs to build QConfig and QuantWrapper objects for
+    quantizing models. Provides a simple user interface for defining how inputs,
+    weights, and outputs should be quantized
+    """
+
+    input_activations: Optional[QuantizationArgs] = Field(
+        default_factory=QuantizationArgs.default_activation_args,
+        help=(
+            "target quantization setting for input activations. Set to None to "
+            "not quantize input activations. Default is 8 bits asymmetric"
+        ),
+    )
+    weights: Optional[QuantizationArgs] = Field(
+        default_factory=QuantizationArgs.default_weight_args,
+        help=(
+            "target quantization setting for model weights. Set to None to "
+            "not quantize weights. Default is 8 bits symmetric"
+        ),
+    )
+    output_activations: Optional[QuantizationArgs] = Field(
+        default=None,
+        help=(
+            "target quantization setting for output activations. Set to None to "
+            "not quantize output activations. Default is None"
+        ),
+    )
+
+    def get_qconfig(self) -> "torch.quantization.QConfig":
+        """
+        :return: QConfig for Modules (output activations used,
+            use QuantWrapper for inputs)
+        """
+        return _get_qconfig(self.output_activations, self.weights)
+
+    def get_wrapper_qconfig(self) -> "torch.quantization.QConfig":
+        """
+        :return: QConfig for QuantWrapper objets (input activations used)
+        """
+        return _get_qconfig(self.input_activations, self.weights)
+
+
+def _get_qconfig(
+    activation_args: Optional[QuantizationArgs], weight_args: Optional[QuantizationArgs]
+) -> "torch.quantization.QConfig":
+    return torch_quantization.QConfig(
+        activation=activation_args.get_observer() if activation_args else None,
+        weight=weight_args.get_observer() if weight_args else None,
+    )

--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -43,13 +43,16 @@ class QuantizationArgs(BaseModel):
     activations or weights in a network
     """
 
-    num_bits: int = Field(default=8, help="number of bits to target for quantization")
+    num_bits: int = Field(
+        default=8, description="number of bits to target for quantization"
+    )
     symmetric: bool = Field(
-        default=False, help="set True to use symmetric quantization. Default False"
+        default=False,
+        description="set True to use symmetric quantization. Default False",
     )
     kwargs: Dict[str, Any] = Field(
         default_factory=dict,
-        help=(
+        description=(
             "optional dict of kwargs to be passed directly to torch quantization "
             "Observers constructor excluding quantization range or symmetry"
         ),
@@ -97,21 +100,21 @@ class QuantizationScheme(BaseModel):
 
     input_activations: Optional[QuantizationArgs] = Field(
         default_factory=QuantizationArgs.default_activation_args,
-        help=(
+        description=(
             "target quantization setting for input activations. Set to None to "
             "not quantize input activations. Default is 8 bits asymmetric"
         ),
     )
     weights: Optional[QuantizationArgs] = Field(
         default_factory=QuantizationArgs.default_weight_args,
-        help=(
+        description=(
             "target quantization setting for model weights. Set to None to "
             "not quantize weights. Default is 8 bits symmetric"
         ),
     )
     output_activations: Optional[QuantizationArgs] = Field(
         default=None,
-        help=(
+        description=(
             "target quantization setting for output activations. Set to None to "
             "not quantize output activations. Default is None"
         ),
@@ -126,7 +129,7 @@ class QuantizationScheme(BaseModel):
 
     def get_wrapper_qconfig(self) -> "torch.quantization.QConfig":
         """
-        :return: QConfig for QuantWrapper objets (input activations used)
+        :return: QConfig for QuantWrapper objects (input activations used)
         """
         return _get_qconfig(self.input_activations, self.weights)
 

--- a/tests/sparseml/pytorch/sparsification/quantization/test_quantize.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_quantize.py
@@ -32,8 +32,8 @@ from sparseml.pytorch.sparsification.quantization import (
             QuantizationArgs(num_bits=4, symmetric=True),
         ),
         (
-            dict(num_bits=8, kwargs=dict(reduce_rage=True)),
-            QuantizationArgs(num_bits=8, kwargs=dict(reduce_rage=True)),
+            dict(num_bits=8, kwargs=dict(reduce_range=True)),
+            QuantizationArgs(num_bits=8, kwargs=dict(reduce_range=True)),
         ),
     ],
 )
@@ -56,13 +56,13 @@ def test_quantization_args_from_dict(quantization_args_dict, target_quantization
             dict(
                 input_activations=dict(num_bits=8, symmetric=False),
                 weights=dict(num_bits=4, symmetric=True),
-                output_activations=dict(num_bits=8, kwargs=dict(reduce_rage=True)),
+                output_activations=dict(num_bits=8, kwargs=dict(reduce_range=True)),
             ),
             QuantizationScheme(
                 input_activations=QuantizationArgs(num_bits=8, symmetric=False),
                 weights=QuantizationArgs(num_bits=4, symmetric=True),
                 output_activations=QuantizationArgs(
-                    num_bits=8, kwargs=dict(reduce_rage=True)
+                    num_bits=8, kwargs=dict(reduce_range=True)
                 ),
             ),
         ),

--- a/tests/sparseml/pytorch/sparsification/quantization/test_quantize.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_quantize.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from sparseml.pytorch.sparsification.quantization import (
+    QuantizationArgs,
+    QuantizationScheme,
+)
+
+
+@pytest.mark.parametrize(
+    "quantization_args_dict,target_quantization_args",
+    [
+        (
+            dict(num_bits=8, symmetric=False),
+            QuantizationArgs(num_bits=8, symmetric=False),
+        ),
+        (
+            dict(num_bits=4, symmetric=True),
+            QuantizationArgs(num_bits=4, symmetric=True),
+        ),
+        (
+            dict(num_bits=8, kwargs=dict(reduce_rage=True)),
+            QuantizationArgs(num_bits=8, kwargs=dict(reduce_rage=True)),
+        ),
+    ],
+)
+def test_quantization_args_from_dict(quantization_args_dict, target_quantization_args):
+    loaded_quantization_args = QuantizationArgs.parse_obj(quantization_args_dict)
+    assert isinstance(loaded_quantization_args, QuantizationArgs)
+    assert loaded_quantization_args == target_quantization_args
+
+
+@pytest.mark.parametrize(
+    "quantization_scheme_dict,target_quantization_scheme",
+    [
+        (
+            dict(input_activations=None, weights=None, output_activations=None),
+            QuantizationScheme(
+                input_activations=None, weights=None, output_activations=None
+            ),
+        ),
+        (
+            dict(
+                input_activations=dict(num_bits=8, symmetric=False),
+                weights=dict(num_bits=4, symmetric=True),
+                output_activations=dict(num_bits=8, kwargs=dict(reduce_rage=True)),
+            ),
+            QuantizationScheme(
+                input_activations=QuantizationArgs(num_bits=8, symmetric=False),
+                weights=QuantizationArgs(num_bits=4, symmetric=True),
+                output_activations=QuantizationArgs(
+                    num_bits=8, kwargs=dict(reduce_rage=True)
+                ),
+            ),
+        ),
+    ],
+)
+def test_quantization_scheme_from_dict(
+    quantization_scheme_dict, target_quantization_scheme
+):
+    loaded_quantization_scheme = QuantizationScheme.parse_obj(quantization_scheme_dict)
+    assert isinstance(loaded_quantization_scheme, QuantizationScheme)
+
+    def _assert_none_or_is_quant_args(val):
+        assert val is None or isinstance(val, QuantizationArgs)
+
+    _assert_none_or_is_quant_args(loaded_quantization_scheme.input_activations)
+    _assert_none_or_is_quant_args(loaded_quantization_scheme.weights)
+    _assert_none_or_is_quant_args(loaded_quantization_scheme.output_activations)
+
+    assert loaded_quantization_scheme == target_quantization_scheme
+
+
+@pytest.mark.parametrize(
+    "qunatization_args,target_quant_min,target_quant_max",
+    [
+        (QuantizationArgs(num_bits=8, symmetric=False), -128, 127),
+        (QuantizationArgs(num_bits=4, symmetric=True), -8, 7),
+    ],
+)
+def test_quantization_args_get_observer(
+    qunatization_args, target_quant_min, target_quant_max
+):
+    observer = qunatization_args.get_observer()
+    assert hasattr(observer, "with_args")
+    assert observer.p.keywords["quant_min"] == target_quant_min
+    assert observer.p.keywords["quant_max"] == target_quant_max


### PR DESCRIPTION
a core feature of the QuantizationModifier refactor is the ability for users to have both more simple and more fine grained control over how quantization is applied at large and in small pieces of the model.  To support this, this PR introduces two simple pydantic models that can be used to define how a particular layer's inputs, weights, and outputs are quantized

intended use:
`QuantizationArgs` defines how quantization should be applied for a particular component via `num_bits`, `symmetric` and optional kwargs that map to pytorch quantization `Observer` args.
`QuantizationScheme` builds on `QuantizationArgs` to allow for args to be set separately for inputs, weights, and outputs. If any of these values are set to None, that particular component of the layer will not be quantized.

helper methods are included to create `Observer` and `QConfig` objects from the pydantic models respectively.

these classes will be built on for parsing inputs to recipes - recipe users will not interface with these objects directly:

a post-refactor modifier YAML may look something like
```yaml
!QuantizationModifier
  ...
  submodule_schemes:
    "bert.encoder":
        input_activations:
          num_bits: 8
          symmetric: False
        weights:
          num_bits: 8
          symmetric: True
        output_activations: None
```

**test_plan**
unit tests included