### PR TITLE
[Exporter Refactor] Adding `any_of` for get_structural_matches and MatchResult to str

### DIFF
--- a/tests/sparseml/exporters/transforms/utils/test_matching.py
+++ b/tests/sparseml/exporters/transforms/utils/test_matching.py
@@ -17,9 +17,9 @@ import pytest
 
 from sparseml.exporters.transforms.utils.matching import (
     INITIALIZER_MATCH,
+    any_of,
     get_structural_matches,
     optional_node,
-    any_of,
 )
 from sparseml.onnx.utils.graph_editor import ONNXGraph
 


### PR DESCRIPTION
See docstring and tests for example.

Test plan: unit tests & I used this in some of the passes (will be in separate PRs) and they all passed their unit tests