### PR TITLE
torchvision image classification

### DIFF
--- a/src/sparseml/pytorch/torchvision/export_onnx.py
+++ b/src/sparseml/pytorch/torchvision/export_onnx.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+import torch
+import torchvision
+from torch.nn import Module
+from torch.utils.data import DataLoader
+from torchvision.transforms.functional import InterpolationMode
+from tqdm import tqdm
+
+import click
+from sparseml.pytorch.models.registry import ModelRegistry
+from sparseml.pytorch.torchvision import presets
+from sparseml.pytorch.utils import ModuleExporter
+from sparseml.pytorch.utils.exporter import DEFAULT_ONNX_OPSET
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@click.command(
+    context_settings=dict(
+        token_normalize_func=lambda x: x.replace("-", "_"), show_default=True
+    )
+)
+@click.option(
+    "--arch-key",
+    type=str,
+    required=True,
+    help="The architecture key for image classification model; "
+    "example: `resnet50`, `mobilenet`. "
+    "Note: Will be read from the checkpoint if not specified",
+)
+@click.option(
+    "--checkpoint-path",
+    type=click.Path(dir_okay=False, file_okay=True, exists=True, path_type=Path),
+    required=True,
+    help="A path to a previous checkpoint to load the state from "
+    "and resume the state for exporting",
+)
+@click.option(
+    "--dataset-path",
+    type=click.Path(dir_okay=True, file_okay=False, exists=True, path_type=Path),
+    required=True,
+    help="The root dir path where the dataset is stored or should "
+    "be downloaded to if available",
+)
+@click.option(
+    "--labels-to-class-mapping",
+    type=click.Path(dir_okay=False, file_okay=True, exists=True, path_type=Path),
+    default=None,
+    help="Optional path to the dataset-specific mapping from "
+    "numeric labels to human-readable class strings. "
+    "Expected to be a path to a .json file containing "
+    "a serialized dictionary",
+)
+@click.option(
+    "--num-samples",
+    type=int,
+    default=-1,
+    help="The number of samples to export along with the model onnx "
+    "and pth files (sample inputs and labels as well as the "
+    "outputs from model execution)",
+)
+@click.option(
+    "--onnx-opset",
+    type=int,
+    default=DEFAULT_ONNX_OPSET,
+    help="The onnx opset to use for exporting the model",
+)
+@click.option(
+    "--save-dir",
+    type=click.Path(dir_okay=True, file_okay=False, path_type=Path),
+    default="torchvision",
+    help="The path to the directory for saving results",
+)
+@click.option(
+    "--convert-qat/--no-convert-qat",
+    default=True,
+    is_flag=True,
+    help="if True, exports of torch QAT graphs will be converted to a fully quantized "
+    "representation. Default is True",
+)
+@click.option(
+    "--interpolation",
+    default="bilinear",
+    type=str,
+    help="the interpolation method (default: bilinear)",
+)
+@click.option(
+    "--img-resize-size",
+    default=256,
+    type=int,
+    help="the resize size used for validation (default: 256)",
+)
+@click.option(
+    "--img-crop-size",
+    default=224,
+    type=int,
+    help="the central crop size used for validation (default: 224)",
+)
+def main(
+    arch_key: str,
+    checkpoint_path: str,
+    dataset_path: Path,
+    labels_to_class_mapping: Optional[Path],
+    num_samples: int,
+    onnx_opset: int,
+    save_dir: Path,
+    convert_qat: bool,
+    interpolation: str,
+    img_resize_size: int,
+    img_crop_size: int,
+):
+    """
+    SparseML torchvision integration for exporting image classification models to
+    onnx along with sample inputs and outputs
+    """
+
+    os.makedirs(save_dir, exist_ok=True)
+
+    dataset = torchvision.datasets.ImageFolder(
+        dataset_path / "val",
+        presets.ClassificationPresetEval(
+            crop_size=img_crop_size,
+            resize_size=img_resize_size,
+            interpolation=InterpolationMode(interpolation),
+        ),
+    )
+    num_classes = len(dataset.classes)
+    data_loader = DataLoader(dataset=dataset, batch_size=1, shuffle=False)
+
+    if arch_key in ModelRegistry.available_keys():
+        model = ModelRegistry.create(key=arch_key, num_classes=num_classes)
+    elif arch_key in torchvision.models.__dict__:
+        # fall back to torchvision
+        model = torchvision.models.__dict__[arch_key](
+            pretrained=False, num_classes=num_classes
+        )
+    else:
+        raise ValueError(
+            f"Unable to find {arch_key} in ModelRegistry or in torchvision.models"
+        )
+    checkpoint = torch.load(checkpoint_path)
+    model.load_state_dict(checkpoint["model"])
+
+    if labels_to_class_mapping is not None:
+        with open(labels_to_class_mapping) as fp:
+            labels_to_class_mapping = json.load(fp)
+
+    export(
+        model=model,
+        val_loader=data_loader,
+        save_dir=save_dir,
+        num_samples=num_samples,
+        onnx_opset=onnx_opset,
+        convert_qat=convert_qat,
+        labels_to_class_mapping=labels_to_class_mapping,
+    )
+
+
+def export(
+    model: Module,
+    val_loader: DataLoader,
+    save_dir: str,
+    num_samples: int,
+    onnx_opset: int,
+    convert_qat: bool,
+    labels_to_class_mapping: Optional[Union[str, Dict[int, str]]],
+) -> None:
+    exporter = ModuleExporter(model, save_dir)
+
+    export_samples = num_samples > 0
+    if num_samples < 0:
+        num_samples = 1
+
+    for batch, (x, label) in tqdm(
+        enumerate(val_loader), desc="Exporting samples", total=num_samples
+    ):
+        if batch >= num_samples:
+            break
+
+        if export_samples:
+            exporter.export_samples(
+                sample_batches=[x], sample_labels=[label], exp_counter=batch
+            )
+
+    _LOGGER.info(f"exporting onnx in {save_dir}")
+    exporter.export_onnx(x, opset=onnx_opset, convert_qat=convert_qat)
+
+    exporter.create_deployment_folder(labels_to_class_mapping=labels_to_class_mapping)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -377,6 +377,10 @@ def main(args):
         optimizer = torch.optim.AdamW(
             parameters, lr=args.lr, weight_decay=args.weight_decay
         )
