### PR TITLE
Changing log_scalar step unit to batch # instead of epoch

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -233,7 +233,11 @@ def add_output_activation_observers(module: Module):
     """
     # adapted from torch/ao/quantization/quantize.py::_add_observer_
     # source: https://github.com/pytorch/pytorch/blob/v1.13.0/torch/ao/quantization/quantize.py#L135  # noqa: E501
-    device = next(module.parameters()).device
+    try:
+        device = next(module.parameters()).device
+    except StopIteration:
+        # default to CPU if module has no parameters
+        device = "cpu"
 
     def _needs_observer(target_module: Module):
         # combines logic from multiple places of original implementation which

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -108,10 +108,10 @@ def train_one_epoch(
                 if args.clip_grad_norm is not None:
                     nn.utils.clip_grad_norm_(model.parameters(), args.clip_grad_norm)
                 optimizer.step()
-                num_optim_steps += 1
 
             # zero grad here to start accumulating next set of gradients
             optimizer.zero_grad()
+            num_optim_steps += 1
         steps_accumulated += 1
 
         if model_ema and i % args.model_ema_steps == 0:
@@ -884,7 +884,13 @@ def _deprecate_old_arguments(f):
     type=float,
     help="minimum lr of lr schedule",
 )
-@click.option("--logging-steps", default=10, type=int, help="print frequency")
+@click.option("--print-freq", default=None, type=int, help="DEPRECATED. Does nothing.")
+@click.option(
+    "--logging-steps",
+    default=10,
+    type=int,
+    help="Frequency in number of batch updates for logging/printing",
+)
 @click.option("--output-dir", default=".", type=str, help="path to save outputs")
 @click.option("--resume", default=None, type=str, help="path of checkpoint")
 @click.option(


### PR DESCRIPTION
- Currently torchvision logs scalars with a step unit of epoch #. All other modifiers use batch # as unit for step, which causes charts not to be displayed in WANDB. This changes the step unit to match for modifiers.
- Fixing bug where using `--gradient-accum-steps` did not adjust `steps_per_epoch` passed to manager
- Also renaming `--print-freq` -> `--logging-steps` and properly using everywhere.

# Test Plan

Tested this command:
```bash
sparseml.image_classification.train --checkpoint-path zoo:cv/classification/efficientnet_v2-s/pytorch/sparseml/imagenet/base-none --arch-key efficientnet_v2_s --output-dir efficientnet-tmp/ --recipe dense_finetune.yaml --dataset-path /home/corey/.cache/nm_datasets/imagenette/imagenette-160/ --batch-size 4 --gradient-accum-steps 4 --auto-augment imagenet --random-erase 0.1 --label-smoothing 0.1 --mixup-alpha 0.2 --cutmix-alpha 1.0 --weight-decay 0.00002 --norm-weight-decay 0.0 --train-crop-size 300 --model-ema --val-crop-size 384 --val-resize-size 384 --ra-sampler --ra-reps 4 --logging-steps 100
```

with this recipe:
```yaml
version: 1.1.0

# General Variables
num_epochs: 3
lr_warmup_epochs: 1
init_lr: 0.0
warmup_lr: 1e-5
final_lr: 0.0
weight_decay: 0.00001

# Modifiers
training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: eval(num_epochs)

  - !LearningRateFunctionModifier
    start_epoch: 0
    end_epoch: eval(lr_warmup_epochs)
    lr_func: linear
    init_lr: eval(init_lr)
    final_lr: eval(warmup_lr)

  - !LearningRateFunctionModifier
    start_epoch: eval(lr_warmup_epochs)
    end_epoch: eval(num_epochs)
    lr_func: cosine
    init_lr: eval(warmup_lr)
    final_lr: eval(final_lr)

  - !SetWeightDecayModifier
    start_epoch: 0
    weight_decay: eval(weight_decay)
```

# Wandb output

<img width="1639" alt="image" src="https://user-images.githubusercontent.com/109536191/211374545-8d38e15b-9501-4b81-8768-2cce226efb05.png">
