### PR TITLE
Saving all hooks during quantization block fusing

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -712,16 +712,16 @@ def _delete_get_block_hooks(
         post_hooks = []
 
         # get first and last Module objects in block by their names
-        block_head = get_layer(block[0], module)
-        block_tail = get_layer(block[-1], module)
+        for name in block:
+            m = get_layer(name, module)
 
-        for handle_id, pre_hook_fn in list(block_head._forward_pre_hooks.items()):
-            pre_hooks.append(pre_hook_fn)
-            del block_head._forward_pre_hooks[handle_id]
+            for handle_id, pre_hook_fn in list(m._forward_pre_hooks.items()):
+                pre_hooks.append(pre_hook_fn)
+                del m._forward_pre_hooks[handle_id]
 
-        for handle_id, hook_fn in list(block_tail._forward_hooks.items()):
-            post_hooks.append(hook_fn)
-            del block_tail._forward_hooks[handle_id]
+            for handle_id, hook_fn in list(m._forward_hooks.items()):
+                post_hooks.append(hook_fn)
+                del m._forward_hooks[handle_id]
 
         block_hooks.append((pre_hooks, post_hooks))
 


### PR DESCRIPTION
Currently only the following hooks are transferred during quantization fusing process:
1. the pre forward hooks for the first layer
2. the post forward hooks for the last layer

Notably, the following hooks are lost:
1. The post forward hooks in the first layer
2. The pre forward hooks in the last layer
3. Any hooks from any layer between first and last layer

This PR changes it so all pre/post hooks from every layer in the fused block is transferred to the new fused module.

# Testing plan

Existing unit tests, and also this was tested for the #1272 PR