### PR TITLE
[Exporter Refactor] Standardize non core transforms

### DIFF
--- a/src/sparseml/exporters/transforms/constants_to_initializers.py
+++ b/src/sparseml/exporters/transforms/constants_to_initializers.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 from onnx import ModelProto, numpy_helper
 
 from sparseml.exporters.transforms.onnx_transform import OnnxTransform
 
 
 __all__ = ["ConstantsToInitializers"]
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class ConstantsToInitializers(OnnxTransform):
@@ -33,10 +29,9 @@ class ConstantsToInitializers(OnnxTransform):
         for node in model.graph.node:
             if node.op_type != "Constant" or len(node.attribute) != 1:
                 continue
-            _LOGGER.debug(f"Transforming {node.name} to initializer")
+            self.log_match(node)
             const_array = numpy_helper.to_array(node.attribute[0].t)
             initializer = numpy_helper.from_array(const_array, name=node.output[0])
             model.graph.initializer.append(initializer)
             self.delete_node_deferred(node)
-        _LOGGER.info(f"Removed {len(self._nodes_to_delete)} Constant nodes")
         return model

--- a/src/sparseml/exporters/transforms/delete_repeated_qdq.py
+++ b/src/sparseml/exporters/transforms/delete_repeated_qdq.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 from onnx import ModelProto
 
 from sparseml.exporters.transforms.onnx_transform import OnnxTransform
@@ -22,8 +20,6 @@ from sparseml.onnx.utils import ONNXGraph
 
 
 __all__ = ["DeleteRepeatedQdq"]
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class DeleteRepeatedQdq(OnnxTransform):
@@ -58,7 +54,7 @@ class DeleteRepeatedQdq(OnnxTransform):
             children_ops=[["DequantizeLinear", "QuantizeLinear", "DequantizeLinear"]],
         )
         for match in matches:
-            _LOGGER.debug(f"Matched {match}")
+            self.log_match(match)
             quant_node_1 = match.node
             (dequant_node_1, quant_node_2, dequant_node_2) = match.children[0]
 
@@ -68,5 +64,4 @@ class DeleteRepeatedQdq(OnnxTransform):
             # remove repeated quant/dequant block
             self.delete_node_deferred(quant_node_1)
             self.delete_node_deferred(dequant_node_1)
-        _LOGGER.info(f"Removed {len(self._nodes_to_delete)} Q/Dq nodes")
         return model

--- a/src/sparseml/exporters/transforms/delete_trivial_onnx_adds.py
+++ b/src/sparseml/exporters/transforms/delete_trivial_onnx_adds.py
@@ -19,7 +19,7 @@ from onnx import ModelProto, numpy_helper
 
 from sparseml.exporters.transforms import OnnxTransform
 from sparseml.exporters.transforms.utils import get_structural_matches
-from sparseml.onnx.utils import ONNXGraph, remove_node_and_params_from_graph
+from sparseml.onnx.utils import ONNXGraph
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,23 +27,27 @@ _LOGGER = logging.getLogger(__name__)
 
 class DeleteTrivialOnnxAdds(OnnxTransform):
     """
-    | Starting with:
-    |   Input   Constant (with initializer, optionally set to zero)
-    |       |    |
-    |        ADD
-    |         |
-    |       OUTPUT
-    |
-    | We end up converting to:
-    |        Input
-    |         |
-    |       OUTPUT
+    Removes add nodes that add 0 to input.
+
+    Transforms
+    ```
+    | input   initializer
+    |     |   |
+    |     |   Constant
+    |     |   |
+    |      Add
+    ```
+    into
+    ```
+    | input
+    ```
     """
 
     def transform(self, model: ModelProto) -> ModelProto:
-        count_converted_nodes = 0
+        count = 0
+        graph = ONNXGraph(model)
         for match in get_structural_matches(
-            ONNXGraph(model), op_type="Add", parent_ops=[[], ["Constant"]]
+            graph, op_type="Add", parent_ops=[[], ["Constant"]]
         ):
             add = match.node
             (constant,) = match.parents[1]
@@ -52,16 +56,13 @@ class DeleteTrivialOnnxAdds(OnnxTransform):
             if not numpy.all(constant_array == 0.0):
                 continue
 
-            _LOGGER.debug(f"Matched Identity node: {match.node.name}")
-            count_converted_nodes += 1
+            _LOGGER.debug(f"Matched {match}")
+            count += 1
 
-            graph = ONNXGraph(model)
             parent = graph.get_node_single_parent(add, 0)
             if parent is not None:
                 parent.output[0] = add.output[0]
