### PR TITLE
Attempting to fix onnx tests

### DIFF
--- a/tests/sparseml/onnx/optim/test_sensitivity_ks.py
+++ b/tests/sparseml/onnx/optim/test_sensitivity_ks.py
@@ -203,9 +203,12 @@ def test_approx_ks_loss_sensitivity(
         onnx_models_with_analysis.loss_approx_path
     )
     expected_layers = sorted(
-        expected_analysis.dict()["results"], key=lambda x: x["index"]
+        expected_analysis.dict()["results"],
+        key=lambda x: (x["id"], x["index"], x["name"]),
     )
-    actual_layers = sorted(analysis.dict()["results"], key=lambda x: x["index"])
+    actual_layers = sorted(
+        analysis.dict()["results"], key=lambda x: (x["id"], x["index"], x["name"])
+    )
     _test_analysis_comparison(expected_layers, actual_layers, False)
 
 
@@ -230,12 +233,13 @@ def test_one_shot_ks_loss_sensitivity(
     )
 
     expected_layers = sorted(
-        expected_analysis.dict()["results"], key=lambda x: x["index"]
+        expected_analysis.dict()["results"],
+        key=lambda x: (x["id"], x["index"], x["name"]),
     )
 
     actual_layers = sorted(
         analysis.dict()["results"],
-        key=lambda x: x["index"],
+        key=lambda x: (x["id"], x["index"], x["name"]),
     )
 
     _test_analysis_comparison(expected_layers, actual_layers, False)
@@ -268,12 +272,13 @@ def test_one_shot_ks_perf_sensitivity(
     )
 
     expected_layers = sorted(
-        expected_analysis.dict()["results"], key=lambda x: x["index"]
+        expected_analysis.dict()["results"],
+        key=lambda x: (x["id"], x["index"], x["name"]),
     )
 
     actual_layers = sorted(
         analysis.dict()["results"],
-        key=lambda x: x["index"],
+        key=lambda x: (x["id"], x["index"], x["name"]),
     )
 
     _test_analysis_comparison(expected_layers, actual_layers, True)

--- a/tests/sparseml/onnx/optim/test_sensitivity_ks.py
+++ b/tests/sparseml/onnx/optim/test_sensitivity_ks.py
@@ -204,10 +204,10 @@ def test_approx_ks_loss_sensitivity(
     )
     expected_layers = sorted(
         expected_analysis.dict()["results"],
-        key=lambda x: (x["id"], x["index"], x["name"]),
+        key=lambda x: (x["index"], x["id"], x["name"]),
     )
     actual_layers = sorted(
-        analysis.dict()["results"], key=lambda x: (x["id"], x["index"], x["name"])
+        analysis.dict()["results"], key=lambda x: (x["index"], x["id"], x["name"])
     )
     _test_analysis_comparison(expected_layers, actual_layers, False)
 
@@ -234,12 +234,12 @@ def test_one_shot_ks_loss_sensitivity(
 
     expected_layers = sorted(
         expected_analysis.dict()["results"],
-        key=lambda x: (x["id"], x["index"], x["name"]),
+        key=lambda x: (x["index"], x["id"], x["name"]),
     )
 
     actual_layers = sorted(
         analysis.dict()["results"],
-        key=lambda x: (x["id"], x["index"], x["name"]),
+        key=lambda x: (x["index"], x["id"], x["name"]),
     )
 
     _test_analysis_comparison(expected_layers, actual_layers, False)
@@ -273,12 +273,12 @@ def test_one_shot_ks_perf_sensitivity(
 
     expected_layers = sorted(
         expected_analysis.dict()["results"],
-        key=lambda x: (x["id"], x["index"], x["name"]),
+        key=lambda x: (x["index"], x["id"], x["name"]),
     )
 
     actual_layers = sorted(
         analysis.dict()["results"],
-        key=lambda x: (x["id"], x["index"], x["name"]),
+        key=lambda x: (x["index"], x["id"], x["name"]),
     )
 
     _test_analysis_comparison(expected_layers, actual_layers, True)


### PR DESCRIPTION
# Background

This is attempting to fix a bug in python 3.9 where the `test_one_shot_ks_perf_sensitivity` is failing.

Two notes:
1. I could not reproduce this failure locally
2. These test pass in python 3.7/3.8/3.10 jenkins pipelines.

**So the only failure is in jenkins pipeline on python 3.9.**

My current hypothesis is that the results returned by model analysis can have multiple values where the `x["index"]` is the same:
![image](https://user-images.githubusercontent.com/109536191/208739297-b7948aeb-eb4d-4b79-a708-e1a328206d73.png)

This *could* make the `sorted` call be inconsistently ordering the actual results.

Another piece of information supporting this hypothesis is the error messages of the 2 failures:

failure 1:
```
expected_layers = [{'averages': OrderedDict([(0.0, 3.500000000000001e-05), (0.4, 3.2000000000000005e-05), (0.8, 3.300000000000001e-05), ...'baseline_average': 7.089999999999999e-05, 'baseline_measurement_index': 0, 'baseline_measurement_key': 0.0, ...}, ...]
actual_layers = [{'averages': OrderedDict([(0.0, 4.599999999999999e-05), (0.4, 4.499999999999999e-05), (0.8, 4.699999999999999e-05), (...0152823)]), 'baseline_average': 0.0137507, 'baseline_measurement_index': 0, 'baseline_measurement_key': 0.0, ...}, ...]
is_perf = True
```
failure 2:
```
expected_layers = [{'averages': OrderedDict([(0.0, 4.9999999999999996e-05), (0.4, 3.0000000000000004e-05), (0.8, 4.599999999999999e-05),...9999e-05)]), 'baseline_average': 4.07e-05, 'baseline_measurement_index': 0, 'baseline_measurement_key': 0.0, ...}, ...]
actual_layers = [{'averages': OrderedDict([(0.0, 3.4000000000000007e-05), (0.4, 3.2000000000000005e-05), (0.8, 3.500000000000001e-05),... 'baseline_average': 0.015620499999999997, 'baseline_measurement_index': 0, 'baseline_measurement_key': 0.0, ...}, ...]
is_perf = True
```

If you swap the actual_layers values from both of these failures, then it seems like both would pass.

# Fix

If my hypothesis is correct, then adding a tie-breaker to the sorting should fix this bug. I changed the sorting key to sort based on:
1. id
4. if id's are equal, then index
5. If id and index are equal, then name

This will break the ties, so if this doesn't solve the issue then I don't know what the problem is.