### PR TITLE
[QuantizationModifier] take ownership of add_observers_, unit test fixes

### DIFF
--- a/src/sparseml/pytorch/recipe_template/main.py
+++ b/src/sparseml/pytorch/recipe_template/main.py
@@ -30,6 +30,8 @@ from sparseml.pytorch.sparsification import (
     MFACPruningModifier,
     MovementPruningModifier,
     OBSPruningModifier,
+)
+from sparseml.pytorch.sparsification.quantization.legacy_modifier_quantization import (
     QuantizationModifier,
 )
 from sparseml.pytorch.utils import get_prunable_layers

--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -231,6 +231,7 @@ def add_output_activation_observers(module: Module):
     :param module: module to add output activation observers to
     """
     # adapted from torch/ao/quantization/quantize.py::_add_observer_
+    # source: https://github.com/pytorch/pytorch/blob/v1.13.0/torch/ao/quantization/quantize.py#L135  # noqa: E501
     device = next(module.parameters()).device
 
     def _needs_observer(target_module: Module):

--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -235,6 +235,9 @@ def add_output_activation_observers(module: Module):
     device = next(module.parameters()).device
 
     def _needs_observer(target_module: Module):
+        # combines logic from multiple places of original implementation which
+        # mostly checked for existnace of a qconfig and if the target was a leaf
+        # module
         if (
             not hasattr(target_module, "quantization_scheme")
             or (hasattr(target_module, "activation_post_process"))


### PR DESCRIPTION
this PR addresses three issues found in testing of the new `QuantizationModifier`:

1. addresses an break in recipe template tests
2. uses `FakeQuantizeBase` for inheritance comparisons where possible (introduced as default in later versions of torch)
3. torch 1.9 tests revealed that torch quantization will inject its own activation post process hooks into certain activations without any way to disable. this PR adds its own implementation of add observers that does not include this override. (fixes issues with quantization of `Sigmoid` and other activations)
4. previously, the new modifier still deferred to torch for quantization of output activations - this was a known hole as we try to quantize "everything" while torch mostly keeps to a white-list. as part of the activation fix in (3), we update our add observers implementation to quantize activations of *all* target modules as determined by `QuantizationScheme` propagation
5. fix for compatibility with the `FloatFunctional` module used for resnet quantization

**test_plan:**
* tests updated to ensure that output activation quantization is tested for existence and adherence to the scheme