### PR TITLE
[QuantizationModifier] UX refactor - submodule_overrides and ignore

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -493,10 +493,11 @@ class QuantizationModifier(ScheduledModifier):
         # add quantization_schemes to target submodules
         set_quantization_schemes(
             module,
-            default_scheme=self._scheme,
-            submodule_schemes=self._submodule_schemes,
-            module_type_schemes=self._module_type_schemes,
-            exclude_module_types=self._exclude_module_types,
+            scheme=self._scheme,
+            scheme_overrides=dict(
+                **(self._submodule_schemes or {}), **(self._module_type_schemes or {})
+            ),
+            ignore=self._exclude_module_types,
         )
 
         # fix for freezing batchnorm statistics when not fusing BN with convs.

--- a/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
@@ -175,7 +175,7 @@ def _test_freeze_bn_stats_observer_applied(modifier, epoch):
         (lambda: QuantizationModifier(start_epoch=0.0), LinearNet),
         (
             lambda: QuantizationModifier(
-                start_epoch=0.0, default_scheme=QuantizationScheme(weights=None)
+                start_epoch=0.0, scheme=QuantizationScheme(weights=None)
             ),
             LinearNet,
         ),
@@ -306,7 +306,7 @@ class TestQuantizationModifierImpl(ScheduledModifierTest):
 )
 def test_quantization_modifier_yaml():
     start_epoch = 0.0
-    default_scheme = dict(
+    scheme = dict(
         input_activations=dict(num_bits=8, symmetric=True),
         weights=dict(num_bits=6, symmetric=False),
     )
@@ -328,7 +328,7 @@ def test_quantization_modifier_yaml():
     yaml_str = f"""
     !QuantizationModifier
         start_epoch: {start_epoch}
-        default_scheme: {default_scheme}
+        scheme: {scheme}
         submodule_schemes: {submodule_schemes}
         module_type_schemes: {module_type_schemes}
         exclude_module_types: {exclude_module_types}
@@ -346,7 +346,7 @@ def test_quantization_modifier_yaml():
     )  # type: QuantizationModifier
     obj_modifier = QuantizationModifier(
         start_epoch=start_epoch,
-        default_scheme=default_scheme,
+        scheme=scheme,
         submodule_schemes=submodule_schemes,
         module_type_schemes=module_type_schemes,
         exclude_module_types=exclude_module_types,
@@ -363,14 +363,10 @@ def test_quantization_modifier_yaml():
         == serialized_modifier.start_epoch
         == obj_modifier.start_epoch
     )
-    assert (
-        yaml_modifier.default_scheme
-        == serialized_modifier.default_scheme
-        == obj_modifier.default_scheme
-    )
-    assert isinstance(yaml_modifier.default_scheme, QuantizationScheme)
-    assert isinstance(serialized_modifier.default_scheme, QuantizationScheme)
-    assert isinstance(obj_modifier.default_scheme, QuantizationScheme)
+    assert yaml_modifier.scheme == serialized_modifier.scheme == obj_modifier.scheme
+    assert isinstance(yaml_modifier.scheme, QuantizationScheme)
+    assert isinstance(serialized_modifier.scheme, QuantizationScheme)
+    assert isinstance(obj_modifier.scheme, QuantizationScheme)
     assert (
         yaml_modifier.submodule_schemes
         == serialized_modifier.submodule_schemes

--- a/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
+++ b/tests/sparseml/pytorch/sparsification/quantization/test_modifier_quantization.py
@@ -120,12 +120,11 @@ def _test_qat_applied(modifier, model):
             # skip helper modules
             continue
 
-        is_target_submodule = modifier.submodule_schemes is None or (
-            any(
-                name.startswith(submodule_name)
-                for submodule_name in modifier.submodule_schemes
-            )
+        is_target_submodule = not any(
+            name.startswith(submodule_name)
+            for submodule_name in (modifier.exclude_module_types or [])
         )
+
         if is_target_submodule and is_quantizable_module(
             module, exclude_module_types=modifier.exclude_module_types
         ):


### PR DESCRIPTION
This PR cleans up the UX with the following effects:

* `default_scheme` renamed to `scheme`
* `submodule_schemes` and `module_type_schemes` unified into `scheme_overrides`
* `exclude_module_types` renamed to `ignore`
* `ignore` also includes the ability to specify submodule names to skip
* all submodules will now be targeted unless included in `ignore` (previously, if `submodule_schemes` was set, then only those submodules would be targeted)

helper functions were migrated first with intermediate testing to ensure that existing functionality remained in-tact

**test_plan:**
* unit tests updated to test for new functionality
* existing unit tests pass
* yaml test updated