### PR TITLE
[QuantizationModifier] override params for model fuse step

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -161,6 +161,13 @@ class QuantizationScheme(BaseModel):
             "not quantize output activations. Default is None"
         ),
     )
+    target_hardware: Optional[str] = Field(
+        default=None,
+        description=(
+            "target deployment runtime/hardware name to be set by default "
+            "classmethods. Default is None"
+        ),
+    )
 
     @classmethod
     def load(
@@ -212,6 +219,7 @@ class QuantizationScheme(BaseModel):
             input_activations=QuantizationArgs(num_bits=8, symmetric=False),
             weights=QuantizationArgs(num_bits=8, symmetric=True),
             output_activations=None,
+            target_hardware="deepsparse",
         )
 
     @classmethod
@@ -225,6 +233,7 @@ class QuantizationScheme(BaseModel):
             input_activations=QuantizationArgs(num_bits=8, symmetric=True),
             weights=QuantizationArgs(num_bits=8, symmetric=True),
             output_activations=None,
+            target_hardware="tensorrt",
         )
 
     def get_qconfig(self) -> "torch.quantization.QConfig":

--- a/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
@@ -300,6 +300,8 @@ def test_quantization_modifier_yaml():
     disable_quantization_observer_epoch = 2.0
     freeze_bn_stats_epoch = 3.0
     num_calibration_steps = 1000
+    model_fuse_fn_name = "custom_fuse_fn"
+    model_fuse_fn_kwargs = dict(inplace=True)
 
     yaml_str = f"""
     !QuantizationModifier
@@ -311,6 +313,8 @@ def test_quantization_modifier_yaml():
         disable_quantization_observer_epoch: {disable_quantization_observer_epoch}
         freeze_bn_stats_epoch: {freeze_bn_stats_epoch}
         num_calibration_steps: {num_calibration_steps}
+        model_fuse_fn_name: {model_fuse_fn_name}
+        model_fuse_fn_kwargs: {model_fuse_fn_kwargs}
     """
     yaml_modifier = QuantizationModifier.load_obj(
         yaml_str
@@ -327,6 +331,8 @@ def test_quantization_modifier_yaml():
         disable_quantization_observer_epoch=disable_quantization_observer_epoch,
         freeze_bn_stats_epoch=freeze_bn_stats_epoch,
         num_calibration_steps=num_calibration_steps,
+        model_fuse_fn_name=model_fuse_fn_name,
+        model_fuse_fn_kwargs=model_fuse_fn_kwargs,
     )
 
     assert isinstance(yaml_modifier, QuantizationModifier)
@@ -372,4 +378,14 @@ def test_quantization_modifier_yaml():
         yaml_modifier.num_calibration_steps
         == serialized_modifier.num_calibration_steps
         == obj_modifier.num_calibration_steps
+    )
+    assert (
+        yaml_modifier.model_fuse_fn_name
+        == serialized_modifier.model_fuse_fn_name
+        == obj_modifier.model_fuse_fn_name
+    )
+    assert (
+        yaml_modifier.model_fuse_fn_kwargs
+        == serialized_modifier.model_fuse_fn_kwargs
+        == obj_modifier.model_fuse_fn_kwargs
     )

--- a/tests/sparseml/pytorch/sparsification/quantization/test_quantize.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_quantize.py
@@ -119,6 +119,7 @@ def test_quantization_args_get_observer(
                 input_activations=QuantizationArgs(num_bits=8, symmetric=False),
                 weights=QuantizationArgs(num_bits=8, symmetric=True),
                 output_activations=None,
+                target_hardware="deepsparse",
             ),
         ),
         (
@@ -127,10 +128,11 @@ def test_quantization_args_get_observer(
                 input_activations=QuantizationArgs(num_bits=8, symmetric=True),
                 weights=QuantizationArgs(num_bits=8, symmetric=True),
                 output_activations=None,
+                target_hardware="tensorrt",
             ),
         ),
         # adding to raise an issue if default scheme changes from deepsparse
-        ("deepsparse", QuantizationScheme()),
+        ("deepsparse", QuantizationScheme(target_hardware="deepsparse")),
     ],
 )
 def test_load_quantization_scheme_from_str(scheme_str, expected_scheme):


### PR DESCRIPTION
ports the model fuse function overrides from the legacy modifier
adds a `target_hardware` field to `QuantizationScheme` for tracking and serialization of platform dependent changes

**test_plan:**
* changes pass unit tests
* yaml tests updated