### PR TITLE
Making onnx opset 13 default

### DIFF
--- a/integrations/keras/classification.py
+++ b/integrations/keras/classification.py
@@ -573,7 +573,7 @@ def parse_args():
         "--onnx-opset",
         type=int,
         default=13,
-        help="The onnx opset to use for export. Default is 11",
+        help="The onnx opset to use for export. Default is 13",
     )
     export_parser.add_argument(
         "--export-debug-mode",

--- a/integrations/keras/classification.py
+++ b/integrations/keras/classification.py
@@ -572,7 +572,7 @@ def parse_args():
     export_parser.add_argument(
         "--onnx-opset",
         type=int,
-        default=11,
+        default=13,
         help="The onnx opset to use for export. Default is 11",
     )
     export_parser.add_argument(

--- a/integrations/pytorch/export.py
+++ b/integrations/pytorch/export.py
@@ -56,7 +56,7 @@ optional arguments:
                         labels as well as the outputs from model
                         execution)
   --onnx-opset ONNX_OPSET
-                        The onnx opset to use for export. Default is 11
+                        The onnx opset to use for export. Default is 13
   --use-zipfile-serialization-if-available
                         USE_ZIPFILE_SERIALIZATION_IF_AVAILABLE
                         for torch >= 1.6.0 only exports the Module's
@@ -132,7 +132,7 @@ class ExportArgs:
     :param num_samples: The number of samples to export along with the model
         onnx and pth files (sample inputs and labels as well as the outputs
         from model execution). Default is 100.
-    :param onnx_opset: The onnx opset to use for export. Default is 11.
+    :param onnx_opset: The onnx opset to use for export. Default is 13.
     :param use_zipfile_serialization_if_available: for torch >= 1.6.0 only
         exports the Module's state dict using the new zipfile serialization.
         Default is True, has no affect on lower torch versions.
@@ -196,7 +196,7 @@ class ExportArgs:
     )
 
     onnx_opset: int = field(
-        default=11, metadata={"help": "The onnx opset to use for export. Default is 11"}
+        default=13, metadata={"help": "The onnx opset to use for export. Default is 13"}
     )
 
     use_zipfile_serialization_if_available: convert_to_bool = field(

--- a/integrations/tensorflow_v1/classification.py
+++ b/integrations/tensorflow_v1/classification.py
@@ -185,7 +185,7 @@ optional arguments:
                         onnx and pth files (sample inputs and labels as well
                         as the outputs from model execution)
   --onnx-opset ONNX_OPSET
-                        The onnx opset to use for export. Default is 11
+                        The onnx opset to use for export. Default is 13
 
 
 ##########
@@ -546,8 +546,8 @@ def parse_args():
             par.add_argument(
                 "--onnx-opset",
                 type=int,
-                default=11,
-                help="The onnx opset to use for export. Default is 11",
+                default=13,
+                help="The onnx opset to use for export. Default is 13",
             )
 
         if par == pruning_sensitivity_parser:
@@ -821,7 +821,7 @@ def train(args, save_dir, logs_dir):
         checkpoint_path=checkpoint_path,
         skip_samples=True,
         num_classes=num_classes,
-        opset=11,
+        opset=13,
     )
 
 

--- a/src/sparseml/keras/utils/exporter.py
+++ b/src/sparseml/keras/utils/exporter.py
@@ -34,7 +34,7 @@ except Exception as keras2onnx_error:
 __all__ = ["ModelExporter"]
 
 
-DEFAULT_ONNX_OPSET = 11
+DEFAULT_ONNX_OPSET = 13
 
 
 class ModelExporter(object):
@@ -67,7 +67,7 @@ class ModelExporter(object):
         Export an ONNX file for the current model.
 
         :param name: name of the onnx file to save
-        :param opset: onnx opset to use for exported model. Default is 11
+        :param opset: onnx opset to use for exported model. Default is 13
         :param doc_string: optional doc string for exported ONNX model
         :param debug_mode: debug mode, default to True, passed into `convert_keras`
         :param kwargs: additional parameters passed into `convert_keras`

--- a/src/sparseml/pytorch/image_classification/export.py
+++ b/src/sparseml/pytorch/image_classification/export.py
@@ -50,7 +50,7 @@ Options:
                                   execution)  [default: -1]
    --onnx-opset, --onnx_opset INTEGER
                                   The onnx opset to use for exporting the
-                                  model  [default: 11]
+                                  model  [default: 13]
   --use_zipfile_serialization_if_available, --use-zipfile-serialization-if-available /
   --no_zipfile_serialization, --no-zipfile-serialization
                                   For torch >= 1.6.0 only exports the Module's
@@ -188,7 +188,7 @@ LOGGER = get_main_logger()
     "--onnx-opset",
     "--onnx_opset",
     type=int,
-    default=11,
+    default=13,
     show_default=True,
     help="The onnx opset to use for exporting the model",
 )
@@ -297,7 +297,7 @@ def main(
     labels_to_class_mapping: Optional[str] = None,
     arch_key: Optional[str] = None,
     num_samples: int = -1,
-    onnx_opset: int = 11,
+    onnx_opset: int = 13,
     use_zipfile_serialization_if_available: bool = True,
     pretrained: Union[str, bool] = True,
     pretrained_dataset: Optional[str] = None,
@@ -388,7 +388,7 @@ def export(
     save_dir: str,
     use_zipfile_serialization_if_available: bool,
     num_samples: int,
-    onnx_opset: int = 11,
+    onnx_opset: int = 13,
     convert_qat: bool = True,
     image_size: int = 224,
     labels_to_class_mapping: Optional[Union[str, Dict[int, str]]] = None,

--- a/src/sparseml/tensorflow_v1/utils/exporter.py
+++ b/src/sparseml/tensorflow_v1/utils/exporter.py
@@ -38,7 +38,7 @@ __all__ = ["default_onnx_opset", "GraphExporter"]
 
 
 def default_onnx_opset() -> int:
-    return 9 if onnx.__version__ < "1.6" else 11
+    return 9 if onnx.__version__ < "1.6" else 13
 
 
 class GraphExporter(object):

--- a/tests/integrations/image_classification/args.py
+++ b/tests/integrations/image_classification/args.py
@@ -152,7 +152,7 @@ class ImageClassificationExportArgs(_ImageClassificationBaseArgs):
         Default=None, description="required - tag for model under save_dir"
     )
     onnx_opset: int = Field(
-        default=11, description="The onnx opset to use for exporting the model"
+        default=13, description="The onnx opset to use for exporting the model"
     )
     num_samples: int = Field(
         default=-1, description="number of forward data output samples to produce"

--- a/tests/integrations/yolov5/args.py
+++ b/tests/integrations/yolov5/args.py
@@ -147,7 +147,7 @@ class Yolov5ExportArgs(BaseModel):
     int8: bool = Field(default=False, description="CoreML/TF INT8 quantization")
     dynamic: bool = Field(default=False, description="ONNX/TF: dynamic axes")
     simplify: bool = Field(default=False, description="ONNX: simplify model")
-    opset: int = Field(default=12, description="ONNX: opset version")
+    opset: int = Field(default=13, description="ONNX: opset version")
     verbose: bool = Field(default=False, description="TensorRT: verbose log")
     nms: bool = Field(default=False, description="TF: add NMS to model")
     agnostic_nms: bool = Field(


### PR DESCRIPTION
For torch-1.12, the default onnx opset should be 13. Unclear what the default should be for other versions.