### PR TITLE
Fixing bugs with resume & checkpointing in torchvision

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -440,7 +440,7 @@ def main(args):
 
     # load params
     if checkpoint is not None:
-        model.load_state_dict(checkpoint["model"])
+        model.load_state_dict(checkpoint["state_dict"])
         optimizer.load_state_dict(checkpoint["optimizer"])
         if model_ema and "model_ema" in checkpoint:
             model_ema.load_state_dict(checkpoint["model_ema"])
@@ -782,7 +782,7 @@ def _deprecate_old_arguments(f):
 )
 @click.option("--print-freq", default=10, type=int, help="print frequency")
 @click.option("--output-dir", default=".", type=str, help="path to save outputs")
-@click.option("--resume", default="", type=str, help="path of checkpoint")
+@click.option("--resume", default=None, type=str, help="path of checkpoint")
 @click.option(
     "--checkpoint-path",
     default=None,


### PR DESCRIPTION
These two lines fix two separate issues:
1. A value Error that resume and checkpoint-path cannot both be specified is thrown if checkpoint-path is specified, because the default of resume is empty string
2. The model params are in "state_dict" instead of "model"