### PR TITLE
Allowing torch 1.10 and 1.11, but raising error with quantized exports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ _deepsparse_ent_deps = [f"deepsparse-ent~={version_nm_deps}"]
 
 _onnxruntime_deps = ["onnxruntime>=1.0.0"]
 _pytorch_deps = [
-    "torch>=1.1.0,<=1.12.1,!=1.10.*,!=1.11.*",
+    "torch>=1.1.0,<=1.12.1",
     "tensorboard>=1.0,<2.9",
     "tensorboardX>=1.0",
     "gputils",

--- a/src/sparseml/pytorch/__init__.py
+++ b/src/sparseml/pytorch/__init__.py
@@ -17,6 +17,7 @@ Functionality for working with and sparsifying Models in the PyTorch framework
 """
 
 import os
+import warnings
 
 from packaging import version
 
@@ -25,17 +26,22 @@ try:
     import torch
 
     _PARSED_TORCH_VERSION = version.parse(torch.__version__)
-    if (
-        _PARSED_TORCH_VERSION.major == 1
-        and _PARSED_TORCH_VERSION.minor in [10, 11]
-        and os.environ.get("NM_BYPASS_TORCH_VERSION", "").lower() == "true"
-    ):
-        raise RuntimeError(
-            "sparseml does not support torch==1.10.* or 1.11.*. "
-            f"Found torch version {torch.__version__}. "
-            "To override this error, set environment variable "
-            "`NM_BYPASS_TORCH_VERSION` to 'true'."
-        )
+    _BYPASS = bool(int(os.environ.get("NM_BYPASS_TORCH_VERSION", "0")))
+    if _PARSED_TORCH_VERSION.major == 1 and _PARSED_TORCH_VERSION.minor in [10, 11]:
+        if not _BYPASS:
+            raise RuntimeError(
+                "sparseml does not support torch==1.10.* or 1.11.*. "
+                f"Found torch version {torch.__version__}.\n\n"
+                "To bypass this error, set environment variable "
+                "`NM_BYPASS_TORCH_VERSION` to '1'.\n\n"
+                "Bypassing may result in errors or "
+                "incorrect behavior, so set at your own risk."
+            )
+        else:
+            warnings.warn(
+                "sparseml quantized onnx export does not work "
+                "with torch==1.10.* or 1.11.*"
+            )
 except ImportError:
     pass
 

--- a/src/sparseml/pytorch/__init__.py
+++ b/src/sparseml/pytorch/__init__.py
@@ -16,6 +16,29 @@
 Functionality for working with and sparsifying Models in the PyTorch framework
 """
 
+import os
+
+from packaging import version
+
+
+try:
+    import torch
+
+    _PARSED_TORCH_VERSION = version.parse(torch.__version__)
+    if (
+        _PARSED_TORCH_VERSION.major == 1
+        and _PARSED_TORCH_VERSION.minor in [10, 11]
+        and os.environ.get("NM_BYPASS_TORCH_VERSION", "").lower() == "true"
+    ):
+        raise RuntimeError(
+            "sparseml does not support torch==1.10.* or 1.11.*. "
+            f"Found torch version {torch.__version__}. "
+            "To override this error, set environment variable "
+            "`NM_BYPASS_TORCH_VERSION` to 'true'."
+        )
+except ImportError:
+    pass
+
 # flake8: noqa
 
 from .base import *

--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -571,18 +571,6 @@ def export_onnx(
     onnx.save(onnx_model, file_path)
 
     if convert_qat and is_quant_module:
-        if (
-            _PARSED_TORCH_VERSION.major == 1
-            and _PARSED_TORCH_VERSION.minor in [10, 11]
-            and os.environ.get("NM_FORCE_QUANT_EXPORT", "").lower() == "true"
-        ):
-            raise RuntimeError(
-                "Quantized exports are not supported in torch==1.10.* or 1.11.*. "
-                f"Found torch version {torch.__version__}. "
-                "To override this error, set environment variable "
-                "`NM_FORCE_QUANT_EXPORT` to 'true'."
-            )
-
         # overwrite exported model with fully quantized version
         # import here to avoid cyclic dependency
         from sparseml.pytorch.sparsification.quantization import (

--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -571,6 +571,18 @@ def export_onnx(
     onnx.save(onnx_model, file_path)
 
     if convert_qat and is_quant_module:
+        if (
+            _PARSED_TORCH_VERSION.major == 1
+            and _PARSED_TORCH_VERSION.minor in [10, 11]
+            and "NM_FORCE_QUANT_EXPORT" not in os.environ
+        ):
+            raise RuntimeError(
+                "Quantized exports are not supported in torch==1.10.* or 1.11.*. "
+                f"Found torch version {torch.__version__}. "
+                "To override this error, set environment variable "
+                "`NM_FORCE_QUANT_EXPORT` to anything."
+            )
+
         # overwrite exported model with fully quantized version
         # import here to avoid cyclic dependency
         from sparseml.pytorch.sparsification.quantization import (

--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -574,13 +574,13 @@ def export_onnx(
         if (
             _PARSED_TORCH_VERSION.major == 1
             and _PARSED_TORCH_VERSION.minor in [10, 11]
-            and "NM_FORCE_QUANT_EXPORT" not in os.environ
+            and os.environ.get("NM_FORCE_QUANT_EXPORT", "").lower() == "true"
         ):
             raise RuntimeError(
                 "Quantized exports are not supported in torch==1.10.* or 1.11.*. "
                 f"Found torch version {torch.__version__}. "
                 "To override this error, set environment variable "
-                "`NM_FORCE_QUANT_EXPORT` to anything."
+                "`NM_FORCE_QUANT_EXPORT` to 'true'."
             )
 
         # overwrite exported model with fully quantized version


### PR DESCRIPTION
Addresses comment in #1062 