### PR TITLE
Adding pass to flatten zero_point/scale params

### DIFF
--- a/tests/sparseml/pytorch/utils/test_exporter.py
+++ b/tests/sparseml/pytorch/utils/test_exporter.py
@@ -15,12 +15,17 @@
 import os
 import tempfile
 
+import numpy
 import onnx
 import pytest
 import torch
+from onnx import numpy_helper
 
 from sparseml.pytorch.utils import ModuleExporter
-from sparseml.pytorch.utils.exporter import _fold_identity_initializers
+from sparseml.pytorch.utils.exporter import (
+    _flatten_qparams,
+    _fold_identity_initializers,
+)
 from tests.sparseml.pytorch.helpers import MLPNet
 
 
@@ -78,5 +83,56 @@ def test_fold_identity_initializers():
     assert len(model.graph.node) == 1
     assert [node.name for node in model.graph.node] == ["add"]
     assert model.graph.node[0].input == ["init1", "input"]
+
+    onnx.checker.check_model(model)
+
+
+def test_flatten_params():
+    mdl_input = onnx.helper.make_tensor_value_info(
+        "input", onnx.TensorProto.FLOAT, (1,)
+    )
+    mdl_output = onnx.helper.make_tensor_value_info(
+        "output", onnx.TensorProto.FLOAT, (1,)
+    )
+
+    zp = onnx.helper.make_tensor(
+        name="zero_point", data_type=onnx.TensorProto.UINT8, dims=(1,), vals=[0]
+    )
+    scale = onnx.helper.make_tensor(
+        name="scale", data_type=onnx.TensorProto.FLOAT, dims=(1,), vals=[1.0]
+    )
+    quantize = onnx.helper.make_node(
+        "QuantizeLinear", ["input", "zero_point", "scale"], ["id1_output"], name="id1"
+    )
+
+    graph = onnx.helper.make_graph(
+        nodes=[quantize],
+        name="g",
+        inputs=[mdl_input],
+        outputs=[mdl_output],
+        initializer=[zp, scale],
+    )
+    model = onnx.helper.make_model(graph)
+    onnx.checker.check_model(model)
+
+    assert len(model.graph.initializer) == 2
+    assert [init.name for init in model.graph.initializer] == ["zero_point", "scale"]
+    zp = numpy_helper.to_array(model.graph.initializer[0])
+    assert zp.shape == (1,)
+    assert zp.dtype == numpy.uint8
+    scale = numpy_helper.to_array(model.graph.initializer[1])
+    assert scale.shape == (1,)
+    assert scale.dtype == numpy.float32
+
+    _flatten_qparams(model)
+
+    assert len(model.graph.initializer) == 2
+    assert [init.name for init in model.graph.initializer] == ["zero_point", "scale"]
+    zp = numpy_helper.to_array(model.graph.initializer[0])
+    assert zp.shape == ()
+    assert zp.dtype == numpy.uint8
+    scale = numpy_helper.to_array(model.graph.initializer[1])
+    assert scale.shape == ()
+    assert scale.dtype == numpy.float32
 
     onnx.checker.check_model(model)


### PR DESCRIPTION
As of torch 1.12, the zero_point/scale params are all arrays with shape `(1,)`. This causes some crashes for yolov5 integration tests (but for some reason not other models).

This PR flattens all the zero_point/scale inits to shape `()` if they have shape `(1,)`

Testing plan: manual export of yolov5. I can probably add a simple unit test for this too