### PR TITLE
One shot export [Image classification]

### DIFF
--- a/src/sparseml/pytorch/image_classification/export.py
+++ b/src/sparseml/pytorch/image_classification/export.py
@@ -97,6 +97,8 @@ Options:
   --num-classes, --num_classes INTEGER
                                   number of classes for model; must be set if
                                   a dataset is not provided
+  --one-shot, --one_shot TEXT     recipe to be applied in one-shot manner,
+                                  before exporting
   --help                          Show this message and exit.
 
 
@@ -106,6 +108,13 @@ sparseml.image_classification.export_onnx \
     --arch-key resnet50 --dataset imagenet \
     --dataset-path ~/datasets/ILSVRC2012 \
     --checkpoint-path ~/checkpoints/resnet50_checkpoint.pth
+
+Example command for exporting ResNet50 with one-shot:
+sparseml.image_classification.export_onnx \
+    --arch-key resnet50 --dataset imagenet \
+    --dataset-path ~/datasets/ILSVRC2012 \
+    --checkpoint-path ~/checkpoints/resnet50_checkpoint.pth \
+    --one-shot ~/recipes/resnet_recipe.md
 """
 import json
 import os
@@ -291,6 +300,14 @@ LOGGER = get_main_logger()
     show_default=True,
     help="number of classes for model; must be set if a dataset is not provided",
 )
+@click.option(
+    "--one-shot",
+    "--one_shot",
+    type=str,
+    default=None,
+    show_default=True,
+    help="recipe to be applied in one-shot manner, before exporting",
+)
 def main(
     dataset: Optional[str] = None,
     dataset_path: Optional[str] = None,
@@ -310,6 +327,7 @@ def main(
     recipe: Optional[str] = None,
     convert_qat: bool = True,
     num_classes: Optional[int] = None,
+    one_shot: Optional[str] = None,
 ):
     """
     SparseML-PyTorch Integration for exporting image classification models to
@@ -369,7 +387,13 @@ def main(
 
     if recipe is not None:
         ScheduledModifierManager.from_yaml(recipe).apply_structure(model)
+
+    if checkpoint_path:
         load_model(checkpoint_path, model, strict=True)
+
+    if one_shot is not None:
+        ScheduledModifierManager.from_yaml(file_path=one_shot).apply(module=model)
+
     export(
         model=model,
         val_loader=val_loader,

--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -164,9 +164,13 @@ def get_save_dir_and_loggers(
             if task == Tasks.TRAIN
             else None
         )
-
+        arch_key_save_name = f"{arch_key.replace('/', '.')}"
         if not model_tag:
-            model_tag = f"{arch_key.replace('/', '.')}_{dataset_name}"
+            model_tag = (
+                f"{arch_key_save_name}_{dataset_name}"
+                if dataset_name
+                else arch_key_save_name
+            )
             model_id = model_tag
             model_inc = 0
             # set location to check for models with same name

--- a/src/sparseml/pytorch/utils/model.py
+++ b/src/sparseml/pytorch/utils/model.py
@@ -17,7 +17,7 @@ Code related to interacting with a trained model such as saving, loading, etc
 """
 
 from collections import OrderedDict
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from packaging import version
@@ -39,7 +39,6 @@ try:
 except Exception as ddp_error:
     DDP = None
     ddp_import_error = ddp_error
-
 
 __all__ = [
     "load_model",
@@ -80,7 +79,13 @@ def load_model(
     """
     if path.startswith("zoo:"):
         path = download_framework_model_by_recipe_type(Model(path))
-    model_dict = torch.load(path, map_location="cpu")
+    model_dict: Union[Module, Dict[str, Any]] = torch.load(path, map_location="cpu")
+
+    if isinstance(model_dict, Module):
+        model_dict = {
+            "state_dict": model_dict.state_dict(),
+        }
+
     recipe = model_dict.get("recipe")
 
     if recipe:

--- a/tests/sparseml/pytorch/image_classification/resnet_test_recipe.yaml
+++ b/tests/sparseml/pytorch/image_classification/resnet_test_recipe.yaml
@@ -1,0 +1,8 @@
+modifiers:
+  - !ACDCPruningModifier
+    compression_sparsity: 0.9
+    start_epoch: 0.0
+    end_epoch: 1.0
+    global_sparsity: False
+    update_frequency: 1.0
+    params: __ALL_PRUNABLE__

--- a/tests/sparseml/pytorch/image_classification/test_export.py
+++ b/tests/sparseml/pytorch/image_classification/test_export.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from pathlib import Path
+
+import onnx
+import pytest
+import torch
+
+from click.testing import CliRunner
+from sparseml.pytorch.image_classification.export import main
+from sparseml.pytorch.models import resnet18
+from sparsezoo.analysis import ModelAnalysis
+
+
+@pytest.fixture()
+def temp_dir(tmp_path):
+    """
+    return: a temporary directory
+    """
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+    yield test_dir
+
+
+@pytest.fixture()
+def resnet_checkpoint(temp_dir):
+    """
+    return: path to a ResNet checkpoint
+    """
+    checkpoint_path = str(temp_dir / "model.pth")
+    model = resnet18()
+    torch.save(model, checkpoint_path)
+    yield checkpoint_path
+
+
+@pytest.fixture()
+def recipe_path():
+    """
+    return: path to a resnet recipe
+    """
+    yield str(Path(__file__).resolve().parent / "resnet_test_recipe.yaml")
+
+
+def test_export_one_shot(resnet_checkpoint, recipe_path, temp_dir):
+    runner = CliRunner()
+    arch_key = "resnet18"
+    result = runner.invoke(
+        main,
+        [
+            "--arch-key",
+            arch_key,
+            "--checkpoint-path",
+            resnet_checkpoint,
+            "--num-samples",
+            0,
+            "--save-dir",
+            temp_dir,
+            "--num-classes",
+            1000,
+            "--one-shot",
+            recipe_path,
+        ],
+    )
+    assert result.exit_code == 0
+
+    expected_onnx_path = str(temp_dir / arch_key / "deployment" / "model.onnx")
+
+    # exported file exists
+    assert Path(expected_onnx_path).exists()
+
+    # exported file is valid onnx
+    model = onnx.load(expected_onnx_path)
+    onnx.checker.check_model(model)
+
+    # check onnx model is sparse
+    model_analysis = ModelAnalysis.from_onnx(onnx_file_path=expected_onnx_path)
+
+    found_prunable_node: bool = False
+    for node in model_analysis.nodes:
+        if node.parameterized_prunable:
+            found_prunable_node = True
+            node_sparsity = node.parameter_summary.block_structure["single"].sparsity
+            assert math.isclose(node_sparsity, 0.9, abs_tol=0.01)
+    assert found_prunable_node


### PR DESCRIPTION
This PR adds support to apply a recipe in `one-shot` manner while exporting Image classification models

Test plan: Automated test to start with a vanilla(non-quantized) `resnet50`, export checkpoint in one-shot manner with a quantization recipe and then check the onnx graph for quantized nodes

Note the failing test should pass after #1122 lands