### PR TITLE
[QuantizationModifier] improved quantization flow - control of propagation with schemes and stronger testing

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/__init__.py
+++ b/src/sparseml/pytorch/sparsification/quantization/__init__.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .constants import *
 from .helpers import *
 from .modifier_quantization import *
 from .quantize import *

--- a/src/sparseml/pytorch/sparsification/quantization/constants.py
+++ b/src/sparseml/pytorch/sparsification/quantization/constants.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Constants related to sparseml pytorch quantization flows
+"""
+
+
+__all__ = [
+    "NON_QUANTIZABLE_MODULE_NAMES",
+]
+
+
+"""
+Quantization Modifier quantizes all 'leaf' level modules by default
+this list contains modules that are very unlikely to be desired for quantization
+and will not have a QuantizationScheme ever attached to them by the modifier
+QuantizationSchemes may be manually attached with the .quantization_scheme
+property and the modifier will then pick up the module for quantization
+"""
+NON_QUANTIZABLE_MODULE_NAMES = {
+    # no-ops
+    "Module",
+    "Identity",
+    "Flatten",
+    "Unflatten",
+    "DataParallel",
+    # losses
+    "L1Loss",
+    "NLLLoss",
+    "KLDivLoss",
+    "MSELoss",
+    "BCELoss",
+    "BCEWithLogitsLoss",
+    "NLLLoss2d",
+    "PoissonNLLLoss",
+    "CosineEmbeddingLoss",
+    "CTCLoss",
+    "HingeEmbeddingLoss",
+    "MarginRankingLoss",
+    "MultiLabelMarginLoss",
+    "MultiLabelSoftMarginLoss",
+    "MultiMarginLoss",
+    "SmoothL1Loss",
+    "GaussianNLLLoss",
+    "HuberLoss",
+    "SoftMarginLoss",
+    "CrossEntropyLoss",
+    "TripletMarginLoss",
+    "AdaptiveLogSoftmaxWithLoss",
+    "TripletMarginWithDistanceLoss",
+    # dropouts
+    "Dropout",
+    "Dropout1d",
+    "Dropout2d",
+    "Dropout3d",
+    "AlphaDropout",
+    "FeatureAlphaDropout",
+}
+
+
+FUSED_MODULE_NAMES = {
+    # Conv based layers
+    "ConvBn1d",
+    "ConvBn2d",
+    "ConvBn3d",
+    "ConvReLU1d",
+    "ConvReLU2d",
+    "ConvReLU3d",
+    "ConvBnReLU1d",
+    "ConvBnReLU2d",
+    "ConvBnReLU3d",
+    # Linear Layers
+    "LinearReLU",
+}

--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -48,7 +48,6 @@ __all__ = [
     "QConfigProperties",
     "LINEAR_ACTIVATION_NAMES",
     "CONV_ACTIVATION_NAMES",
-    "is_quantizable_module",
 ]
 
 LINEAR_ACTIVATION_NAMES = ["Linear", "LinearReLU"]
@@ -108,29 +107,6 @@ _FUSED_MODULE_TYPES = (
     if nni  # nni will always import if torch.quantization is available
     else tuple()
 )
-
-
-def is_quantizable_module(
-    module: Module,
-    exclude_module_types: Optional[List[str]] = None,
-) -> bool:
-    """
-    :param module: module to check
-    :param exclude_module_types: string names of modules to not include for
-        quantization. Default None
-    :return: boolean value if the module is quantizable. Module is considered
-        quantizable if its type is not included in exclude_module_types and
-        it either has no module children or is a torch qat fused module
-    """
-    exclude_module_types = exclude_module_types or []
-    if module.__class__.__name__ in exclude_module_types:
-        return False
-    # for now - considering any "leaf level" (no children) submodule
-    # to be quantizable, update PR on this feature branch will prune the
-    # list of valid module types
-    return len(list(module.children())) == 0 or isinstance(
-        module, tuple(_QUANTIZABLE_MODULE_TYPES)
-    )
 
 
 @dataclass


### PR DESCRIPTION
this PR adds the following functionality and improvements:

core:
  * quantization modifier now fully controls propagation of schemes and qconfigs by having its own function for selecting which submodules get a quantization_scheme, then only adding qconfigs to submodules with schemes
  * modifier now by default targets all (minus a hardcoded list of 'non' quantizable modules) leaf submodules for quantization

improvements:
  * testing fixes
  * testing includes check that observers are actually created
  * quantization flow in modifier improved to just set schemes -> apply qat from schemes

**test_plan:**
unit tests included