### PR TITLE
Moving github workflows to python 3.10 & adding backwards compat steps

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
@@ -152,7 +152,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
@@ -176,7 +176,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
@@ -215,3 +215,51 @@ jobs:
         run: pip3 install .[dev,tf_v1,onnxruntime]
       - name: "🔬 Running tensorflow_v1 tests"
         run: make test TARGETS=tensorflow_v1
+  compat-tests-pytorch-1.9:
+    runs-on: ubuntu-22.04
+    env:
+      SPARSEZOO_TEST_MODE: "true"
+    needs: test-setup
+    if: ${{needs.test-setup.outputs.pytorch == 1}}
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: "neuralmagic/sparsezoo"
+          path: "sparsezoo"
+          ref: ${{needs.test-setup.outputs.branch}}
+      - name: "⚙️ Install sparsezoo dependencies"
+        run: pip3 install -U pip && pip3 install setuptools sparsezoo/
+      - name: "Clean sparsezoo directory"
+        run: rm -r sparsezoo/
+      - name: "⚙️ Install dependencies"
+        run: pip3 install .[dev,torchvision,onnxruntime] torch==1.9.1
+      - name: "🔬 Running pytorch tests"
+        run: make test TARGETS=pytorch
+  compat-tests-pytorch-1.9-onnx:
+    runs-on: ubuntu-22.04
+    env:
+      SPARSEZOO_TEST_MODE: "true"
+    needs: test-setup
+    if: ${{needs.test-setup.outputs.onnx == 1}}
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: "neuralmagic/sparsezoo"
+          path: "sparsezoo"
+          ref: ${{needs.test-setup.outputs.branch}}
+      - name: "⚙️ Install sparsezoo dependencies"
+        run: pip3 install -U pip && pip3 install setuptools sparsezoo/
+      - name: "Clean sparsezoo directory"
+        run: rm -r sparsezoo/
+      - name: "⚙️ Install dependencies"
+        run: pip3 install .[dev,torchvision,onnxruntime] torch==1.9.1
+      - name: "🔬 Running onnx tests"
+        run: make test TARGETS=onnx


### PR DESCRIPTION
Github workflows will now default to python 3.10 and torch 1.12

Test plan: unit tests