### PR TITLE
Fix sparsity scheduler for GMP

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_magnitude.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_magnitude.py
@@ -152,6 +152,7 @@ class GMPruningModifier(BaseGradualPruningModifier, BaseGMPruningModifier):
                 "params",
                 "leave_enabled",
                 "mask_type",
+                "inter_func",
             ],
         )
 


### PR DESCRIPTION
Fixes https://github.com/neuralmagic/sparseml/issues/1282 by passing the missed `inter_func` argument to super.