### PR TITLE
[WIP][QuantizationModifier] base refactor flow - quantize entire module from QuantizationScheme

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -125,6 +125,9 @@ def is_quantizable_module(
     exclude_module_types = exclude_module_types or []
     if module.__class__.__name__ in exclude_module_types:
         return False
+    # for now - considering any "leaf level" (no children) submodule
+    # to be quantizable, update PR on this feature branch will prune the
+    # list of valid module types
     return len(list(module.children())) == 0 or isinstance(
         module, tuple(_QUANTIZABLE_MODULE_TYPES)
     )

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -19,15 +19,34 @@ PyTorch version must support quantization (>=1.2, ONNX export support introduced
 """
 
 
-from typing import Any, Dict, Type
+from typing import Any, Dict, List, Optional, Type, Union
 
+from torch.nn import Module
+from torch.optim.optimizer import Optimizer
+
+from sparseml.optim import BaseModifier, ModifierProp
 from sparseml.pytorch.sparsification.modifier import (
     PyTorchModifierYAML,
     ScheduledModifier,
 )
+from sparseml.pytorch.sparsification.quantization.helpers import (
+    configure_module_bn_wrappers,
+    fuse_module_conv_bn_relus,
+)
 from sparseml.pytorch.sparsification.quantization.legacy_modifier_quantization import (
     QuantizationModifier as LegacyQuantizationModifier,
 )
+from sparseml.pytorch.sparsification.quantization.quantize import (
+    DictQuantizationScheme,
+    QuantizationScheme,
+    add_input_activation_quant_wrappers,
+    prepare_module_qat,
+    raise_if_torch_quantization_not_available,
+    set_qconfigs_from_quantization_schemes,
+    set_quantization_schemes,
+)
+from sparseml.pytorch.utils import BaseLogger
+from sparseml.sparsification import SparsificationTypes
 
 
 __all__ = [
@@ -39,9 +58,180 @@ __all__ = [
 def _select_quantization_modifier(state: Dict[str, Any]) -> Type:
     # if kwargs for the legacy quantization modifier are provided,
     # route YAML loading to that class
+    import pdb
+
+    pdb.set_trace()
     return LegacyQuantizationModifier if "submodules" in state else QuantizationModifier
 
 
 @PyTorchModifierYAML(swap_class_by_state_fn=_select_quantization_modifier)
 class QuantizationModifier(ScheduledModifier):
-    pass
+    """
+    Enables quantization aware training (QAT) for a given module or its submodules
+    After the start epoch, the specified module(s)' forward pass will emulate
+    quantized execution and the modifier will be enabled until training is completed.
+
+    | Sample yaml:
+    |   !QuantizationModifier
+    |       start_epoch: 0.0
+    |       default_scheme:
+    |           input_activations:
+    |               num_bits: 8
+    |               symmetric: False
+    |           weights:
+    |               num_bits: 8
+    |               symmetric: True
+
+    :param start_epoch: The epoch to start the modifier at
+    :param default_scheme: Default QuantizationScheme to use when enabling quantization
+        in a module. May also be a dictionary to be loaded into the QuantizationScheme
+        class. If None, the default scheme (`QuantizationScheme()`) will be used.
+        Default is None
+    :param end_epoch: Disabled, setting to anything other than -1 will raise an
+        exception. For compatibility with YAML serialization only.
+    """
+
+    def __init__(
+        self,
+        start_epoch: float = -1.0,
+        default_scheme: Union[QuantizationScheme, DictQuantizationScheme, None] = None,
+        end_epoch: float = -1,
+    ):
+        raise_if_torch_quantization_not_available()
+        if end_epoch != -1:
+            raise ValueError(
+                "end_epoch is disabled for QuantizationModifier and can only be set to"
+                " -1. Given {}".format(end_epoch)
+            )
+        super().__init__(start_epoch=start_epoch, end_epoch=-1.0, end_comparator=-1)
+
+        self._default_scheme = _load_default_scheme(default_scheme)
+
+        self._qat_enabled = False
+
+    @BaseModifier.sparsification_types.getter
+    def sparsification_types(self) -> List[SparsificationTypes]:
+        """
+        :return: the sparsification types this modifier instance will apply
+        """
+        return [SparsificationTypes.quantization, SparsificationTypes.structured]
+
+    @ModifierProp()
+    def default_scheme(self) -> Union[QuantizationScheme, DictQuantizationScheme, None]:
+        """
+        :return: Default QuantizationScheme to use when enabling quantization
+            in a module. returned as a dictionary for serialization purposes
+        """
+        return self._default_scheme
+
+    @default_scheme.setter
+    def default_scheme(
+        self,
+        value: Union[QuantizationScheme, DictQuantizationScheme, None],
+    ):
+        """
+        :params value: Default QuantizationScheme to use when enabling quantization
+            in a module. May also be a dictionary to be loaded into the
+            QuantizationScheme class. If None, the default scheme
+            (`QuantizationScheme()`) will be used
+        """
+        self._default_scheme = _load_default_scheme(value)
+
+    def initialize(
+        self,
+        module: Module,
+        epoch: float = 0,
+        loggers: Optional[List[BaseLogger]] = None,
+        **kwargs,
+    ):
+        """
+        Grab the module / submodule to perform QAT on
+
+        :param module: the PyTorch model/module to modify
+        :param epoch: The epoch to initialize the modifier and module at.
+            Defaults to 0 (start of the training process)
+        :param loggers: Optional list of loggers to log the modification process to
+        :param kwargs: Optional kwargs to support specific arguments
+            for individual modifiers.
+        """
+        super().initialize(module, epoch, loggers, **kwargs)
+
+        self._check_quantization_update(module, epoch, steps_per_epoch=0)
+
+    def update(
+        self, module: Module, optimizer: Optimizer, epoch: float, steps_per_epoch: int
+    ):
+        """
+        If start_pending(), fuses the model, sets the model quantization config,
+        calls torch.quantization.prepare_qat on the model to begin QAT
+        If end_pending(), updates the modules layers params to their original
+        trainable state.
+
+        :param module: module to modify
+        :param optimizer: optimizer to modify
+        :param epoch: current epoch and progress within the current epoch
+        :param steps_per_epoch: number of steps taken within each epoch
+            (calculate batch number using this and epoch)
+        """
+        super().update(module, optimizer, epoch, steps_per_epoch)
+        self._check_quantization_update(module, epoch, steps_per_epoch)
+
+    def update_ready(self, epoch: float, steps_per_epoch: int) -> bool:
+        """
+
+        :param epoch: current epoch and progress within the current epoch
+        :param steps_per_epoch: number of steps taken within each epoch
+            (calculate batch number using this and epoch)
+        :return: True if the modifier is pending an update and update() should be called
+        """
+        if not self._initialized:
+            raise RuntimeError("modifier must be initialized first")
+
+        if not self._enabled:
+            return False
+
+        pending = self.start_pending(epoch, steps_per_epoch)
+
+        return pending
+
+    def _check_quantization_update(
+        self, module: Module, epoch: float, steps_per_epoch: int
+    ):
+        if self.start_pending(epoch, steps_per_epoch) and not self._qat_enabled:
+            self._enable_module_qat(module)
+
+    def _enable_module_qat(self, module: Module):
+        # fuse conv-bn-relu blocks prior to quantization emulation
+        fuse_module_conv_bn_relus(module, inplace=True)
+
+        # add quantization_schemes to target submodules
+        set_quantization_schemes(module, default_scheme=self._default_scheme)
+
+        # set appropriate qconfig properties in submodules
+        set_qconfigs_from_quantization_schemes(module)
+
+        # fix for freezing batchnorm statistics when not fusing BN with convs.
+        # pytorch only supports freezing batchnorm statistics for fused modules.
+        # this fix wraps BN modules adding with a new module class that supports
+        # methods related to freezing/unfreezing BN statistics.
+        configure_module_bn_wrappers(module)
+
+        # inject necessary QuantWrappers into the module to apply QAT to
+        # targeted layer input activations
+        module = add_input_activation_quant_wrappers(module)
+
+        # convert target qconfig layers to QAT modules with FakeQuantize
+        prepare_module_qat(module)
+
+        self._qat_enabled = True
+
+
+def _load_default_scheme(
+    default_scheme: Union[QuantizationScheme, DictQuantizationScheme, None]
+) -> QuantizationScheme:
+    if default_scheme is None:
+        return QuantizationScheme()
+    elif isinstance(default_scheme, QuantizationScheme):
+        return default_scheme
+    else:
+        return QuantizationScheme.parse_obj(default_scheme)

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -58,9 +58,6 @@ __all__ = [
 def _select_quantization_modifier(state: Dict[str, Any]) -> Type:
     # if kwargs for the legacy quantization modifier are provided,
     # route YAML loading to that class
-    import pdb
-
-    pdb.set_trace()
     return LegacyQuantizationModifier if "submodules" in state else QuantizationModifier
 
 
@@ -95,7 +92,7 @@ class QuantizationModifier(ScheduledModifier):
         self,
         start_epoch: float = -1.0,
         default_scheme: Union[QuantizationScheme, DictQuantizationScheme, None] = None,
-        end_epoch: float = -1,
+        end_epoch: float = -1.0,
     ):
         raise_if_torch_quantization_not_available()
         if end_epoch != -1:

--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -17,24 +17,45 @@ Tooling for applying quantization to pytorch modules via
 structured configurations
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import torch
 from pydantic import BaseModel, Field
+from torch.nn import Module
 
-from sparseml.pytorch.sparsification.quantization.helpers import compute_range
+from sparseml.pytorch.sparsification.quantization.helpers import (
+    get_observer,
+    is_quantizable_module,
+    prepare_embeddings_qat,
+)
 
 
 try:
     from torch import quantization as torch_quantization
+    from torch.nn import intrinsic as torch_intrinsic
 except Exception:
     torch_quantization = None
+    torch_intrinsic = None
 
 
 __all__ = [
+    "DictQuantizationArgs",
+    "DictQuantizationScheme",
     "QuantizationArgs",
     "QuantizationScheme",
+    "set_quantization_schemes",
+    "set_qconfigs_from_quantization_schemes",
+    "add_input_activation_quant_wrappers",
+    "raise_if_torch_quantization_not_available",
 ]
+
+
+"""
+Type definition aliases for defining QuantizationArgs and QuantizationScheme
+as dictionaries for YAML serialization
+"""
+DictQuantizationArgs = Dict[str, Union[int, bool, Dict[str, Any]]]
+DictQuantizationScheme = Dict[str, DictQuantizationArgs]
 
 
 class QuantizationArgs(BaseModel):
@@ -76,18 +97,12 @@ class QuantizationArgs(BaseModel):
         """
         :return: torch quantization FakeQuantize built based on these QuantizationArgs
         """
-        qscheme = (
-            torch.per_tensor_symmetric if self.symmetric else torch.per_tensor_affine
-        )
-        target_dtype = torch.qint8
-        quant_min, quant_max = compute_range(target_dtype, self.num_bits)
-        return torch_quantization.FakeQuantize.with_args(
-            observer=torch_quantization.MovingAverageMinMaxObserver,
-            quant_min=quant_min,
-            quant_max=quant_max,
-            dtype=target_dtype,
-            qscheme=qscheme,
-            **self.kwargs,
+        return get_observer(
+            symmetric=self.symmetric,
+            dtype=torch.qint8,
+            bits=self.num_bits,
+            reduce_range=self.kwargs.get("reduce_range", False),
+            qconfig_kwargs=self.kwargs,
         )
 
 
@@ -97,6 +112,14 @@ class QuantizationScheme(BaseModel):
     quantizing models. Provides a simple user interface for defining how inputs,
     weights, and outputs should be quantized
     """
+
+    def __init__(self, *args, **kwargs):
+        # support for loading from yaml str
+        args = [arg if arg != "null" else None for arg in args]
+        for key, val in kwargs.items():
+            if val == "null":
+                kwargs[key] = None
+        super().__init__(*args, **kwargs)
 
     input_activations: Optional[QuantizationArgs] = Field(
         default_factory=QuantizationArgs.default_activation_args,
@@ -132,6 +155,101 @@ class QuantizationScheme(BaseModel):
         :return: QConfig for QuantWrapper objects (input activations used)
         """
         return _get_qconfig(self.input_activations, self.weights)
+
+    def __str__(self) -> str:
+        """
+        :return: YAML friendly string serialization
+        """
+        dict_repr = self.dict()
+        dict_repr = {
+            key: val if val is not None else "null" for key, val in dict_repr.items()
+        }
+        return str(dict_repr)
+
+
+def set_quantization_schemes(module: Module, default_scheme: QuantizationScheme):
+    """
+    Sets an appropriate `quantization_scheme` porperty to targeted sections of the
+    given module based on inputs
+
+    :param module: module to attach QuantizationSchemes to
+    :param default_scheme: default scheme to add to a target module unless overwritten
+        by another scheme
+    """
+    module.quantization_scheme = default_scheme
+
+
+def set_qconfigs_from_quantization_schemes(module: Module):
+    """
+    Sets `qconfig` properties to the given module and its submodule
+    based on any potentially assigned quantization schemes
+
+    :param module: module to set qconfig properties for
+    """
+    for submodule in module.modules():
+        if not hasattr(submodule, "quantization_scheme"):
+            continue
+        submodule.qconfig = submodule.quantization_scheme.get_qconfig()
+
+
+def add_input_activation_quant_wrappers(module: Module) -> Module:
+    """
+    Adds QuantWrapper objects to wrap submodules that include quantization
+    schemes targeting input activations
+
+    :param module: module to add input activation QuantWrappers for
+    :return: the updated module - necessary in case top level module is wrapped
+        as in-place modification will not support it
+    """
+    # check if module type is appropriate for quantization
+    is_quantizable = is_quantizable_module(module)
+
+    # check if module targets input activation quantization
+    quantize_activations = (
+        hasattr(module, "quantization_scheme")
+        and (module.quantization_scheme is not None)
+        and module.quantization_scheme.input_activations is not None
+    )
+
+    if is_quantizable and quantize_activations:
+        # wrap module with a QuantWrapper and assign it the input activation qconfig
+        wrapper_qconfig = module.quantization_scheme.get_wrapper_qconfig()
+        module = torch_quantization.QuantWrapper(module)
+        module.qconfig = wrapper_qconfig
+
+        # assumes no nested children of a wrapped block need input activation
+        # does not recurse further in this case
+    else:
+        # recurse to module children
+        for name, child in module.named_children():
+            setattr(module, name, add_input_activation_quant_wrappers(child))
+    return module
+
+
+def prepare_module_qat(module: Module):
+    """
+    Converts submodules with set qconfigs into quantization aware modules
+    with FakeQuantize modules in the model
+
+    :param module: module to convert to QAT mode
+    """
+    # set modules with proper qconfigs to QAT mode
+    torch_quantization.prepare_qat(module, inplace=True)
+    # manual pass to convert relevant Embedding layers
+    prepare_embeddings_qat(module)
+
+
+def raise_if_torch_quantization_not_available():
+    """
+    :raises: RuntimeError if the installed torch version does not include
+        support for quantization aware training
+    """
+    if torch_quantization is None or torch_intrinsic is None:
+        raise RuntimeError(
+            "Unable to import package torch.quantization and/or "
+            "torch.nn.intrinsic. "
+            "Try upgrading your PyTorch version to use the QuantizationModifier."
+        )
 
 
 def _get_qconfig(

--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional, Union
 
 import torch
 from pydantic import BaseModel, Field
-from torch.nn import Module
+from torch.nn import Identity, Module
 
 from sparseml.pytorch.sparsification.quantization.helpers import (
     get_observer,
@@ -191,6 +191,9 @@ def set_qconfigs_from_quantization_schemes(module: Module):
             continue
         submodule.qconfig = submodule.quantization_scheme.get_qconfig()
 
+    # TODO: remove after set_quantization_schemes updated
+    torch_quantization.propagate_qconfig_(module)
+
 
 def add_input_activation_quant_wrappers(module: Module) -> Module:
     """
@@ -256,6 +259,6 @@ def _get_qconfig(
     activation_args: Optional[QuantizationArgs], weight_args: Optional[QuantizationArgs]
 ) -> "torch.quantization.QConfig":
     return torch_quantization.QConfig(
-        activation=activation_args.get_observer() if activation_args else None,
-        weight=weight_args.get_observer() if weight_args else None,
+        activation=activation_args.get_observer() if activation_args else Identity,
+        weight=weight_args.get_observer() if weight_args else Identity,
     )

--- a/tests/sparseml/pytorch/sparsification/quantization/test_helpers.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_helpers.py
@@ -29,8 +29,8 @@ from sparseml.pytorch.sparsification.quantization import (
     prepare_embeddings_qat,
 )
 from sparseml.pytorch.sparsification.quantization.helpers import get_observer
-from sparseml.pytorch.sparsification.quantization.modifier_quantization import (
-    QuantizationModifier,
+from sparseml.pytorch.sparsification.quantization.legacy_modifier_quantization import (
+    QuantizationModifier as LegacyQuantizationModifier,
 )
 
 
@@ -294,7 +294,7 @@ def test_zero_point_is_128():
 
     # give QATMatMul a layer to be wrapped
     dummy_sequential = torch.nn.Sequential(_QATMatMul())
-    QuantizationModifier().apply(dummy_sequential)
+    LegacyQuantizationModifier().apply(dummy_sequential)
     qat_matmul = dummy_sequential[0]
     _ = qat_matmul(torch.randn(10, 10), torch.randn(10, 10))
 

--- a/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
@@ -20,12 +20,147 @@ from sparseml.pytorch.sparsification.quantization.modifier_quantization import (
     QuantizationModifier,
 )
 from sparseml.pytorch.sparsification.quantization.quantize import QuantizationScheme
+from tests.sparseml.pytorch.helpers import ConvNet, LinearNet, create_optim_sgd
+from tests.sparseml.pytorch.sparsification.test_modifier import ScheduledModifierTest
+
+
+from tests.sparseml.pytorch.helpers import (  # noqa isort:skip
+    test_epoch,
+    test_loss,
+    test_steps_per_epoch,
+)
 
 
 try:
     from torch import quantization as torch_quantization
 except Exception:
     torch_quantization = None
+
+
+def _assert_qconfigs_equal(qconfig_1, qconfig_2):
+    def _assert_observers_eq(observer_1, observer_2):
+        assert type(observer_1) is type(observer_2)
+
+        if hasattr(observer_1, "p"):
+            # assume observer is a partial, test by properties dict
+            assert observer_1.p.keywords == observer_2.p.keywords
+        else:
+            # default to plain `==`
+            assert observer_1 == observer_2
+
+    # check activation and weight observers
+    _assert_observers_eq(qconfig_1.activation, qconfig_2.activation)
+    _assert_observers_eq(qconfig_1.weight, qconfig_2.weight)
+
+
+def _test_quantized_module(module):
+    quantization_scheme = getattr(module, "quantization_scheme", None)
+    qconfig = getattr(module, "qconfig", None)
+    assert quantization_scheme is not None
+    assert qconfig is not None
+
+    is_quant_wrapper = isinstance(module, torch_quantization.QuantWrapper)
+
+    expected_qconfig = (
+        quantization_scheme.get_wrapper_qconfig()
+        if is_quant_wrapper
+        else quantization_scheme.get_qconfig()
+    )
+
+    _assert_qconfigs_equal(qconfig, expected_qconfig)
+
+    if is_quant_wrapper:
+        # test wrapped module
+        _test_quantized_module(module.module)
+
+
+def _test_qat_applied(modifier, model):
+    # TODO: update to test against expected target modules from modifier
+    # for now, just test QuantWrappers are as expected
+    assert getattr(model, "qconfig", None) is not None
+
+    for module in model.modules():
+        if isinstance(module, torch_quantization.QuantWrapper):
+            _test_quantized_module(module)
+
+
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
+    reason="Skipping pytorch tests",
+)
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_QUANT_TESTS", False),
+    reason="Skipping pytorch torch quantization tests",
+)
+@pytest.mark.skipif(
+    torch_quantization is None,
+    reason="torch quantization not available",
+)
+@pytest.mark.parametrize(
+    "modifier_lambda,model_lambda",
+    [
+        (lambda: QuantizationModifier(start_epoch=0.0), LinearNet),
+        (
+            lambda: QuantizationModifier(
+                start_epoch=0.0, default_scheme=QuantizationScheme(weights=None)
+            ),
+            LinearNet,
+        ),
+        (lambda: QuantizationModifier(start_epoch=0.0), ConvNet),
+        (lambda: QuantizationModifier(start_epoch=2.0), ConvNet),
+    ],
+    scope="function",
+)
+@pytest.mark.parametrize("optim_lambda", [create_optim_sgd], scope="function")
+class TestQuantizationModifierImpl(ScheduledModifierTest):
+    def test_lifecycle(
+        self,
+        modifier_lambda,
+        model_lambda,
+        optim_lambda,
+        test_steps_per_epoch,  # noqa: F811,
+    ):
+        modifier = modifier_lambda()
+        model = model_lambda()
+        optimizer = optim_lambda(model)
+
+        self.initialize_helper(modifier, model)
+
+        for epoch in range(int(modifier.start_epoch)):
+            assert not modifier.update_ready(epoch, test_steps_per_epoch)
+
+        update_epochs = [modifier.start_epoch]
+        for epoch in update_epochs:
+            assert modifier.update_ready(epoch, test_steps_per_epoch)
+        # test update ready is still true after start epoch
+        # even if quantization has not been applied yet
+        assert modifier.update_ready(modifier.start_epoch + 0.1, test_steps_per_epoch)
+
+        # test QAT setup
+        if modifier.start_epoch > 0:
+            for module in model.modules():
+                assert not hasattr(module, "qconfig") or module.qconfig is None
+        else:
+            # QAT should be applied
+            # _test_qat_applied(modifier, model)
+            pass
+
+        modifier.scheduled_update(
+            model, optimizer, modifier.start_epoch, test_steps_per_epoch
+        )
+
+        # test update ready is False after start epoch is applied, before disable epochs
+        if (
+            len(update_epochs) == 1
+            or min(update_epochs[1:]) <= modifier.start_epoch + 1
+        ):
+            # test epochs in 0.1 intervals
+            for epoch_interval in range(10):
+                epoch_interval *= 0.1
+                epoch = modifier.start_epoch + 0.1 * epoch_interval
+                assert not modifier.update_ready(epoch, test_steps_per_epoch)
+
+        # _test_qat_applied(modifier, model)
 
 
 @pytest.mark.skipif(

--- a/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from sparseml.pytorch.sparsification.quantization.modifier_quantization import (
+    QuantizationModifier,
+)
+from sparseml.pytorch.sparsification.quantization.quantize import QuantizationScheme
+
+
+try:
+    from torch import quantization as torch_quantization
+except Exception:
+    torch_quantization = None
+
+
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
+    reason="Skipping pytorch tests",
+)
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_QUANT_TESTS", False),
+    reason="Skipping pytorch torch quantization tests",
+)
+@pytest.mark.skipif(
+    torch_quantization is None,
+    reason="torch quantization not available",
+)
+def test_quantization_modifier_yaml():
+    start_epoch = 0.0
+    default_scheme = dict(
+        input_activations=dict(num_bits=8, symmetric=True),
+        weights=dict(num_bits=6, symmetric=False),
+    )
+    yaml_str = f"""
+        !QuantizationModifier
+            start_epoch: {start_epoch}
+            default_scheme: {default_scheme}
+        """
+    yaml_modifier = QuantizationModifier.load_obj(
+        yaml_str
+    )  # type: QuantizationModifier
+    serialized_modifier = QuantizationModifier.load_obj(
+        str(yaml_modifier)
+    )  # type: QuantizationModifier
+    obj_modifier = QuantizationModifier(
+        start_epoch=start_epoch,
+        default_scheme=default_scheme,
+    )
+
+    assert isinstance(yaml_modifier, QuantizationModifier)
+    assert (
+        yaml_modifier.start_epoch
+        == serialized_modifier.start_epoch
+        == obj_modifier.start_epoch
+    )
+    assert (
+        yaml_modifier.default_scheme
+        == serialized_modifier.default_scheme
+        == obj_modifier.default_scheme
+    )
+    assert isinstance(yaml_modifier.default_scheme, QuantizationScheme)
+    assert isinstance(serialized_modifier.default_scheme, QuantizationScheme)
+    assert isinstance(obj_modifier.default_scheme, QuantizationScheme)

--- a/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
@@ -142,7 +142,7 @@ class TestQuantizationModifierImpl(ScheduledModifierTest):
                 assert not hasattr(module, "qconfig") or module.qconfig is None
         else:
             # QAT should be applied
-            # _test_qat_applied(modifier, model)
+            _test_qat_applied(modifier, model)
             pass
 
         modifier.scheduled_update(
@@ -160,7 +160,7 @@ class TestQuantizationModifierImpl(ScheduledModifierTest):
                 epoch = modifier.start_epoch + 0.1 * epoch_interval
                 assert not modifier.update_ready(epoch, test_steps_per_epoch)
 
-        # _test_qat_applied(modifier, model)
+        _test_qat_applied(modifier, model)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Adds support for a basic quantization flow in the updated `QuantizationModifier`. as of this PR, we will still follow torch `propagate_qconfig` and default to quantizing the entire module

Importantly, sets up helper functions that follow the `QuantizationScheme` arguments

**test_plan:**
* yaml serialization test included
* lifecycle testing + assertions around proper QAT application