### PR TITLE
Adding export script for openpifpaf

### DIFF
--- a/src/sparseml/openpifpaf/README.md
+++ b/src/sparseml/openpifpaf/README.md
@@ -1,8 +1,10 @@
 # OpenPifPaf Integration
 
+## Training
+
 Sample training command:
 ```bash
-CUDA_VISIBLE_DEVICES=0 python src/sparseml/pytorch/openpifpaf/train.py \
+CUDA_VISIBLE_DEVICES=0 python src/sparseml/openpifpaf/train.py \
     --recipe prune-openpifpaf.yaml
     --lr=0.001 \
     --momentum=0.9 \
@@ -40,4 +42,13 @@ pruning_modifiers:
     start_epoch: 0.1
     end_epoch: 8.0
     update_frequency: 0.5
+```
+
+## Exporting
+
+From a training checkpoint
+```bash
+python src/sparseml/openpifpaf/export_onnx.py \
+    --checkpoint <path to .pkl.epochXXX file from train> \
+    --dataset <same dataset used for training>
 ```

--- a/src/sparseml/openpifpaf/README.md
+++ b/src/sparseml/openpifpaf/README.md
@@ -5,23 +5,26 @@
 Sample training command:
 ```bash
 CUDA_VISIBLE_DEVICES=0 python src/sparseml/openpifpaf/train.py \
-    --recipe prune-openpifpaf.yaml
+    --recipe prune-openpifpaf.yaml \
     --lr=0.001 \
     --momentum=0.9 \
     --b-scale=10.0 \
     --clip-grad-value=10.0 \
     --bce-background-clamp=-7 \
     --epochs=100 \
-    --lr-decay 80 90 \
+    --lr-decay 230 240 \
     --lr-decay-epochs=10 \
-    --batch-size=16 \
+    --batch-size=8 \
     --weight-decay=1e-5 \
-    --dataset=cocodet \
-    --cocodet-train-image-dir=/network/datasets/coco/images/train2017 \
-    --cocodet-val-image-dir=/network/datasets/coco/images/val2017 \
-    --cocodet-train-annotations=/network/datasets/coco/annotations/instances_train2017.json \
-    --cocodet-val-annotations=/network/datasets/coco/annotations/instances_val2017.json \
-    --cocodet-upsample=2 \
+    --dataset=cocokp \
+    --cocokp-square-edge=513 \
+    --cocokp-upsample=2 \
+    --cocokp-extended-scale \
+    --cocokp-orientation-invariant=0.1 \
+    --cocokp-train-image-dir=/network/datasets/coco/images/train2017 \
+    --cocokp-val-image-dir=/network/datasets/coco/images/val2017 \
+    --cocokp-train-annotations=/home/corey/coco/annotations/person_keypoints_train2017.json \
+    --cocokp-val-annotations=/home/corey/coco/annotations/person_keypoints_val2017.json \
     --basenet=mobilenetv3small
 ```
 
@@ -49,6 +52,6 @@ pruning_modifiers:
 From a training checkpoint
 ```bash
 python src/sparseml/openpifpaf/export_onnx.py \
-    --checkpoint <path to .pkl.epochXXX file from train> \
-    --dataset <same dataset used for training>
+    --checkpoint=<path to .pkl.epochXXX file from train> \
+    --dataset=cocokp
 ```

--- a/src/sparseml/openpifpaf/export_onnx.py
+++ b/src/sparseml/openpifpaf/export_onnx.py
@@ -22,6 +22,7 @@ import onnx
 import torch
 
 import openpifpaf
+from sparseml.pytorch.optim.manager import ScheduledModifierManager
 from sparseml.pytorch.utils import ModuleExporter
 
 
@@ -66,7 +67,9 @@ def main():
     )
     parser.add_argument("--input-width", type=int, default=129)
     parser.add_argument("--input-height", type=int, default=97)
-
+    parser.add_argument(
+        "--one-shot", type=str, help="Path to recipe to apply in a zero shot fashion."
+    )
     openpifpaf.datasets.cli(parser)
 
     args = parser.parse_args()
