### PR TITLE
Relax eval_on_test constraint, set training mode earlier for qat

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/modifier_quantization.py
@@ -713,7 +713,8 @@ class QuantizationModifier(ScheduledModifier):
             self._strip_excluded_module_qconfigs(module)
 
         # set modules with proper qconfigs to QAT mode
-        torch_quantization.prepare_qat(module, inplace=True)
+        self._prepare_qat(module, inplace=True)
+
         if self._quantize_embeddings:
             prepare_embeddings_qat(module, qproperties)
 
@@ -725,6 +726,13 @@ class QuantizationModifier(ScheduledModifier):
         if hasattr(module, "module"):
             # for DP/DDP unwrapping
             module.module.export_with_qlinearconv = self._quantize_conv_activations
+
+    def _prepare_qat(self, module, inplace=False):
+        # Set training mode to satisfy a constraint during torch's prepare_qat
+        prev_training_mode = module.training
+        module.training = True
+        torch_quantization.prepare_qat(module, inplace=inplace)
+        module.training = prev_training_mode
 
     def _calibrate_if_possible(self, module):
         if self.num_calibration_steps == 0 and self._calibration_dataloader:

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -836,6 +836,11 @@ class TrainerInterface(RecipeManagerTrainerInterface):
         :param kwargs: keyword args to pass to super().train()
         :return: the output from super.train()
         """
+        prev_training_mode = None
+        if not self.one_shot:
+            # Set training mode to satisfy a constraint during prepare_qat
+            prev_training_mode = self.model.training
+            self.model.training = True
         checkpoint, epoch = self._generate_apply_manager_params(kwargs)
         applied = self.apply_manager(epoch=epoch, checkpoint=checkpoint)
         self.callback_disable_fp16.check_disable(epoch, force=True)
@@ -847,6 +852,9 @@ class TrainerInterface(RecipeManagerTrainerInterface):
         else:
             _LOGGER.info(f"Skipping Training due to one-shot: {self.one_shot}")
         self.log_model_sparsification()
+
+        if prev_training_mode is not None:
+            self.model.training = prev_training_mode
 
         return output
 

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -836,11 +836,6 @@ class TrainerInterface(RecipeManagerTrainerInterface):
         :param kwargs: keyword args to pass to super().train()
         :return: the output from super.train()
         """
-        prev_training_mode = None
-        if not self.one_shot:
-            # Set training mode to satisfy a constraint during prepare_qat
-            prev_training_mode = self.model.training
-            self.model.training = True
         checkpoint, epoch = self._generate_apply_manager_params(kwargs)
         applied = self.apply_manager(epoch=epoch, checkpoint=checkpoint)
         self.callback_disable_fp16.check_disable(epoch, force=True)
@@ -852,9 +847,6 @@ class TrainerInterface(RecipeManagerTrainerInterface):
         else:
             _LOGGER.info(f"Skipping Training due to one-shot: {self.one_shot}")
         self.log_model_sparsification()
-
-        if prev_training_mode is not None:
-            self.model.training = prev_training_mode
 
         return output
 


### PR DESCRIPTION
This PR:
- sets the training mode earlier to pass a check in prepare_qat by torch;
- allows for using eval_on_test even if the validation set is present (so that we could run eval after hyperparam search on the test set);
- moves the train, eval, predict split creation into a separate func.