### PR TITLE
Only applying flatten qparams to initializers that exist

### DIFF
--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -672,9 +672,9 @@ def _flatten_qparams(model: onnx.ModelProto):
 
     for node in model.graph.node:
         if node.op_type in ["QuantizeLinear", "DequantizeLinear"]:
-            # scale is required
-            scale_init = graph.get_init_by_name(node.input[1], allow_optional=False)
-            if list(scale_init.dims) == [1]:
+            # scale is required if the input is an initializer
+            scale_init = graph.get_init_by_name(node.input[1])
+            if scale_init is not None and list(scale_init.dims) == [1]:
                 inits_to_flatten.add(node.input[1])
 
                 # zero_point is optional AND shape must match


### PR DESCRIPTION
in torch 1.9, some initializers into QuantizeLinear and DequantizeLinear are actually Constant nodes. This is currently handled by a pass in the convert qat stuff, but since flatten_qparams happens outside of that, the constant nodes haven't been merged in.

A simple change for now is to only change the inputs to Q/DQ if they are initializers. Previously this function would error they weren't initializers.

Test plan: manual testing of exporting yolov5 on torch1.9 and 1.12