+    elif opt_name == "adam":
+        optimizer = torch.optim.Adam(
+            parameters, lr=args.lr, weight_decay=args.weight_decay
+        )
     else:
         raise RuntimeError(
             f"Invalid optimizer {args.opt}. Only SGD, RMSprop and AdamW are supported."

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -460,7 +460,7 @@ def main(args):
             epoch,
             args,
             model_ema,
-            scaler,
+            scaler=None if manager.qat_active(epoch=epoch) else scaler,
         )
         lr_scheduler.step()
         evaluate(model, criterion, data_loader_test, device=device)

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -24,6 +24,7 @@ from torch import nn
 from torch.utils.data.dataloader import default_collate
 from torchvision.transforms.functional import InterpolationMode
 
+from sparseml.pytorch.optim import ScheduledModifierManager
 from sparseml.pytorch.torchvision import presets, transforms, utils
 from sparseml.pytorch.torchvision.sampler import RASampler
 
@@ -432,9 +433,12 @@ def main(args):
             evaluate(model, criterion, data_loader_test, device=device)
         return
 
+    manager = ScheduledModifierManager.from_yaml(args.recipe_path)
+    optimizer = manager.modify(model, optimizer, len(data_loader))
+
     print("Start training")
     start_time = time.time()
-    for epoch in range(args.start_epoch, args.epochs):
+    for epoch in range(args.start_epoch, manager.max_epochs):
         if args.distributed:
             train_sampler.set_epoch(epoch)
         train_one_epoch(
@@ -472,6 +476,7 @@ def main(args):
             utils.save_on_master(
                 checkpoint, os.path.join(args.output_dir, "checkpoint.pth")
             )
+    manager.finalize()
 
     total_time = time.time() - start_time
     total_time_str = str(datetime.timedelta(seconds=int(total_time)))
@@ -485,6 +490,7 @@ def get_args_parser(add_help=True):
         description="PyTorch Classification Training", add_help=add_help
     )
 
