### PR TITLE
Torchvision eval fixes

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -22,7 +22,6 @@ import time
 import warnings
 from functools import update_wrapper
 from types import SimpleNamespace
-from sparseml.pytorch.utils.model import load_model
 
 import torch
 import torch.utils.data
@@ -40,6 +39,7 @@ from sparseml.pytorch.utils.helpers import (
     download_framework_model_by_recipe_type,
     torch_distributed_zero_first,
 )
+from sparseml.pytorch.utils.model import load_model
 from sparsezoo import Model
 
 

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -418,22 +418,24 @@ def main(args):
         checkpoint = _load_checkpoint(args.checkpoint_path)
 
         # restore state from prior recipe
-        manager = ScheduledModifierManager.from_yaml(args.recipe)
-        checkpoint_manager = ScheduledModifierManager.from_yaml(
-            checkpoint["checkpoint_recipe"]
+        manager = ScheduledModifierManager.from_yaml(
+            checkpoint["recipe"] or args.recipe
         )
-        checkpoint_manager.apply_structure(model, epoch=checkpoint["epoch"])
+        checkpoint_manager = ScheduledModifierManager.from_yaml(checkpoint["recipe"])
+        checkpoint_manager.apply_structure(model, epoch=checkpoint.get("epoch", -1))
     elif args.resume:
         checkpoint = _load_checkpoint(args.resume)
 
         # NOTE: override manager with the checkpoint's manager
-        manager = ScheduledModifierManager.from_yaml(checkpoint["checkpoint_recipe"])
+        manager = ScheduledModifierManager.from_yaml(checkpoint["recipe"])
         checkpoint_manager = None
         manager.initialize(model, epoch=checkpoint["epoch"])
 
         # NOTE: override start epoch
         args.start_epoch = checkpoint["epoch"] + 1
     else:
+        if args.recipe is None:
+            raise ValueError("Must specify --recipe if not loading from a checkpoint")
         checkpoint = None
         manager = ScheduledModifierManager.from_yaml(args.recipe)
         checkpoint_manager = None
@@ -446,6 +448,23 @@ def main(args):
             model_ema.load_state_dict(checkpoint["model_ema"])
         if scaler and "scaler" in checkpoint:
             scaler.load_state_dict(checkpoint["scaler"])
+
+    if args.test_only:
+        # We disable the cudnn benchmarking because it can
+        # noticeably affect the accuracy
+        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.deterministic = True
+        if model_ema:
+            evaluate(
+                model_ema,
+                criterion,
+                data_loader_test,
+                device,
+                log_suffix="EMA",
+            )
+        else:
+            evaluate(model, criterion, data_loader_test, device)
+        return
 
     optimizer = manager.modify(model, optimizer, len(data_loader))
 
@@ -502,23 +521,6 @@ def main(args):
 
         if args.resume and checkpoint:
             lr_scheduler.load_state_dict(checkpoint["lr_scheduler"])
-
-    if args.test_only:
-        # We disable the cudnn benchmarking because it can
-        # noticeably affect the accuracy
-        torch.backends.cudnn.benchmark = False
-        torch.backends.cudnn.deterministic = True
-        if model_ema:
-            evaluate(
-                model_ema,
-                criterion,
-                data_loader_test,
-                device,
-                log_suffix="EMA",
-            )
-        else:
-            evaluate(model, criterion, data_loader_test, device)
-        return
 
     model_without_ddp = model
     if args.distributed:
@@ -580,12 +582,12 @@ def main(args):
                     if epoch == manager.max_epochs - 1
                     else epoch + checkpoint_manager.max_epochs
                 )
-                checkpoint["checkpoint_recipe"] = str(
+                checkpoint["recipe"] = str(
                     ScheduledModifierManager.compose_staged(checkpoint_manager, manager)
                 )
             else:
                 checkpoint["epoch"] = -1 if epoch == manager.max_epochs - 1 else epoch
-                checkpoint["checkpoint_recipe"] = str(manager)
+                checkpoint["recipe"] = str(manager)
 
             file_names = ["checkpoint.pth"]
             if is_new_best:
@@ -658,7 +660,7 @@ def _deprecate_old_arguments(f):
         allow_extra_args=True,
     )
 )
-@click.option("--recipe", required=True, type=str, help="Path to recipe")
+@click.option("--recipe", default=None, type=str, help="Path to recipe")
 @click.option("--dataset-path", required=True, type=str, help="dataset path")
 @click.option(
     "--arch-key",

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -419,7 +419,7 @@ def main(args):
 
         # restore state from prior recipe
         manager = ScheduledModifierManager.from_yaml(
-            checkpoint["recipe"] or args.recipe
+            args.recipe or checkpoint["recipe"]
         )
         checkpoint_manager = ScheduledModifierManager.from_yaml(checkpoint["recipe"])
         checkpoint_manager.apply_structure(model, epoch=checkpoint.get("epoch", -1))


### PR DESCRIPTION
This fixes a couple things:
1. Renames checkpoint_recipe -> recipe to be consistent with old checkpoints
2. Optionally get epoch from checkpoint
3. Removes calls to apply_structure with checkpoint since ModelRegistry/load_model does that already
4. Makes `--recipe` optional 

# Testing plan
ran this command successfully
```bash
sparseml.image_classification.train --test-only --dataset-path ../.cache/nm_datasets/imagenette/imagenette-160 --arch-key resnet50 --checkpoint-path zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/channel30_pruned90_quant-none
```