### PR TITLE
[QuantizationModifier] strict mode - raise if unmatched submodules or types

### DIFF
--- a/src/sparseml/pytorch/sparsification/modifier.py
+++ b/src/sparseml/pytorch/sparsification/modifier.py
@@ -733,9 +733,10 @@ class ScheduledModifier(Modifier, BaseScheduled):
     ):
         tag = tag or type(self).__name__
         loggers = loggers or self.loggers
+        edge_epochs = [None, float("-inf"), float("inf")]
         step = (
             loggers.epoch_to_step(epoch, steps_per_epoch)
-            if (epoch is not None) and (steps_per_epoch is not None)
+            if (epoch not in edge_epochs) and (steps_per_epoch is not None)
             else None
         )
         loggers.log_scalar(tag=tag, value=value, step=step, level=level)


### PR DESCRIPTION
strict by default adds a check that the all overrides and ignores given by the user are actually found in the module. meant to catch any config errors earlier rather than later but gives user the option to turn off

**test_plan:**
* yaml test updated
* existing tests now passing under strict (found and fixed one issue)
* test added to check for expected errors