### PR TITLE
[QuantizationModifier] module_type_schemes - override quantization scheme by layer type

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -83,6 +83,11 @@ class QuantizationModifier(ScheduledModifier):
     |                   num_bits: 8
     |                   symmetric: False
     |               weights: null
+    |       module_type_schemes:
+    |           Conv2d:
+    |               input_activations:
+    |                   num_bits: 8
+    |                   symmetric: True
     |       exclude_module_types: ["ReLU"]
 
     :param start_epoch: The epoch to start the modifier at

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -92,11 +92,14 @@ class QuantizationModifier(ScheduledModifier):
         If None, the default scheme (`QuantizationScheme()`) will be used.
         Default is None
     :param submodule_schemes: Specify submodules to target for quantization. Must
-        be a dictionary of the submodule name to the a quantization scheme
+        be a dictionary of the submodule name to a quantization scheme
         specification to quantize that submodule with.  Modules not included under
         a named submodule in the dictionary will not be targeted for quantization.
         If set to None, the entire module will be quantized falling back to the default
         scheme. Default is None
+    :param module_type_schemes: Specify how to quantize specific module types. Must
+        be a dictionary of the module type name to a quantization scheme
+        specification to quantize that module type with. Default is None
     :param exclude_module_types: optional list of module class names
         to not quantize. Default is None
     :param end_epoch: Disabled, setting to anything other than -1 will raise an
@@ -108,6 +111,7 @@ class QuantizationModifier(ScheduledModifier):
         start_epoch: float = -1.0,
         default_scheme: QuantizationSchemeLoadable = None,
         submodule_schemes: Optional[Dict[str, QuantizationSchemeLoadable]] = None,
+        module_type_schemes: Optional[Dict[str, QuantizationSchemeLoadable]] = None,
         exclude_module_types: Optional[List[str]] = None,
         end_epoch: float = -1.0,
     ):
@@ -122,6 +126,9 @@ class QuantizationModifier(ScheduledModifier):
         self._default_scheme = QuantizationScheme.load(default_scheme)
         self._submodule_schemes = _load_quantization_schemes_dict(
             submodule_schemes, self._default_scheme
+        )
+        self._module_type_schemes = _load_quantization_schemes_dict(
+            module_type_schemes, self._default_scheme
         )
         self._exclude_module_types = exclude_module_types
 
@@ -155,20 +162,48 @@ class QuantizationModifier(ScheduledModifier):
     @ModifierProp()
     def submodule_schemes(self) -> Optional[Dict[str, QuantizationSchemeLoadable]]:
         """
-        :return: Default QuantizationScheme to use when enabling quantization
-            in a module. returned as a dictionary for serialization purposes
+        :return: Specify submodules to target for quantization. Must
+            be a dictionary of the submodule name to a quantization scheme
+            specification to quantize that submodule with.  Modules not included under
+            a named submodule in the dictionary will not be targeted for quantization.
+            If set to None, the entire module will be quantized falling back to the
+            default scheme.
         """
         return self._submodule_schemes
 
     @submodule_schemes.setter
     def submodule_schemes(self, value: Optional[Dict[str, QuantizationSchemeLoadable]]):
         """
-        :params value: Default QuantizationScheme to use when enabling quantization
-            in a module. May also be a dictionary to be loaded into the
-            QuantizationScheme class. If None, the default scheme
-            (`QuantizationScheme()`) will be used
+        :params value:  Specify submodules to target for quantization. Must
+            be a dictionary of the submodule name to a quantization scheme
+            specification to quantize that submodule with.  Modules not included under
+            a named submodule in the dictionary will not be targeted for quantization.
+            If set to None, the entire module will be quantized falling back to the
+            default scheme.
         """
         self._submodule_schemes = _load_quantization_schemes_dict(
+            value, self._default_scheme
+        )
+
+    @ModifierProp()
+    def module_type_schemes(self) -> Optional[Dict[str, QuantizationSchemeLoadable]]:
+        """
+        :return: Default Specify how to quantize specific module types. Must
+            be a dictionary of the module type name to a quantization scheme
+            specification to quantize that module type with.
+        """
+        return self._module_type_schemes
+
+    @module_type_schemes.setter
+    def module_type_schemes(
+        self, value: Optional[Dict[str, QuantizationSchemeLoadable]]
+    ):
+        """
+        :params value: Specify how to quantize specific module types. Must
+            be a dictionary of the module type name to a quantization scheme
+            specification to quantize that module type with.
+        """
+        self._module_type_schemes = _load_quantization_schemes_dict(
             value, self._default_scheme
         )
 
@@ -262,6 +297,7 @@ class QuantizationModifier(ScheduledModifier):
             module,
             default_scheme=self._default_scheme,
             submodule_schemes=self._submodule_schemes,
+            module_type_schemes=self._module_type_schemes,
             exclude_module_types=self._exclude_module_types,
         )
 


### PR DESCRIPTION
`module_type_schemes` allows a user to override quantization schemes by matching layer class names (ie `Linear`, `Conv2d`)

this replaces arguments in the existing quantization modifier that handle specific layer types (ie conv/linear activations, embeddings, etc)

**test_plan:**:
unit tests updated for:
* yaml serialization
* check the correct scheme is set when there is a module_type_schemes match