### PR TITLE
[QuantizationModifier][patch] default to CPU when module has no device

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -233,7 +233,11 @@ def add_output_activation_observers(module: Module):
     """
     # adapted from torch/ao/quantization/quantize.py::_add_observer_
     # source: https://github.com/pytorch/pytorch/blob/v1.13.0/torch/ao/quantization/quantize.py#L135  # noqa: E501
-    device = next(module.parameters()).device
+    try:
+        device = next(module.parameters()).device
+    except StopIteration:
+        # default to CPU if module has no parameters
+        device = "cpu"
 
     def _needs_observer(target_module: Module):
         # combines logic from multiple places of original implementation which


### PR DESCRIPTION
this PR fixes a small bug in the quantization modifier when accessing module `parameters` generator of a module that has no parameters.

issue scope is very small as this is an unlikely scenario, but came up in testing of a singular QATMatMul (non parameterized)

**test_plan:**
covered offline by NM QA team