### PR TITLE
[Exporter Refactor] Don't print onnx models on failure

### DIFF
--- a/src/sparseml/onnx/utils/helpers.py
+++ b/src/sparseml/onnx/utils/helpers.py
@@ -90,7 +90,7 @@ def validate_onnx_file(path: str):
         if not onnx_model.opset_import:
             raise ValueError("could not parse opset_import")
     except Exception as err:
-        raise ValueError("file at {} is not a valid onnx model: {}".format(path, err))
+        raise ValueError(f"Invalid onnx model: {err}")
 
 
 def check_load_model(model: Union[str, ModelProto]) -> ModelProto:
@@ -107,7 +107,7 @@ def check_load_model(model: Union[str, ModelProto]) -> ModelProto:
     if isinstance(model, str):
         return onnx.load(clean_path(model))
 
-    raise ValueError("unknown type given for model: {}".format(model))
+    raise ValueError(f"unknown type given for model: {type(model)}")
 
 
 def extract_node_id(node: NodeProto) -> str:


### PR DESCRIPTION
This was causing long debug/test failures because it was printing the whole onnx model to stdout.