### PR TITLE
Log overall sparsity of the model

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_base.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_base.py
@@ -432,7 +432,7 @@ class BasePruningModifier(ABC, ScheduledUpdateModifier):
                     steps_per_epoch=steps_per_epoch,
                 )
         self.log_scalar(
-            tag="Overall sparsity",
+            tag=f"modifier_sparsity/{self.__class__.__name__}",
             value=num_zeros / (num_params + torch.finfo(torch.float32).eps),
             epoch=epoch,
             steps_per_epoch=steps_per_epoch,

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_base.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_base.py
@@ -432,7 +432,7 @@ class BasePruningModifier(ABC, ScheduledUpdateModifier):
                     steps_per_epoch=steps_per_epoch,
                 )
         self.log_scalar(
-            tag=f"Overall sparsity",
+            tag="Overall sparsity",
             value=num_zeros / (num_params + torch.finfo(torch.float32).eps),
             epoch=epoch,
             steps_per_epoch=steps_per_epoch,


### PR DESCRIPTION
Issues like https://github.com/neuralmagic/sparseml/issues/1282 are very hard to detect when `global_sparsity: True`, as the final model will have the desired target sparsity but the sparsity scheduler might have followed the wrong interpolation function. This PR adds logging of the overall sparsity of the model, which makes this issue easily detectable.