### PR TITLE
Simplifying and fixing fix_batch_norm_names

### DIFF
--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -747,8 +747,6 @@ def _delete_trivial_onnx_adds(model: onnx.ModelProto):
 
 
 def _unwrap_batchnorms(model: onnx.ModelProto):
-    onnx.checker.check_model(model)
-
     for init in model.graph.initializer:
         init.name = init.name.replace(".bn_wrapper_replace_me", "")
     for node in model.graph.node:


### PR DESCRIPTION
In torch 1.12, some of the initializers are used by multiple nodes. For this fix_batch_norm_names function, this was causing a bug where:
1. A node's input & initializer were updated by removing ".module"
2. Another node that also used that initializer was not updated because the check for `init_name not in name_to_inits` failed, so the node was skipped

This PR simplifies the logic of the above by changing initializer names and node input/output names separately.
