### PR TITLE
Using typing.Mapping instead of collections

### DIFF
--- a/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
@@ -18,7 +18,7 @@ Base modifier for performing model distillation
 
 import logging
 from copy import deepcopy
-from typing import Any, Dict, Iterable, List, Optional, Union, Mapping
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
 
 import torch
 import torch.nn.functional as TF

--- a/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
@@ -17,9 +17,8 @@ Base modifier for performing model distillation
 """
 
 import logging
-from collections import Mapping
 from copy import deepcopy
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union, Mapping
 
 import torch
 import torch.nn.functional as TF


### PR DESCRIPTION
collections.Mapping no longer exists in python 3.10