### PR TITLE
fix registration of torchvision models for torchvsion>=0.13

### DIFF
--- a/src/sparseml/pytorch/models/external/torchvision.py
+++ b/src/sparseml/pytorch/models/external/torchvision.py
@@ -40,8 +40,13 @@ __all__ = []
 def _register_classification_models():
     # find model functions in torchvision.models
     for model_name, constructor_function in getmembers(torchvision_models, isfunction):
-        # using the "pretrained" keyword as proxy for a model function
-        if "pretrained" not in signature(constructor_function).parameters:
+        # using the "pretrained" or "weights" keyword as proxy for a model function
+        # "pretrained" is keyword for torchvision pre 0.13 "weights" for post 1.13
+        constructor_params = signature(constructor_function).parameters
+        if (
+            "pretrained" not in constructor_params
+            and "weights" not in constructor_params
+        ):
             continue
 
         key = "torchvision.{}".format(model_name)


### PR DESCRIPTION
torchvision changes the keyword for specifying pretrained models after their 0.13 release from `pretrained` to `weights`. This caused an issue in the registration of those models to our model registry, breaking our tests against torchvision>=0.13.

this change allows searches for the "weights" keyword as well to register the models

**test_plan:**
previously broken tests `tests/sparseml/pytorch/models/external/test_torchvision.py` fixed after resolution. tested locally against torchvision 0.13 and 0.10