### PR TITLE
Use correct URL for ONNX export

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ manager.apply(model)
 More information on the codebase and contained processes can be found in the SparseML docs:
 - [Sparsification Code](https://docs.neuralmagic.com/sparseml/source/code)
 - [Sparsification Recipes](https://docs.neuralmagic.com/sparseml/source/recipes)
-- [Exporting to ONNX](https://docs.neuralmagic.com/sparseml/source/onnx_export)
+- [Exporting to ONNX](https://docs.neuralmagic.com/user-guide/onnx-export)
 
 ## Resources
 


### PR DESCRIPTION
When I click on the link, it leads to a 404. Now, it points to the right place