### PR TITLE
Transformers auto install - don't import before install

### DIFF
--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -96,7 +96,7 @@ def _check_transformers_install():
         else:
             _LOGGER.warning(
                 f"sparseml-transformers v{_EXPECTED_VERSION} installation not "
-                "detected. Installing  sparseml-transformers v{_EXPECTED_VERSION} "
+                f"detected. Installing  sparseml-transformers v{_EXPECTED_VERSION} "
                 "dependencies if transformers is already  installed in the "
                 "environment, it will be overwritten. Set  environment variable "
                 "NM_NO_AUTOINSTALL_TRANSFORMERS to disable"

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -18,7 +18,6 @@ Tools for integrating SparseML with transformers training flows
 
 # flake8: noqa
 
-import importlib
 import logging as _logging
 
 import pkg_resources

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -62,9 +62,7 @@ def _install_transformers_and_deps():
             ]
         )
 
-        import transformers
-
-        importlib.reload(transformers)
+        import transformers as _transformers
 
         _LOGGER.info("sparseml-transformers and dependencies successfully installed")
     except Exception:
@@ -110,7 +108,7 @@ def _check_transformers_install():
         import transformers as _transformers
 
         # Edge case where user has expected version of transformers installed, but
-        # not ours
+        # not the nm integrated one
         if not _transformers.NM_INTEGRATED:
             _install_transformers_and_deps()
             raise RuntimeError(


### PR DESCRIPTION
If a user has a version of transformers installed that is either not one of ours or is out of date with the expected version, then after our auto-install gets triggered and overrides their version, the stale transformers import will cause errors. As importlib.reload() doesn't work with the transformers library, this PR fixes the issue by checking the version of the transformers install without importing.

Test Plan
```python
pip install sparseml
sparseml.transformers.train.text_classification --help
pip show transformers #-> 4.18.0.dev0
pip uninstall sparseml
pip install -e . # in sparseml source directory
sparseml.transformers.train.text_classification --help
pip show transformers #-> 4.23.1
pip uninstall transformers
pip install transformers
sparseml.transformers.train.text_classification --help
pip show transformers #-> 4.23.1
pip uninstall transformers
sparseml.transformers.train.text_classification --help
pip show transformers #-> 4.23.1
```