### PR TITLE
Adding --recipe-args to torchvision train script

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -423,7 +423,9 @@ def main(args):
 
         # restore state from prior recipe
         manager = (
-            ScheduledModifierManager.from_yaml(args.recipe)
+            ScheduledModifierManager.from_yaml(
+                args.recipe, recipe_variables=args.recipe_args
+            )
             if args.recipe is not None
             else None
         )
@@ -448,7 +450,9 @@ def main(args):
     else:
         checkpoint = None
         manager = (
-            ScheduledModifierManager.from_yaml(args.recipe)
+            ScheduledModifierManager.from_yaml(
+                args.recipe, recipe_variables=args.recipe_args
+            )
             if args.recipe is not None
             else None
         )
@@ -691,6 +695,12 @@ def _deprecate_old_arguments(f):
     )
 )
 @click.option("--recipe", default=None, type=str, help="Path to recipe")
+@click.option(
+    "--recipe-args",
+    default=None,
+    type=str,
+    help="json parsable dict of recipe variable names to values to overwrite with",
+)
 @click.option("--dataset-path", required=True, type=str, help="dataset path")
 @click.option(
     "--arch-key",


### PR DESCRIPTION
Adds missing feature that the old training script had.

# Testing plan

1. Ran command in readme
2. Ran command in readme + `--recipe-args '{"num_epochs": 5}'`