+    parser.add_argument("--recipe-path", required=True, type=str, help="Path to recipe")
     parser.add_argument(
         "--data-path",
         default="/datasets01/imagenet_full_size/061417/",

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -95,14 +95,27 @@ def train_one_epoch(
         metric_logger.meters["img/s"].update(batch_size / (time.time() - start_time))
 
 
-def evaluate(model, criterion, data_loader, device, print_freq=100, log_suffix=""):
+def evaluate(
+    model,
+    criterion,
+    data_loader,
+    device,
+    steps_per_epoch,
+    print_freq=100,
+    log_suffix="",
+):
     model.eval()
     metric_logger = utils.MetricLogger(delimiter="  ")
     header = f"Test: {log_suffix}"
 
     num_processed_samples = 0
     with torch.inference_mode():
-        for image, target in metric_logger.log_every(data_loader, print_freq, header):
+        for i, (image, target) in enumerate(
+            metric_logger.log_every(data_loader, print_freq, header)
+        ):
+            if i >= steps_per_epoch:
+                break
+
             image = image.to(device, non_blocking=True)
             target = target.to(device, non_blocking=True)
             output = model(image)
@@ -289,6 +302,10 @@ def main(args):
         pin_memory=True,
     )
 
+    steps_per_eval = len(data_loader_test)
+    if args.max_eval_steps > 0:
+        steps_per_eval = min(steps_per_eval, args.max_eval_steps)
+
     print("Creating model")
     model = torchvision.models.get_model(
         args.model, weights=args.weights, num_classes=num_classes
@@ -437,10 +454,15 @@ def main(args):
         torch.backends.cudnn.deterministic = True
         if model_ema:
             evaluate(
-                model_ema, criterion, data_loader_test, device=device, log_suffix="EMA"
+                model_ema,
+                criterion,
+                data_loader_test,
+                device,
+                steps_per_eval,
+                log_suffix="EMA",
             )
         else:
-            evaluate(model, criterion, data_loader_test, device=device)
+            evaluate(model, criterion, data_loader_test, device, steps_per_eval)
         return
 
     manager = ScheduledModifierManager.from_yaml(args.recipe_path)
@@ -463,10 +485,15 @@ def main(args):
             scaler=None if manager.qat_active(epoch=epoch) else scaler,
         )
         lr_scheduler.step()
-        evaluate(model, criterion, data_loader_test, device=device)
+        evaluate(model, criterion, data_loader_test, device, steps_per_eval)
         if model_ema:
             evaluate(
-                model_ema, criterion, data_loader_test, device=device, log_suffix="EMA"
+                model_ema,
+                criterion,
+                data_loader_test,
+                device,
+                steps_per_eval,
+                log_suffix="EMA",
             )
         if args.output_dir:
             checkpoint = {
@@ -759,6 +786,13 @@ def get_args_parser(add_help=True):
         default=1,
         type=int,
         help="gradient accumulation steps",
+    )
+    parser.add_argument(
+        "--max-eval-steps",
+        default=-1,
+        type=int,
+        help="Per epoch number of eval steps to run. If negative, "
+        "will run for the entire dataset",
     )
     return parser
 

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import math
 import os
 import time
 import warnings
@@ -468,6 +469,8 @@ def main(args):
     manager = ScheduledModifierManager.from_yaml(args.recipe_path)
     optimizer = manager.modify(model, optimizer, len(data_loader))
 
+    best_top1_acc = -math.inf
+
     print("Start training")
     start_time = time.time()
     for epoch in range(args.start_epoch, manager.max_epochs):
@@ -485,7 +488,7 @@ def main(args):
             scaler=None if manager.qat_active(epoch=epoch) else scaler,
         )
         lr_scheduler.step()
