### PR TITLE
GPU Synchronisation bug

### DIFF
--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -233,14 +233,11 @@ class ImageClassificationTrainer(Trainer):
         _LOGGER.info(f"Applied {self.recipe_path} to manager")
 
     def _initialize_module_tester(self):
-        """
-        This uses self.model.module unlike the ModuleTrainer which uses self.model
-        so that the validation runs on the local copy of the model on the rank 0 gpu
-        rather than on the distributed model
-        """
-        
+        # This uses self.model.module unlike the ModuleTrainer which uses self.model
+        # so that the validation runs on the local copy of the model on the rank 0 gpu
+        # rather than on the distributed model
         tester = ModuleTester(
-            module=self.model.module,
+            module=self.model.module if is_parallel_model(self.model) else self.model,
             device=self.device,
             loss=self.val_loss,
             loggers=self.loggers,

--- a/src/sparseml/pytorch/image_classification/utils/trainer.py
+++ b/src/sparseml/pytorch/image_classification/utils/trainer.py
@@ -233,8 +233,14 @@ class ImageClassificationTrainer(Trainer):
         _LOGGER.info(f"Applied {self.recipe_path} to manager")
 
     def _initialize_module_tester(self):
+        """
+        This uses self.model.module unlike the ModuleTrainer which uses self.model
+        so that the validation runs on the local copy of the model on the rank 0 gpu
+        rather than on the distributed model
+        """
+        
         tester = ModuleTester(
-            module=self.model,
+            module=self.model.module,
             device=self.device,
             loss=self.val_loss,
             loggers=self.loggers,


### PR DESCRIPTION
There is a GPU synchronisation error that occurs after an image classification training runs to completion in Kubeflow DDP 

"""
ProcessGroupNCCL.cpp:325] Some NCCL operations have failed or timed out. Due to the asynchronous nature of CUDA kernels, subsequent GPU operations might run on corrupted/incomplete data. To avoid this inconsistency, we are taking the entire process down.
terminate called after throwing an instance of 'std::runtime_error'
  what():  NCCL error: unhandled system error, NCCL version 2.7.8
ncclSystemError: System call (socket, malloc, munmap, etc) failed.
Fatal Python error: Aborted
"""

This PR fixes the GPU synchronisation error by making sure that the image classification validation (post training) that runs only on the rank 0 GPU uses the local (rank 0) copy of the model rather than the distributed version. This avoids the NCCL communication during validation reaching out to other (rank > 0) processes that have already completed their training execution. 

Reproduction:
I ran the training command listed under transfer-classification.md in this link in kubeflow:
https://sparsezoo.neuralmagic.com/models/cv%2Fclassification%2Fresnet_v1-50%2Fpytorch%2Fsparseml%2Fimagenet%2Fpruned95-none



