### PR TITLE
[WIP] Add convenience functions to recipe template

### DIFF
--- a/src/sparseml/pytorch/recipe_template/main.py
+++ b/src/sparseml/pytorch/recipe_template/main.py
@@ -48,10 +48,14 @@ def recipe_template(
     quantization: Union[bool, str] = False,
     lr: str = "linear",
     mask_type: str = "unstructured",
-    global_sparsity: bool = False,
+    global_sparsity: bool = True,
     target: Optional[str] = None,
     model: Union[str, Module, None] = None,
     file_name: Optional[str] = None,
+    num_epochs: float = 20.0,
+    init_lr: float = 0.001,
+    final_lr: float = 0.0,
+    sparsity: float = 0.8,
 ) -> str:
     """
     Returns a valid yaml or md recipe based on specified arguments
@@ -76,6 +80,10 @@ def recipe_template(
     :param file_name: an optional filename to save this recipe to. If specified the
         extension is used to determine if file should be written in markdown
         or yaml syntax. If not specified recipe is not written to a file
+    :param num_epochs: total number of epochs to target in recipe, default 20
+    :param init_lr: target initial learning rate, default 0.001
+    :param final_lr: target final learning rate, default 0.0
+    :param sparsity: target model sparsity, default 0.8
     :return: A valid string recipe based on the arguments
     """
 