-        evaluate(model, criterion, data_loader_test, device, steps_per_eval)
+        top1_acc = evaluate(model, criterion, data_loader_test, device, steps_per_eval)
         if model_ema:
             evaluate(
                 model_ema,
@@ -495,6 +498,9 @@ def main(args):
                 steps_per_eval,
                 log_suffix="EMA",
             )
+        is_new_best = epoch >= args.save_best_after and top1_acc > best_top1_acc
+        if is_new_best:
+            best_top1_acc = top1_acc
         if args.output_dir:
             checkpoint = {
                 "model": model_without_ddp.state_dict(),
@@ -507,12 +513,11 @@ def main(args):
                 checkpoint["model_ema"] = model_ema.state_dict()
             if scaler:
                 checkpoint["scaler"] = scaler.state_dict()
-            utils.save_on_master(
-                checkpoint, os.path.join(args.output_dir, f"model_{epoch}.pth")
-            )
-            utils.save_on_master(
-                checkpoint, os.path.join(args.output_dir, "checkpoint.pth")
-            )
+            file_names = [f"model_{epoch}.pth", "checkpoint.pth"]
+            if is_new_best:
+                file_names.append("checkpoint-best.pth")
+            for fname in file_names:
+                utils.save_on_master(checkpoint, os.path.join(args.output_dir, fname))
     manager.finalize()
 
     total_time = time.time() - start_time
@@ -786,6 +791,13 @@ def get_args_parser(add_help=True):
         default=1,
         type=int,
         help="gradient accumulation steps",
+    )
+    parser.add_argument(
+        "--save-best-after",
+        default=1,
+        type=int,
+        help="Save the best validation result after the given "
+        "epoch completes until the end of training",
     )
     parser.add_argument(
         "--max-eval-steps",

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -484,6 +484,9 @@ def main(args):
     for epoch in range(args.start_epoch, manager.max_epochs):
         if args.distributed:
             train_sampler.set_epoch(epoch)
+        if manager.qat_active(epoch=epoch):
+            scaler = None
+            model_ema = None
         train_one_epoch(
             model,
             criterion,
@@ -493,8 +496,8 @@ def main(args):
             epoch,
             steps_per_epoch,
             args,
-            model_ema,
-            scaler=None if manager.qat_active(epoch=epoch) else scaler,
+            model_ema=model_ema,
+            scaler=scaler,
         )
         lr_scheduler.step()
         top1_acc = evaluate(model, criterion, data_loader_test, device, steps_per_eval)

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -399,52 +399,6 @@ def main(args):
 
     scaler = torch.cuda.amp.GradScaler() if args.amp else None
 
-    args.lr_scheduler = args.lr_scheduler.lower()
-    if args.lr_scheduler == "steplr":
-        main_lr_scheduler = torch.optim.lr_scheduler.StepLR(
-            optimizer, step_size=args.lr_step_size, gamma=args.lr_gamma
-        )
-    elif args.lr_scheduler == "cosineannealinglr":
-        main_lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-            optimizer, T_max=args.epochs - args.lr_warmup_epochs, eta_min=args.lr_min
-        )
-    elif args.lr_scheduler == "exponentiallr":
-        main_lr_scheduler = torch.optim.lr_scheduler.ExponentialLR(
-            optimizer, gamma=args.lr_gamma
-        )
-    else:
-        raise RuntimeError(
-            f"Invalid lr scheduler '{args.lr_scheduler}'. "
-            "Only StepLR, CosineAnnealingLR and ExponentialLR "
-            "are supported."
-        )
-
-    if args.lr_warmup_epochs > 0:
-        if args.lr_warmup_method == "linear":
-            warmup_lr_scheduler = torch.optim.lr_scheduler.LinearLR(
-                optimizer,
-                start_factor=args.lr_warmup_decay,
-                total_iters=args.lr_warmup_epochs,
-            )
-        elif args.lr_warmup_method == "constant":
-            warmup_lr_scheduler = torch.optim.lr_scheduler.ConstantLR(
-                optimizer,
-                factor=args.lr_warmup_decay,
-                total_iters=args.lr_warmup_epochs,
-            )
-        else:
-            raise RuntimeError(
-                f"Invalid warmup lr method '{args.lr_warmup_method}'. "
-                "Only linear and constant are supported."
-            )
-        lr_scheduler = torch.optim.lr_scheduler.SequentialLR(
-            optimizer,
-            schedulers=[warmup_lr_scheduler, main_lr_scheduler],
-            milestones=[args.lr_warmup_epochs],
-        )
-    else:
-        lr_scheduler = main_lr_scheduler
-
     model_ema = None
     if args.model_ema:
         # Decay adjustment that aims to keep the decay independent from
