### PR TITLE
Automatically install latest transformers version

### DIFF
--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -34,6 +34,7 @@ try:
     assert _upstream_base_version == _expected_upstream_base_version
     _transformers_import_error = None
 except Exception as _transformers_import_err:
+    _nm_integrated = False
     _transformers_import_error = _transformers_import_err
 
 

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -27,10 +27,11 @@ try:
     import transformers as _transformers
 
     # triggers error if the latest neuralmagic/transformers is not installed
-    assert (
-        _transformers.NM_INTEGRATED
-        and str(version.parse(_transformers.__version__)) == "4.23.1"
-    )
+    _nm_integrated = _transformers.NM_INTEGRATED
+    _upstream_base_version = str(version.parse(_transformers.__version__))
+    _expected_upstream_base_version = "4.23.1"
+    assert _nm_integrated
+    assert _upstream_base_version == _expected_upstream_base_version
     _transformers_import_error = None
 except Exception as _transformers_import_err:
     _transformers_import_error = _transformers_import_err
@@ -93,6 +94,14 @@ def _check_transformers_install():
             )
             # skip any further checks
             return
+        elif _nm_integrated:
+            _LOGGER.warning(
+                f"incompatible sparseml-transformers v{_upstream_base_version} "
+                "detected. Overwriting exiting installation with sparseml-transformers "
+                f"v{_expected_upstream_base_version}. Set environment variable "
+                "NM_NO_AUTOINSTALL_TRANSFORMERS to disable"
+            )
+            _install_transformers_and_deps()
         else:
             _LOGGER.warning(
                 "sparseml-transformers installation not detected. Installing "

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -20,12 +20,17 @@ Tools for integrating SparseML with transformers training flows
 
 import logging as _logging
 
+from packaging import version
+
 
 try:
     import transformers as _transformers
 
-    # triggers error if neuralmagic/transformers is not installed
-    assert _transformers.NM_INTEGRATED
+    # triggers error if the latest neuralmagic/transformers is not installed
+    assert (
+        _transformers.NM_INTEGRATED
+        and str(version.parse(_transformers.__version__)) == "4.23.1"
+    )
     _transformers_import_error = None
 except Exception as _transformers_import_err:
     _transformers_import_error = _transformers_import_err


### PR DESCRIPTION
Older versions of our transformers fork are unsupported with main. This PR enforces install of the correct version

**Test Plan**
```
pip install https://github.com/neuralmagic/transformers/releases/download/v1.2/transformers-4.18.0.dev0-py3-none-any.whl
pip show transformers
sparseml.transformers.question_answering --help
pip show transformers
sparseml.transformers.question_answering --help
pip show transformers
```