### PR TITLE
Falling back to model.pth if model.ckpt.pth is missing

### DIFF
--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -1146,17 +1146,15 @@ def download_framework_model_by_recipe_type(
     recipe_name = recipe_name or (
         zoo_model.stub_params.get("recipe_type") or zoo_model.stub_params.get("recipe")
     )
+
+    framework_model = None
     if recipe_name and "transfer" in recipe_name.lower():
         # fetching the model for transfer learning
         model_name = f"model.ckpt.{model_suffix}"
         framework_model = zoo_model.training.default.get_file(model_name)
-        if not framework_model:
-            raise ValueError(
-                f"Could not find saved checkpoint {model_name} in SparseZoo Model "
-                f"{zoo_model.source}"
-            )
-    else:
-        # fetching the model for inference
+
+    if framework_model is None:
+        # fetching the model for inference or fall back if model.ckpt.pth doesn't exist
         model_name = f"model.{model_suffix}"
         framework_model = zoo_model.training.default.get_file(model_name)
 


### PR DESCRIPTION
If you run the transfer learning command from here https://sparsezoo.neuralmagic.com/models/cv%2Fclassification%2Fresnet_v1-50%2Fpytorch%2Fsparseml%2Fimagenet%2Fpruned95-none, the model.ckpt.pth file is missing, so you will get a value error raised even though the model.pth file exists.

This PR just falls back to model.pth if model.ckpt.pth is missing.

Testing plan:
1. ran training command above to verify crash
2. ran same training command after fix to verify training started