@@ -483,8 +437,6 @@ def main(args):
 
         # NOTE: override start epoch
         args.start_epoch = checkpoint["epoch"] + 1
-
-        lr_scheduler.load_state_dict(checkpoint["lr_scheduler"])
     else:
         checkpoint = None
         manager = ScheduledModifierManager.from_yaml(args.recipe_path)
@@ -500,6 +452,60 @@ def main(args):
             scaler.load_state_dict(checkpoint["scaler"])
 
     optimizer = manager.modify(model, optimizer, len(data_loader))
+
+    if manager.learning_rate_modifiers:
+        lr_scheduler = None
+    else:
+        args.lr_scheduler = args.lr_scheduler.lower()
+        if args.lr_scheduler == "steplr":
+            main_lr_scheduler = torch.optim.lr_scheduler.StepLR(
+                optimizer, step_size=args.lr_step_size, gamma=args.lr_gamma
+            )
+        elif args.lr_scheduler == "cosineannealinglr":
+            main_lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+                optimizer,
+                T_max=args.epochs - args.lr_warmup_epochs,
+                eta_min=args.lr_min,
+            )
+        elif args.lr_scheduler == "exponentiallr":
+            main_lr_scheduler = torch.optim.lr_scheduler.ExponentialLR(
+                optimizer, gamma=args.lr_gamma
+            )
+        else:
+            raise RuntimeError(
+                f"Invalid lr scheduler '{args.lr_scheduler}'. "
+                "Only StepLR, CosineAnnealingLR and ExponentialLR "
+                "are supported."
+            )
+
+        if args.lr_warmup_epochs > 0:
+            if args.lr_warmup_method == "linear":
+                warmup_lr_scheduler = torch.optim.lr_scheduler.LinearLR(
+                    optimizer,
+                    start_factor=args.lr_warmup_decay,
+                    total_iters=args.lr_warmup_epochs,
+                )
+            elif args.lr_warmup_method == "constant":
+                warmup_lr_scheduler = torch.optim.lr_scheduler.ConstantLR(
+                    optimizer,
+                    factor=args.lr_warmup_decay,
+                    total_iters=args.lr_warmup_epochs,
+                )
+            else:
+                raise RuntimeError(
+                    f"Invalid warmup lr method '{args.lr_warmup_method}'. "
+                    "Only linear and constant are supported."
+                )
+            lr_scheduler = torch.optim.lr_scheduler.SequentialLR(
+                optimizer,
+                schedulers=[warmup_lr_scheduler, main_lr_scheduler],
+                milestones=[args.lr_warmup_epochs],
+            )
+        else:
+            lr_scheduler = main_lr_scheduler
+
+        if args.resume and checkpoint:
+            lr_scheduler.load_state_dict(checkpoint["lr_scheduler"])
 
     if args.test_only:
         # We disable the cudnn benchmarking because it can
@@ -546,7 +552,8 @@ def main(args):
             model_ema=model_ema,
             scaler=scaler,
         )