-            remove_node_and_params_from_graph(model, add)
-            remove_node_and_params_from_graph(model, constant)
-
-        if count_converted_nodes > 0:
-            _LOGGER.info(f"Delete {count_converted_nodes} trivial ONNX Add nodes")
+            self.delete_node_deferred(add)
+            self.delete_node_deferred(constant)
+        _LOGGER.info(f"Deleted {count} Add nodes")
         return model

--- a/src/sparseml/exporters/transforms/fold_conv_div_bn.py
+++ b/src/sparseml/exporters/transforms/fold_conv_div_bn.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import numpy
 from onnx import ModelProto, numpy_helper
 
@@ -20,15 +22,12 @@ from sparseml.exporters.transforms.utils.matching import (
     MatchResult,
     get_structural_matches,
 )
-from sparseml.onnx.utils import (
-    ONNXGraph,
-    get_batch_norm_params,
-    get_init_by_name,
-    remove_node_and_params_from_graph,
-)
+from sparseml.onnx.utils import ONNXGraph, get_batch_norm_params, get_init_by_name
 
 
 __all__ = ["FoldConvDivBn"]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class FoldConvDivBn(OnnxTransform):
@@ -43,21 +42,21 @@ class FoldConvDivBn(OnnxTransform):
     Specifically, this transforms
 
     ```
-    input   weight  bias (optional)
-         |    |    |
-            Conv
-              |
-            Div
-              |
-        BatchNormalization
+    | input   weight  bias (optional)
+    |      |    |    |
+    |         Conv
+    |           |
+    |         Div
+    |           |
+    |     BatchNormalization
     ```
 
     into
 
     ```
-    input   weight  bias
-         |    |    |
-            Conv
+    | input  weight  bias
+    |      |   |    |
+    |        Conv
     ```
     """
 
@@ -68,11 +67,12 @@ class FoldConvDivBn(OnnxTransform):
             children_ops=[["Div", "BatchNormalization"]],
         )
         for match in matches:
-            self._do_transform(model, match)
-        ONNXGraph(model).delete_unused_initializers()
+            _LOGGER.debug(f"Matched {match}")
+            self._transform_match(model, match)
+        _LOGGER.info(f"Folded {len(matches)} Conv->Div->Bn")
         return model
 
-    def _do_transform(self, model: ModelProto, match: MatchResult):
+    def _transform_match(self, model: ModelProto, match: MatchResult):
         conv_node = match.node
         div_node, bn_node = match.children[0]
 
@@ -107,5 +107,5 @@ class FoldConvDivBn(OnnxTransform):
             numpy_helper.from_array(folded_bias, name=bias_name)
         )
 
-        remove_node_and_params_from_graph(model, div_node)
-        remove_node_and_params_from_graph(model, bn_node)
+        self.delete_node_deferred(div_node)
+        self.delete_node_deferred(bn_node)

--- a/src/sparseml/exporters/transforms/fold_conv_div_bn.py
+++ b/src/sparseml/exporters/transforms/fold_conv_div_bn.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 import numpy
 from onnx import ModelProto, numpy_helper
 
@@ -26,8 +24,6 @@ from sparseml.onnx.utils import ONNXGraph, get_batch_norm_params, get_init_by_na
 
 
 __all__ = ["FoldConvDivBn"]
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class FoldConvDivBn(OnnxTransform):
@@ -67,9 +63,8 @@ class FoldConvDivBn(OnnxTransform):
             children_ops=[["Div", "BatchNormalization"]],
         )
         for match in matches:
-            _LOGGER.debug(f"Matched {match}")
+            self.log_match(match)
             self._transform_match(model, match)
-        _LOGGER.info(f"Folded {len(matches)} Conv->Div->Bn")
         return model
 
     def _transform_match(self, model: ModelProto, match: MatchResult):

--- a/src/sparseml/exporters/transforms/fold_identity_initializers.py
+++ b/src/sparseml/exporters/transforms/fold_identity_initializers.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
-
 from onnx import ModelProto
 
 from sparseml.exporters.transforms import OnnxTransform
@@ -21,8 +19,6 @@ from sparseml.onnx.utils import ONNXGraph
 
 
 __all__ = ["FoldIdentityInitializers"]
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class FoldIdentityInitializers(OnnxTransform):
@@ -48,13 +44,11 @@ class FoldIdentityInitializers(OnnxTransform):
 
     def transform(self, model: ModelProto) -> ModelProto:
         graph = ONNXGraph(model)
-        matches = get_structural_matches(graph, op_type="Identity")
-        for match in matches:
-            _LOGGER.debug(f"Matched {match}")
+        for match in get_structural_matches(graph, op_type="Identity"):
+            self.log_match(match)
             for child_node in graph.get_node_children(match.node):
                 for i, child_node_input in enumerate(child_node.input):
                     if child_node_input == match.node.output[0]:
                         child_node.input[i] = match.node.input[0]
             self.delete_node_deferred(match.node)
-        _LOGGER.info(f"Removed {len(matches)} Identity")
         return model

--- a/src/sparseml/exporters/transforms/fold_relu_quants.py
+++ b/src/sparseml/exporters/transforms/fold_relu_quants.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
 
 from onnx import ModelProto
 
@@ -24,8 +23,6 @@ from sparseml.onnx.utils import ONNXGraph
 
 
 __all__ = ["FoldReLUQuants"]
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class FoldReLUQuants(OnnxTransform):
@@ -65,9 +62,8 @@ class FoldReLUQuants(OnnxTransform):
 
             # set all child input nodes to the relu node input
             if delete:
-                _LOGGER.debug(f"Matched {match}")
+                self.log_match(match)
                 for quant in relu_children:
                     quant.input[0] = match.node.input[0]
                 self.delete_node_deferred(match.node)
-        _LOGGER.info(f"Removed {len(self._nodes_to_delete)} Relu")
         return model

--- a/src/sparseml/exporters/transforms/quantize_residuals.py
+++ b/src/sparseml/exporters/transforms/quantize_residuals.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 import onnx
 from onnx import ModelProto, NodeProto
 
@@ -22,8 +20,6 @@ from sparseml.onnx.utils import ONNXGraph, get_quantize_parent_for_dequantize_no
 
 
 __all__ = ["QuantizeResiduals"]
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class QuantizeResiduals(OnnxTransform):
@@ -91,6 +87,8 @@ class QuantizeResiduals(OnnxTransform):
             ):
                 continue
 
+            self.log_match(add_node)
+
             # create de-quantize node for identity
             dequant_output = f"{other_input_node.output[0]}_identity_dequantized"
             identity_dequantize_node = onnx.helper.make_node(
@@ -108,5 +106,4 @@ class QuantizeResiduals(OnnxTransform):
                 if inp == other_input_node.output[0]
             ][0]
             add_node.input[relu_input_idx] = dequant_output
-        _LOGGER.info(f"Quantized {len(self._nodes_to_add)} residuals")
         return model

--- a/src/sparseml/exporters/transforms/remove_duplicate_quantize_ops.py
+++ b/src/sparseml/exporters/transforms/remove_duplicate_quantize_ops.py
@@ -70,5 +70,5 @@ class RemoveDuplicateQuantizeOps(OnnxTransform):
                     if inp == old_id:
                         node.input[idx] = new_id
 
-        _LOGGER.info(f"Removed {len(self._nodes_to_delete)} QuantizeLinear nodes")
+        _LOGGER.debug("Removed %d QuantizeLinear nodes", len(self._nodes_to_delete))
         return model

--- a/tests/sparseml/exporters/transforms/test_delete_trivial_onnx_adds.py
+++ b/tests/sparseml/exporters/transforms/test_delete_trivial_onnx_adds.py
@@ -56,7 +56,7 @@ def _create_test_model(initializer_set_to_nonzero=False):
         name="g",
         inputs=[model_input],
         outputs=[model_output],
-        initializer=[initializer_constant],
+        initializer=[],
     )
 
     model = onnx.helper.make_model(graph)
@@ -73,7 +73,7 @@ def _test_initializer_zero(model):
 
 def _test_initializer_nonzero(model):
     assert [node.name for node in model.graph.node] == ["constant", "add"]
-    assert [node.name for node in model.graph.initializer] == ["constant_initializer"]
+    assert [node.name for node in model.graph.initializer] == []
     assert model.graph.input[0].name == "input"
     assert model.graph.output[0].name == "output"
 

--- a/tests/sparseml/exporters/transforms/test_fold_conv_div_bn.py
+++ b/tests/sparseml/exporters/transforms/test_fold_conv_div_bn.py
@@ -52,10 +52,9 @@ def onnx_model():
     bn = onnx.helper.make_node(
         "BatchNormalization",
         inputs=["div_output", "scale", "bias", "mean", "variance"],
-        outputs=["bn_output"],
+        outputs=["output"],
         name="bn",
     )
-
     graph = onnx.helper.make_graph(
         nodes=[conv, div, bn],
         name="g",


### PR DESCRIPTION
Depends on #1263 

This:
- Uses the delete_node_deferred from #1263
- Adds logging to all the passes
- Standardizes the docstring format