### PR TITLE
[QuantizationModifier] target hardware support

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -93,7 +93,8 @@ class QuantizationModifier(ScheduledModifier):
     :param start_epoch: The epoch to start the modifier at
     :param default_scheme: Default QuantizationScheme to use when enabling quantization
         in a module. May also be a dictionary to be loaded into the QuantizationScheme
-        class. A string alias may also be used, supported aliases: ['default'].
+        class. A string alias may also be used, supported aliases:
+        ['default', 'deepsparse', 'tensorrt'].
         If None, the default scheme (`QuantizationScheme()`) will be used.
         Default is None
     :param submodule_schemes: Specify submodules to target for quantization. Must

--- a/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
@@ -167,7 +167,7 @@ def _test_qat_applied(modifier, model):
         (lambda: QuantizationModifier(start_epoch=0.0), ConvNet),
         (
             lambda: QuantizationModifier(
-                start_epoch=2.0, submodule_schemes=dict(mlp="default")
+                start_epoch=2.0, submodule_schemes=dict(mlp="deepsparse")
             ),
             ConvNet,
         ),
@@ -182,7 +182,7 @@ def _test_qat_applied(modifier, model):
             lambda: QuantizationModifier(
                 start_epoch=0.0,
                 submodule_schemes=dict(
-                    seq="default", mlp=QuantizationScheme(weights=None)
+                    seq="tensorrt", mlp=QuantizationScheme(weights=None)
                 ),
                 exclude_module_types=["ReLU"],
             ),
@@ -262,7 +262,7 @@ def test_quantization_modifier_yaml():
         weights=dict(num_bits=6, symmetric=False),
     )
     submodule_schemes = dict(
-        feature_extractor="default",
+        feature_extractor="deepsparse",
         classifier=dict(
             input_activations=dict(num_bits=8, symmetric=True),
             weights=None,

--- a/tests/sparseml/pytorch/sparsification/quantization/test_quantize.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_quantize.py
@@ -107,3 +107,32 @@ def test_quantization_args_get_observer(
 
     assert observer.p.keywords["quant_min"] == target_quant_min
     assert observer.p.keywords["quant_max"] == target_quant_max
+
+
+@pytest.mark.parametrize(
+    "scheme_str,expected_scheme",
+    [
+        ("default", QuantizationScheme()),
+        (
+            "deepsparse",
+            QuantizationScheme(
+                input_activations=QuantizationArgs(num_bits=8, symmetric=False),
+                weights=QuantizationArgs(num_bits=8, symmetric=True),
+                output_activations=None,
+            ),
+        ),
+        (
+            "tensorrt",
+            QuantizationScheme(
+                input_activations=QuantizationArgs(num_bits=8, symmetric=True),
+                weights=QuantizationArgs(num_bits=8, symmetric=True),
+                output_activations=None,
+            ),
+        ),
+        # adding to raise an issue if default scheme changes from deepsparse
+        ("deepsparse", QuantizationScheme()),
+    ],
+)
+def test_load_quantization_scheme_from_str(scheme_str, expected_scheme):
+    loaded_scheme = QuantizationScheme.load(scheme_str)
+    assert loaded_scheme == expected_scheme


### PR DESCRIPTION
adds support for `deepsparse` and `tensorrt` as target hardware deployments by adding  `QuantizationScheme` aliases for them.

this was done instead of having an explicit target_harware argument to avoid requiring an extra argument. the aliases be set either as the default scheme and/or in the dict overrides

**test_plan**:
unit tests added/updated for:
* using target hardware with the modifier
* `QuantizationModifier.load` returns the correct scheme based on the alias