-        lr_scheduler.step()
+        if lr_scheduler:
+            lr_scheduler.step()
         top1_acc = evaluate(model, criterion, data_loader_test, device, steps_per_eval)
         if model_ema:
             evaluate(
@@ -564,9 +571,10 @@ def main(args):
             checkpoint = {
                 "model": model_without_ddp.state_dict(),
                 "optimizer": optimizer.state_dict(),
-                "lr_scheduler": lr_scheduler.state_dict(),
                 "args": args,
             }
+            if lr_scheduler:
+                checkpoint["lr_scheduler"] = lr_scheduler.state_dict()
             if model_ema:
                 checkpoint["model_ema"] = model_ema.state_dict()
             if scaler:

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -132,6 +132,8 @@ def evaluate(
             image = image.to(device, non_blocking=True)
             target = target.to(device, non_blocking=True)
             output = model(image)
+            if isinstance(output, tuple):
+                output = output[0]
             loss = criterion(output, target)
 
             acc1, acc5 = utils.accuracy(output, target, topk=(1, 5))

--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -981,13 +981,13 @@ def set_deterministic_seeds(seed: int = 0):
 
 
 @contextmanager
-def torch_distributed_zero_first(local_rank: int):
+def torch_distributed_zero_first(local_rank: Optional[int]):
     """
     Decorator to make all processes in distributed training wait for each
     local 0 ranked process to do something.
     :param local_rank: the local rank of this process
     """
-    if local_rank not in [-1, 0]:
+    if local_rank is not None and local_rank not in [-1, 0]:
         torch.distributed.barrier()
     yield
     if local_rank == 0:


### PR DESCRIPTION
This is the base feature branch for torchvision image classification rewrite

TODOS:
- [x] Add in managers/finalizers #1103 
- [x] Override lr scheduler with manager #1141 
- [x] Handle EMA #1113 
- [x] Add `--gradient-accum-steps` #1106 
- [x] ~Add --max-train-steps~ REVERTED #1108
- [x] ~Add --max-eval-steps~ REVERTED #1109
- [x] Add `--save-best-after` #1114
- [x] Recipe staging and model re-loading #1124
- [x] Override AMP after certain epoch #1107 
- [x] Use ModelRegistry and fall back to torchvision models if not found in model registry #1136 
- [x] export script (requires sample inputs & outputs) #1154
    - [ ] (Lower priority) add `--one-shot` arg

Verification
- [ ] ensure you can plug in torchvision models in deepsparse pipelines
- [x] verify reproducibility for current recipes
- [x] ensure export_onnx works on output of training (See #1154)

Later:
- [ ] add helper functions
- [ ] override weight decay with manager?
- [ ] Add `--log-dir` and add tensorboard support
- [ ] Swap to using click for cli

# Testing plan

### Base training

Ran the following and verified that they both achieve similar top1 accuracy scores of > 90%
```bash
sparseml.image_classification.train \
    --recipe-path zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original \
    --pretrained True \
    --arch-key resnet50 \
    --dataset imagenette \
    --dataset-path ~/.cache/nm_datasets/imagenette/imagenette-320/  \
    --train-batch-size 128 --test-batch-size 128 \
    --optim SGD \
    --optim-args '{}' \
    --model-tag resnet50-imagenette-pruned-conservative \
    --save-dir ./training-runs/image_classification-pretrained \
    --logs-dir ./training-runs/image_classification-pretrained
```

```bash
python src/sparseml/pytorch/torchvision/train.py \
    --recipe-path zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original \
    --pretrained True \
    --arch-key resnet50 \
    --dataset imagenette \
    --dataset-path ~/.cache/nm_datasets/imagenette/imagenette-320/  \
    --batch-size 128 \
    --opt sgd-nesterov \
    --momentum 0.9 \
    --output-dir ./training-runs/torchvision-pretrained-quant/resnet50-imagenette-pruned-conservative
```

These were run in the following variants:
1. no pretraining
2. pretrained
3. pretrained + quantization modifier added to recipe