### PR TITLE
Distillation support for torchvision script

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -105,7 +105,7 @@ def train_one_epoch(
                     module=model,
                     optimizer=optimizer,
                     epoch=epoch,
-                    steps_per_epoch=len(data_loader),
+                    steps_per_epoch=len(data_loader) / accum_steps,
                     student_outputs=outputs,
                     student_inputs=image,
                 )

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -516,7 +516,12 @@ def main(args):
             )
 
     if manager is not None:
-        manager.initialize(model, epoch=args.start_epoch, loggers=logger)
+        manager.initialize(
+            model,
+            epoch=args.start_epoch,
+            loggers=logger,
+            distillation_teacher=args.distill_teacher,
+        )
         optimizer = manager.modify(
             model, optimizer, len(data_loader), epoch=args.start_epoch
         )
@@ -992,6 +997,13 @@ def _deprecate_old_arguments(f):
     type=int,
     help="Save the best validation result after the given "
     "epoch completes until the end of training",
+)
+@click.option(
+    "--distill-teacher",
+    default=None,
+    type=click.Choice(["self", "disable"], case_sensitive=False),
+    help="Teacher model for distillation (a trained image classification model)"
+    "currently only supports 'self' for self-distillation and 'disable'",
 )
 @click.pass_context
 def cli(ctx, **kwargs):

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -91,7 +91,7 @@ def train_one_epoch(
 
         if steps_accumulated % args.gradient_accum_steps == 0:
             if manager is not None:
-                manager.loss_update(
+                loss = manager.loss_update(
                     loss=loss,
                     module=model,
                     optimizer=optimizer,


### PR DESCRIPTION
The goal of this PR is to add distillation support to our `pytorch/torchvision` integration
Test recipe:

`distillation.yaml`:

```yaml
num_epochs: &num_epochs 10
lr: &lr 0.008

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0.0
    end_epoch: *num_epochs

  - !SetLearningRateModifier
    start_epoch: 0.0
    learning_rate: *lr

  - !DistillationModifier
     start_epoch: 0.0
     hardness: 0.5
     temperature: 2.0
     distill_output_keys: [0]

```

Test commands, (run manually):

- [X] self distillation

```bash
sparseml.image_classification.train \ 
    --recipe distillation.yaml --pretrained True --pretrained-dataset imagenette \
    --arch-key resnet50 --dataset-path /home/rahul/datasets/imagenette/imagenette-160 \
    --batch-size 128 --opt SGD --output-dir ./training-runs/image_classification-pretrained \
    --distill-teacher self
```

- [X] This command should fail (distillation recipe given but no `--distill-teacher` specified)

```bash
sparseml.image_classification.train \ 
    --recipe distillation.yaml --pretrained True --pretrained-dataset imagenette \
    --arch-key resnet50 --dataset-path /home/rahul/datasets/imagenette/imagenette-160 \
    --batch-size 128 --opt SGD --output-dir ./training-runs/image_classification-pretrained 
```

- [X] Disable distillation

```bash
sparseml.image_classification.train \ 
    --recipe distillation.yaml --pretrained True --pretrained-dataset imagenette \
    --arch-key resnet50 --dataset-path /home/rahul/datasets/imagenette/imagenette-160 \
    --batch-size 128 --opt SGD --output-dir ./training-runs/image_classification-pretrained \
    --distill-teacher disable
```

- [X] Distill a `mobilenet` using a `resnet50` teacher from sparsezoo

```bash
sparseml.image_classification.train \ 
    --recipe distillation.yaml --pretrained True --pretrained-dataset imagenette \
    --arch-key mobilenet --dataset-path /home/rahul/datasets/imagenette/imagenette-160 \
    --batch-size 128 --opt SGD --output-dir ./training-runs/image_classification-pretrained \
    --distill-teacher zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/base-none \
    --pretrained-teacher-dataset imagenet --teacher-arch-key resnet50
``` 