### PR TITLE
[QuantizationModifier] logging support

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -473,6 +473,8 @@ class QuantizationModifier(ScheduledModifier):
             module.apply(freeze_bn_stats)
             self._bn_stats_frozen = True
 
+        self._log_quantization(module, epoch, steps_per_epoch)
+
     def _disable_quantization_observer_update_ready(self, epoch: float) -> bool:
         return (
             self._disable_quantization_observer_epoch is not None
@@ -613,6 +615,51 @@ class QuantizationModifier(ScheduledModifier):
                 "Disabling model fuse step"
             )
             self._model_fuse_fn_name = "no_fuse"
+
+    def _log_quantization(
+        self,
+        module: Module,
+        epoch: float,
+        steps_per_epoch: int,
+    ):
+        """
+        Check whether to log an update for the learning rate of the modifier.
+
+        :param module: module to modify
+        :param optimizer: optimizer to modify
+        :param epoch: current epoch and progress within the current epoch
+        :param steps_per_epoch: number of steps taken within each epoch
+            (calculate batch number using this and epoch)
+        """
+
+        def _log(tag, value):
+            self.log_scalar(
+                tag=tag,
+                value=value,
+                epoch=epoch,
+                steps_per_epoch=steps_per_epoch,
+            )
+
+        # log layer-wise quantization info
+        num_fake_quantizes = 0
+        for name, submodule in module.named_modules():
+            if not isinstance(submodule, torch.quantization.FakeQuantize):
+                continue
+            num_fake_quantizes += 1
+
+        # log global quantization info
+        _log(
+            tag="QuantizationModifier/num_fake_quantize_global",
+            value=num_fake_quantizes,
+        )
+        _log(
+            tag="QuantizationModifier/bn_stats_frozen",
+            value=1.0 if self._bn_stats_frozen else 0.0,
+        )
+        _log(
+            tag="QuantizationModifier/qat_observers_disabled",
+            value=1.0 if self._quantization_observer_disabled else 0.0,
+        )
 
 
 class _QuantizationSchemesDict(dict):

--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -20,6 +20,7 @@ PyTorch version must support quantization (>=1.2, ONNX export support introduced
 
 
 import logging
+import math
 import warnings
 from itertools import cycle
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
@@ -646,6 +647,14 @@ class QuantizationModifier(ScheduledModifier):
             if not isinstance(submodule, torch.quantization.FakeQuantize):
                 continue
             num_fake_quantizes += 1
+
+            qrange = submodule.quant_max - submodule.quant_min + 1
+            num_bits = int(math.log2(qrange))
+
+            _log(
+                tag=f"QuantizationModifier/{name}/num_bits",
+                value=num_bits,
+            )
 
         # log global quantization info
         _log(


### PR DESCRIPTION
adds support to log:
* number of fake quantize ops injected
* status of bn/observer freezing
* number of bits of each fake quantize op w/ name

**test_plan:**
manually verified:

quantization flow:
```python
import logging
logging.basicConfig(level=logging.DEBUG)

from sparseml.pytorch.models import resnet18
from sparseml.pytorch.optim import ScheduledModifierManager
from sparseml.pytorch.sparsification import QuantizationModifier
from sparseml.pytorch.utils import PythonLogger, LoggerManager

model = resnet18()
manager = ScheduledModifierManager([QuantizationModifier(start_epoch=1.0)])
manager.initialize(model, epoch=0, loggers=([PythonLogger()]))
manager.update(model, None, 1.0, 1)
```

resulting log file:
```
python QuantizationModifier/num_fake_quantize_global [0 - 1670537974.3711507]: 0
python QuantizationModifier/bn_stats_frozen [0 - 1670537974.37134]: 0.0
python QuantizationModifier/qat_observers_disabled [0 - 1670537974.371371]: 0.0
python QuantizationModifier/input.conv.quant.activation_post_process/num_bits [1 - 1670537975.335868]: 8
python QuantizationModifier/input.conv.module.weight_fake_quant/num_bits [1 - 1670537975.335981]: 8
python QuantizationModifier/input.pool.quant.activation_post_process/num_bits [1 - 1670537975.3360167]: 8
python QuantizationModifier/sections.0.0.conv1.quant.activation_post_process/num_bits [1 - 1670537975.3360507]: 8

...

python QuantizationModifier/sections.3.1.conv1.quant.activation_post_process/num_bits [1 - 1670537975.3388393]: 8
python QuantizationModifier/sections.3.1.conv1.module.weight_fake_quant/num_bits [1 - 1670537975.3388638]: 8
python QuantizationModifier/sections.3.1.conv2.quant.activation_post_process/num_bits [1 - 1670537975.3388903]: 8
python QuantizationModifier/sections.3.1.conv2.module.weight_fake_quant/num_bits [1 - 1670537975.3389149]: 8
python QuantizationModifier/sections.3.1.conv3.quant.activation_post_process/num_bits [1 - 1670537975.338941]: 8
python QuantizationModifier/sections.3.1.conv3.module.weight_fake_quant/num_bits [1 - 1670537975.3389664]: 8
python QuantizationModifier/sections.3.1.add_relu.quant.activation_post_process/num_bits [1 - 1670537975.338992]: 8
python QuantizationModifier/sections.3.2.conv1.quant.activation_post_process/num_bits [1 - 1670537975.3390198]: 8
python QuantizationModifier/sections.3.2.conv1.module.weight_fake_quant/num_bits [1 - 1670537975.3390446]: 8
python QuantizationModifier/sections.3.2.conv2.quant.activation_post_process/num_bits [1 - 1670537975.339071]: 8
python QuantizationModifier/sections.3.2.conv2.module.weight_fake_quant/num_bits [1 - 1670537975.3390954]: 8
python QuantizationModifier/sections.3.2.conv3.quant.activation_post_process/num_bits [1 - 1670537975.3391218]: 8
python QuantizationModifier/sections.3.2.conv3.module.weight_fake_quant/num_bits [1 - 1670537975.339147]: 8
python QuantizationModifier/sections.3.2.add_relu.quant.activation_post_process/num_bits [1 - 1670537975.3391728]: 8
python QuantizationModifier/classifier.avgpool.quant.activation_post_process/num_bits [1 - 1670537975.3392015]: 8
python QuantizationModifier/classifier.fc.quant.activation_post_process/num_bits [1 - 1670537975.339228]: 8
python QuantizationModifier/classifier.fc.module.weight_fake_quant/num_bits [1 - 1670537975.339255]: 8
python QuantizationModifier/classifier.softmax.quant.activation_post_process/num_bits [1 - 1670537975.3392801]: 8
python QuantizationModifier/classifier.softmax.module.activation_post_process/num_bits [1 - 1670537975.3393056]: 8
python QuantizationModifier/num_fake_quantize_global [1 - 1670537975.3393326]: 128
python QuantizationModifier/bn_stats_frozen [1 - 1670537975.339352]: 0.0
python QuantizationModifier/qat_observers_disabled [1 - 1670537975.3393712]: 0.0
```