### PR TITLE
[Transformers] Drop creation of HF model cards

### DIFF
--- a/src/sparseml/transformers/masked_language_modeling.py
+++ b/src/sparseml/transformers/masked_language_modeling.py
@@ -744,11 +744,6 @@ def main(**kwargs):
             num_samples_to_export=data_args.num_export_samples
         )
 
-    if training_args.push_to_hub:
-        trainer.push_to_hub(**kwargs)
-    else:
-        trainer.create_model_card(**kwargs)
-
 
 def _mp_fn(index):
     # For xla_spawn (TPUs)

--- a/src/sparseml/transformers/question_answering.py
+++ b/src/sparseml/transformers/question_answering.py
@@ -844,10 +844,6 @@ def main(**kwargs):
         trainer.save_sample_inputs_outputs(
             num_samples_to_export=data_args.num_export_samples
         )
-    if training_args.push_to_hub:
-        trainer.push_to_hub(**kwargs)
-    else:
-        trainer.create_model_card(**kwargs)
 
 
 def _mp_fn(index):

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -873,11 +873,6 @@ def main(**kwargs):
             num_samples_to_export=data_args.num_export_samples
         )
 
-    if training_args.push_to_hub:
-        trainer.push_to_hub(**kwargs)
-    else:
-        trainer.create_model_card(**kwargs)
-
 
 def _split_train_val(train_dataset, val_ratio):
     # Fixed random seed to make split consistent across runs with the same ratio

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -729,11 +729,6 @@ def main(**kwargs):
             num_samples_to_export=data_args.num_export_samples
         )
 
-    if training_args.push_to_hub:
-        trainer.push_to_hub(**kwargs)
-    else:
-        trainer.create_model_card(**kwargs)
-
 
 def _mp_fn(index):
     # For xla_spawn (TPUs)


### PR DESCRIPTION
The sparseml transformers integration is broken as of `huggingface_hub` release v0.10. The new release added validators to model card creation which breaks our flow. Choosing to drop model card creation as it's not utilized in the sparseml flow.