### PR TITLE
Fix Error Message with `ImageFolderDataset`

### DIFF
--- a/src/sparseml/pytorch/datasets/classification/imagefolder.py
+++ b/src/sparseml/pytorch/datasets/classification/imagefolder.py
@@ -29,11 +29,11 @@ try:
     from torchvision import transforms
     from torchvision.datasets import ImageFolder
 
-    torchvision_import_error = None
 except Exception as torchvision_error:
-    transforms = None
-    ImageFolder = object  # default for constructor
-    torchvision_import_error = torchvision_error
+    raise ImportError(
+        "torchvision dependencies not found, kindly install using "
+        f"`pip install sparseml[torchvision]`, {torchvision_error}"
+    )
 
 from sparseml.pytorch.datasets.registry import DatasetRegistry
 from sparseml.utils import clean_path
@@ -84,9 +84,6 @@ class ImageFolderDataset(ImageFolder, FFCVImageNetDataset):
         rand_trans: bool = False,
         image_size: int = 224,
     ):
-        if torchvision_import_error is not None:
-            raise torchvision_import_error
-
         root = clean_path(root)
         non_rand_resize_scale = 256.0 / 224.0  # standard used
         init_trans = (

--- a/tests/sparseml/pytorch/datasets/classification/test_imagefolder.py
+++ b/tests/sparseml/pytorch/datasets/classification/test_imagefolder.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import builtins
+
+import pytest
+
+
+@pytest.fixture
+def hide_torchvision(monkeypatch):
+    import_orig = builtins.__import__
+
+    def mocked_torchvision_import(name, *args, **kwargs):
+        if name == "torchvision":
+            raise ImportError()
+        return import_orig(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mocked_torchvision_import)
+
+
+@pytest.mark.usefixtures("hide_torchvision")
+def test_message():
+    with pytest.raises(ImportError, match="not found"):
+        from sparseml.pytorch.datasets.classification import (  # noqa F401
+            ImageFolderDataset,
+        )

--- a/tests/sparseml/pytorch/datasets/classification/test_imagefolder.py
+++ b/tests/sparseml/pytorch/datasets/classification/test_imagefolder.py
@@ -30,7 +30,7 @@ def hide_torchvision(monkeypatch):
 
 
 @pytest.mark.usefixtures("hide_torchvision")
-def test_message():
+def test_import_error():
     with pytest.raises(ImportError, match="not found"):
         from sparseml.pytorch.datasets.classification import (  # noqa F401
             ImageFolderDataset,


### PR DESCRIPTION
Before this PR if anything from `sparseml.pytorch.datasets.classification` module was imported (w/o `torchvision` installed), an un-intuitive error message was thrown:

```python
from sparseml.pytorch.datasets.classification.imagefolder import ImageFolderDataset
Traceback (most recent call last):
  File "/home/XXXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3378, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-a247de027853>", line 1, in <module>
    from sparseml.pytorch.datasets.classification.imagefolder import ImageFolderDataset
  File "/home/XXXXX/projects/sparseml/src/sparseml/pytorch/datasets/__init__.py", line 22, in <module>
    from .classification import *
  File "/home/XXXXX/projects/sparseml/src/sparseml/pytorch/datasets/classification/__init__.py", line 22, in <module>
    from .imagefolder import *
  File "/home/XXXXX/projects/sparseml/src/sparseml/pytorch/datasets/classification/imagefolder.py", line 57, in <module>
    class ImageFolderDataset(ImageFolder, FFCVImageNetDataset):
  File "/usr/lib/python3.8/abc.py", line 85, in __new__
    cls = super().__new__(mcls, name, bases, namespace, **kwargs)
TypeError: Cannot create a consistent method resolution
order (MRO) for bases object, FFCVImageNetDataset
```

This PR addresses this by catching and exposing the error early, and also fixes the error message with what went wrong.

```python
from sparseml.pytorch.datasets.classification.imagefolder import ImageFolderDataset
Traceback (most recent call last):
  File "/home/XXXXX/projects/sparseml/src/sparseml/pytorch/datasets/classification/imagefolder.py", line 29, in <module>
    from torchvision import transforms
ModuleNotFoundError: No module named 'torchvision'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/XXXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3378, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-a247de027853>", line 1, in <module>
    from sparseml.pytorch.datasets.classification.imagefolder import ImageFolderDataset
  File "/home/XXXXX/projects/sparseml/src/sparseml/pytorch/datasets/__init__.py", line 22, in <module>
    from .classification import *
  File "/home/XXXXX/projects/sparseml/src/sparseml/pytorch/datasets/classification/__init__.py", line 22, in <module>
    from .imagefolder import *
  File "/home/XXXXX/projects/sparseml/src/sparseml/pytorch/datasets/classification/imagefolder.py", line 33, in <module>
    raise ImportError(
ImportError: torchvision dependencies not found, kindly install using `pip install sparseml[torchvision]`, No module named 'torchvision'
```

This PR also adds an automated test, to avoid missing this in the future