### PR TITLE
Update Zoo download function

### DIFF
--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -1138,6 +1138,7 @@ def download_framework_model_by_recipe_type(
     By default, the function will return path to the final framework model
     :params zoo_model: model object from sparsezoo
     :params recipe_name: a name of the recipe (e.g. "transfer_learn", "original" etc.)
+    :params model_suffix: model_suffix that models are saved with
     :return: path to the framework model
     """
 

--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -1130,7 +1130,7 @@ def memory_aware_threshold(tensor: torch.Tensor, idx: int) -> Tensor:
 
 
 def download_framework_model_by_recipe_type(
-    zoo_model: Model, recipe_name: Optional[str] = None
+    zoo_model: Model, recipe_name: Optional[str] = None, model_suffix: str = ".pth"
 ) -> str:
     """
     Extract the path of the framework model from the
@@ -1145,13 +1145,18 @@ def download_framework_model_by_recipe_type(
     recipe_name = recipe_name or (
         zoo_model.stub_params.get("recipe_type") or zoo_model.stub_params.get("recipe")
     )
-
-    if recipe_name:
-        if "transfer" in recipe_name.lower():
-            # fetching the model for transfer learning
-            framework_model = zoo_model.training.default.get_file("model.ckpt.pth")
+    if recipe_name and "transfer" in recipe_name.lower():
+        # fetching the model for transfer learning
+        model_name = f"model.ckpt.{model_suffix}"
+        framework_model = zoo_model.training.default.get_file(model_name)
+        if not framework_model:
+            raise ValueError(
+                f"Could not find saved checkpoint {model_name} in SparseZoo Model "
+                f"{zoo_model.source}"
+            )
     else:
         # fetching the model for inference
-        framework_model = zoo_model.training.default.get_file("model.pth")
+        model_name = f"model.{model_suffix}"
+        framework_model = zoo_model.training.default.get_file(model_name)
 
     return framework_model.path

--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -1130,7 +1130,7 @@ def memory_aware_threshold(tensor: torch.Tensor, idx: int) -> Tensor:
 
 
 def download_framework_model_by_recipe_type(
-    zoo_model: Model, recipe_name: Optional[str] = None, model_suffix: str = ".pth"
+    zoo_model: Model, recipe_name: Optional[str] = None, model_suffix: str = "pth"
 ) -> str:
     """
     Extract the path of the framework model from the


### PR DESCRIPTION
This PR updates `download_framework_model_by_recipe_type()` with the following features:
- Option to specify save model suffix to cover more integrations (e.g. '.pt' for yolov5)
- Throws a verbose error for the user if they provide a bad recipe url

**Testing Plan**
Tested with local, updated version of yolov5 and with the two following IC commands
```
sparseml.image_classification.train  --recipe-path zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/channel30_pruned90_quant-none     --pretrained True     --arch-key resnet50     --dataset imagenet     --dataset-path /network/datasets/imagenette2-160     --train-batch-size 256     --test-batch-size 256     --loader-num-workers 16     --model-tag resnet50-imagenet-channel30_pruned90_quant-none
```
```
sparseml.image_classification.train --recipe-path zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned_quant-moderate?recipe_type=transfer_learn --arch-key mobilenet --model-kwargs '{"ignore_error_tensors": ["classifier.fc.weight", "classifier.fc.bias"]}' --dataset imagenette --dataset-path /network/datasets/imagenette2-160  --train-batch-size 128 --test-batch-size 256 --loader-num-workers 16 --optim Adam --optim-args '{}' --model-tag mobilenet-imagenette-pruned_quant-transfer_learned
```