### PR TITLE
Stop integration tests on first failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test:
 # run integration tests
 testinteg:
 	@echo "Running integration tests";
-	SPARSEZOO_TEST_MODE="true" pytest tests/integrations $(PYTEST_INTEGRATION_ARGS)
+	SPARSEZOO_TEST_MODE="true" pytest -x tests/integrations $(PYTEST_INTEGRATION_ARGS)
 
 # create docs
 docs:


### PR DESCRIPTION
Our set of integration tests take ~10 minutes to run on GHA. This can add up to a significant amount of waiting time when bug hunting. This PR updates the integration test command to stop after the first error is encountered to be able to cycle on fixes faster