@@ -76,6 +79,10 @@ def main():
     datamodule = openpifpaf.datasets.factory(args.dataset)
 
     model, _ = openpifpaf.network.Factory().factory(head_metas=datamodule.head_metas)
+
+    if args.one_shot:
+        manager = ScheduledModifierManager.from_yaml(args.one_shot)
+        manager.apply(model)
 
     image_size_warning(model.base_net.stride, args.input_width, args.input_height)
 

--- a/src/sparseml/openpifpaf/export_onnx.py
+++ b/src/sparseml/openpifpaf/export_onnx.py
@@ -1,0 +1,98 @@
+# Adapted from https://github.com/openpifpaf/openpifpaf
+
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import os
+
+import onnx
+import torch
+
+import openpifpaf
+from sparseml.pytorch.utils import ModuleExporter
+
+
+LOG = logging.getLogger(__name__)
+
+
+def image_size_warning(basenet_stride, input_w, input_h):
+    if input_w % basenet_stride != 1:
+        LOG.warning(
+            "input width (%d) should be a multiple of basenet "
+            "stride (%d) + 1: closest are %d and %d",
+            input_w,
+            basenet_stride,
+            (input_w - 1) // basenet_stride * basenet_stride + 1,
+            ((input_w - 1) // basenet_stride + 1) * basenet_stride + 1,
+        )
+
+    if input_h % basenet_stride != 1:
+        LOG.warning(
+            "input height (%d) should be a multiple of basenet "
+            "stride (%d) + 1: closest are %d and %d",
+            input_h,
+            basenet_stride,
+            (input_h - 1) // basenet_stride * basenet_stride + 1,
+            ((input_h - 1) // basenet_stride + 1) * basenet_stride + 1,
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    openpifpaf.network.Factory.cli(parser)
+
+    parser.add_argument(
+        "--save-dir",
+        type=str,
+        default="openpifpaf-onnx-exports",
+        help="The path to the directory for saving results",
+    )
+    parser.add_argument(
+        "--name", default="model.onnx", type=str, help="Name of the model file"
+    )
+    parser.add_argument("--input-width", type=int, default=129)
+    parser.add_argument("--input-height", type=int, default=97)
+
+    openpifpaf.datasets.cli(parser)
+
+    args = parser.parse_args()
+
+    openpifpaf.network.Factory.configure(args)
+
+    datamodule = openpifpaf.datasets.factory(args.dataset)
+
+    model, _ = openpifpaf.network.Factory().factory(head_metas=datamodule.head_metas)
+
+    image_size_warning(model.base_net.stride, args.input_width, args.input_height)
+
+    # configure
+    openpifpaf.network.heads.CompositeField3.inplace_ops = False
+    openpifpaf.network.heads.CompositeField4.inplace_ops = False
+
+    exporter = ModuleExporter(model, args.save_dir)
+    exporter.export_onnx(
+        torch.randn(1, 3, args.input_height, args.input_width),
+        name=args.name,
+        input_names=["input_batch"],
+        output_names=[meta.name for meta in datamodule.head_metas],
+    )
+    onnx.checker.check_model(os.path.join(args.save_dir, args.name))
+    exporter.create_deployment_folder()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sparseml/openpifpaf/train.py
+++ b/src/sparseml/openpifpaf/train.py
@@ -25,7 +25,7 @@ import torch
 import openpifpaf
 from openpifpaf import __version__
 from openpifpaf.train import default_output_file
-from sparseml.pytorch.openpifpaf.trainer import SparseMLTrainer
+from sparseml.openpifpaf.trainer import SparseMLTrainer
 
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
The main differences from the builtin openpifpaf export script are:
1. Using our ModuleExporter
2. Adding dataset arguments to cli so the correct model structure is exported (builtin one assumes cocokp)

Test plan:
1. Ran export command with a checkpoint from training
2. Ran deepsparse.benchmark on the resulting .onnx file