@@ -144,9 +152,13 @@ def _build_recipe_template(
     quantization: bool,
     lr_func: str,
     mask_type: str,
-    global_sparsity: bool = False,
+    global_sparsity: bool = True,
     target: Optional[str] = None,
     model: Union[Module, None] = None,
+    num_epochs: float = 20.0,
+    init_lr: float = 0.001,
+    final_lr: float = 0.0,
+    sparsity: float = 0.8,
 ) -> str:
     pruning_was_applied: bool = pruning not in ["constant", ""]
     recipe_variables: Dict[str, Any] = _get_base_recipe_variables(
@@ -155,13 +167,22 @@ def _build_recipe_template(
         lr_func=lr_func,
         mask_type=mask_type,
         global_sparsity=global_sparsity,
+        num_epochs=num_epochs,
+        init_lr=init_lr,
+        final_lr=final_lr,
+        sparsity=sparsity,
     )
 
     builder_groups = {"training_modifiers": _get_training_builders()}
 
+    pruning_end_epoch = 0.0
+
     if pruning:
         pruning_builders, pruning_variables = _get_pruning_builders_and_variables(
-            pruning_algo=pruning, model=model, global_sparsity=global_sparsity
+            pruning_algo=pruning,
+            model=model,
+            global_sparsity=global_sparsity,
+            end_epoch=pruning_end_epoch,
         )
         recipe_variables.update(pruning_variables)
         builder_groups["pruning_modifiers"] = pruning_builders
@@ -196,18 +217,38 @@ def _get_base_recipe_variables(
     quantization: bool,
     lr_func: str = "linear",
     mask_type: str = "unstructured",
-    global_sparsity: bool = False,
+    global_sparsity: bool = True,
+    num_epochs: float = 20.0,
+    init_lr: float = 0.001,
+    final_lr: float = 0.0,
+    sparsity: float = 0.8,
 ) -> Dict[str, Any]:
-    recipe_variables = dict(lr_func=lr_func, init_lr=1.5e-4, final_lr=0)
+    recipe_variables = dict(lr_func=lr_func, init_lr=init_lr, final_lr=final_lr)
 
-    if pruning:
+    num_qat_epochs = 0
+    if quantization:
+        num_qat_epochs = 5.0 if num_epochs >= 15.0 else 2.0
         recipe_variables.update(
             dict(
-                num_pruning_active_epochs=20,
-                num_pruning_finetuning_epochs=10,
-                pruning_init_sparsity=0.05,
-                pruning_final_sparsity=0.9,
-                pruning_update_frequency=0.01,
+                num_qat_epochs=num_qat_epochs,
+                num_qat_finetuning_epochs=num_qat_epochs / 2,
+                quantization_submodules="null",
+            )
+        )
+
+    if pruning:
+        num_pruning_active_epochs = 0.5 * (num_epochs - num_qat_epochs)
+        recipe_variables.update(
+            dict(
+                num_pruning_active_epochs=num_pruning_active_epochs,
+                num_pruning_finetuning_epochs=0.5 * (num_epochs - num_qat_epochs),
+                pruning_init_sparsity=min(0.05, sparsity),  # enforce init <= final
+                pruning_final_sparsity=sparsity,
+                pruning_update_frequency=(
+                    1.0
+                    if num_pruning_active_epochs / 20.0 > 1
+                    else num_pruning_active_epochs / 20.0
+                ),
                 mask_type=mask_type,
                 global_sparsity=global_sparsity,
                 _num_pruning_epochs=(
@@ -216,14 +257,6 @@ def _get_base_recipe_variables(
             )
         )
 
-    if quantization:
-        recipe_variables.update(
-            dict(
-                num_qat_epochs=5,
-                num_qat_finetuning_epochs=2.5,
-                quantization_submodules="null",
-            )
-        )
     recipe_variables["num_epochs"] = _get_num_epochs(
         pruning=pruning,
         quantization=quantization,
@@ -264,7 +297,7 @@ def _get_training_builders() -> List[ModifierYAMLBuilder]:
 def _get_pruning_builders_and_variables(
     pruning_algo: str,
     model: Optional[Module] = None,
-    global_sparsity: bool = False,
+    global_sparsity: bool = True,
 ) -> Tuple[List[ModifierYAMLBuilder], Dict[str, Any]]:
     prunable_params = (
         "__ALL_PRUNABLE__"
@@ -277,7 +310,7 @@ def _get_pruning_builders_and_variables(
         params=prunable_params,
         init_sparsity=0.05,
         final_sparsity=0.8,
-        end_epoch=10.0,
+        end_epoch="eval(pruning_active_epochs)",
         update_frequency=1.0,
         mask_type="eval(mask_type)",
         global_sparsity="eval(global_sparsity)",
@@ -339,8 +372,7 @@ def _get_pruning_builders_and_variables(
     elif pruning_algo == "constant":
         modifier_class = ConstantPruningModifier
 
-        # constant pruning modifier only specifies start_epoch, end_epoch and
-        # params
+        # constant pruning modifier only specifies start_epoch and params
         pruning_arguments = dict(
             start_epoch=0.0,
             params="__ALL_PRUNABLE__",  # preferred for constant pruning

--- a/src/sparseml/pytorch/recipe_template/utils.py
+++ b/src/sparseml/pytorch/recipe_template/utils.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [
+    "create_recipe",
+    "create_sparse_transfer_recipe",
+    "create_pruning_recipe",
+    "create_quantization_recipe",
+]
+
+
+def create_recipe(model=None, **recipe_args):
+    """
+    Convenience function to create a recipe based on supplied args and kwargs
+    """
+
+
+def create_sparse_transfer_recipe(
+    model=None, quant=True, lr_func="linear", **recipe_args
+):
+    """
+    Convenience function to create a sparse transfer recipe
+    """
+
+
+def create_pruning_recipe(
+    model=None, quantization=False, lr_func="linear", **recipe_args
+):
+    """
+    Convenience function to create a pruning recipe
+    """
+
+
+def create_quantization_recipe(
+    model=None, pruning=False, lr_func="linear", **recipe_args
+):
+    """
+    Convenience function to create a quantization
+    """

--- a/tests/sparseml/pytorch/recipe_template/test_main.py
+++ b/tests/sparseml/pytorch/recipe_template/test_main.py
@@ -19,11 +19,11 @@ from packaging import version
 from torch.nn import Module
 from torch.quantization import FakeQuantize
 
+from sparseml.optim.helpers import load_recipe_variables_from_yaml
 from sparseml.pytorch import recipe_template
 from sparseml.pytorch.models import resnet50
 from sparseml.pytorch.optim import ScheduledModifierManager
 from sparseml.pytorch.utils import tensor_sparsity
-from src.sparseml.optim import load_recipe_variables_from_yaml
 
 
 @pytest.fixture

--- a/tests/sparseml/pytorch/recipe_template/test_main.py
+++ b/tests/sparseml/pytorch/recipe_template/test_main.py
@@ -147,3 +147,12 @@ def test_one_shot_applies_sparsification(pruning, quantization, quant_expected, 
         ) / sum(torch.numel(weight) for weight in weights)
 
         assert sparsity > 0.75
+
+
+def test_correct_recipe_variables():
+    # TODO: verify correct top level recipe variables given
+    #  num_epochs, init_lr, final_lr, sparsity
+
+    # use sparseml.optim.helpers.load_recipe_variables_from_yaml to extract variables
+    # from generated recipe and compare to expected values
+    pass


### PR DESCRIPTION
The following PR adds 4 convenience functions to recipe_template module, the goal being that they can be used directly and have good defaults, the function could in turn be also used as an alternative to  passing a recipe to `ScheduleModifierManager.from_yaml(...)` and instead do something like `ScheduledModifierManager.from_yaml(create_recipe())`