### PR TITLE
Deprecating dynamic_axes and always setting it

### DIFF
--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -484,13 +484,18 @@ def export_onnx(
     if "output_names" not in export_kwargs:
         export_kwargs["output_names"] = _get_output_names(out)
 
-    if dynamic_axes == "batch":
-        dynamic_axes = {
-            tensor_name: {0: "batch"}
-            for tensor_name in (
-                export_kwargs["input_names"] + export_kwargs["output_names"]
-            )
-        }
+    if dynamic_axes is not None:
+        warnings.warn(
+            "Setting dynamic_axes is deprecated, now it is always set",
+            category=DeprecationWarning,
+        )
+
+    dynamic_axes = {
+        tensor_name: {0: "batch"}
+        for tensor_name in (
+            export_kwargs["input_names"] + export_kwargs["output_names"]
+        )
+    }
 
     # disable active quantization observers because they cannot be exported
     disabled_observers = []

--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -486,7 +486,8 @@ def export_onnx(
 
     if dynamic_axes is not None:
         warnings.warn(
-            "Setting dynamic_axes is deprecated, now it is always set",
+            "`dynamic_axes` is deprecated and does not affect anything. "
+            "The 0th axis is always treated as dynamic.",
             category=DeprecationWarning,
         )
 


### PR DESCRIPTION
Reasoning: in torch 1.12 any shape operations *without* batch dimension as dynamic will be treated as a constant, and therefore constant folding operations will apply to them. For example in resnet there is a flatten operation towards the end of the graph.

In torch 1.12, without dynamic_axes="batch" set, you get this graph:

![image](https://user-images.githubusercontent.com/109536191/195614517-5eae87e3-3540-408d-a757-be603e1e1a74.png)

With dynamic_axes="batch set, you get this graph:

![image](https://user-images.githubusercontent.com/109536191/195614614-c935f22c-8982-43dd-b599-dfd49d298076.png)

