### PR TITLE
Adding Softmax to to_exclude in quantization modifier

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -695,7 +695,7 @@ class QuantizationModifier(ScheduledModifier):
             )
 
         # remove qconfigs for module types in exclude_module_types
-        to_exclude = []
+        to_exclude = ["Softmax"]
         if self.exclude_module_types:
             to_exclude.extend(self.exclude_module_types)
 


### PR DESCRIPTION
In torch 1.12, softmax gets a qconfig added to it by the quantization modifier. Thus it ends up with QDQ nodes after the softmax node in the onnx graph:
![image](https://user-images.githubusercontent.com/109536191/194120969-b1e290c9-37f5-4c71-9d5e-dc79acf904ad.png)

This PR adds Softmax to a to_exclude list in Quantization modifier so this does not occur.

Test plan: ran resnet50 export for quant & non-quant versions and verified that softmax no longer has QDQ nodes after it in 1.12