### PR TITLE
[Layer Wise Distillation] Minor fixes

### DIFF
--- a/src/sparseml/pytorch/sparsification/distillation/modifier_distillation.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_distillation.py
@@ -120,6 +120,12 @@ class DistillationModifier(BaseDistillationModifier):
         self._temperature = value
 
     def compute_distillation_loss(self, student_outputs, teacher_outputs, **kwargs):
+        if type(student_outputs) != type(teacher_outputs):
+            raise ValueError(
+                f"Student output type of {type(student_outputs)} must match "
+                f"teacher output type of {type(teacher_outputs)}"
+            )
+
         return kldiv_loss(
             student_outputs,
             teacher_outputs,

--- a/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
@@ -132,6 +132,7 @@ class BaseDistillationModifier(ScheduledUpdateModifier):
 
         self._teacher = None
         self._distillation_enabled = False
+        self._compare_model_output = True
 
         self._logged_loss_terms = {}
 
@@ -321,7 +322,9 @@ class BaseDistillationModifier(ScheduledUpdateModifier):
                 teacher_inputs, self._teacher, check_feat_lab_inp=False
             )
 
-        if type(student_outputs) != type(teacher_outputs):
+        if self._compare_model_output and type(student_outputs) != type(
+            teacher_outputs
+        ):
             raise ValueError(
                 f"Student output type of {type(student_outputs)} must match "
                 f"teacher output type of {type(teacher_outputs)}"

--- a/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
@@ -132,7 +132,6 @@ class BaseDistillationModifier(ScheduledUpdateModifier):
 
         self._teacher = None
         self._distillation_enabled = False
-        self._compare_model_output = True
 
         self._logged_loss_terms = {}
 
@@ -320,14 +319,6 @@ class BaseDistillationModifier(ScheduledUpdateModifier):
         with torch.no_grad():
             teacher_outputs = tensors_module_forward(
                 teacher_inputs, self._teacher, check_feat_lab_inp=False
-            )
-
-        if self._compare_model_output and type(student_outputs) != type(
-            teacher_outputs
-        ):
-            raise ValueError(
-                f"Student output type of {type(student_outputs)} must match "
-                f"teacher output type of {type(teacher_outputs)}"
             )
 
         distillation_loss = self.compute_distillation_loss(

--- a/src/sparseml/pytorch/sparsification/distillation/modifier_per_layer.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_per_layer.py
@@ -155,8 +155,6 @@ class PerLayerDistillationModifier(BaseDistillationModifier):
         self._teacher_output_shapes: Dict[str, torch.Size] = {}
         self._loaded_projection = None
 
-        self._compare_model_output = False
-
     def _reset_cache(self):
         self._cached_student_output.clear()
         self._cached_teacher_output.clear()

--- a/src/sparseml/pytorch/sparsification/distillation/modifier_per_layer.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_per_layer.py
@@ -155,6 +155,8 @@ class PerLayerDistillationModifier(BaseDistillationModifier):
         self._teacher_output_shapes: Dict[str, torch.Size] = {}
         self._loaded_projection = None
 
+        self._compare_model_output = False
+
     def _reset_cache(self):
         self._cached_student_output.clear()
         self._cached_teacher_output.clear()
@@ -354,7 +356,7 @@ class PerLayerDistillationModifier(BaseDistillationModifier):
         steps_per_epoch: int,
     ):
         super().update(module, optimizer, epoch, steps_per_epoch)
-        if epoch >= self.end_epoch:
+        if self.end_epoch > 0 and epoch >= self.end_epoch:
             for handle in self._student_handles:
                 handle.remove()
             for handle in self._teacher_handles:

--- a/src/sparseml/pytorch/sparsification/distillation/modifier_per_layer.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_per_layer.py
@@ -356,7 +356,7 @@ class PerLayerDistillationModifier(BaseDistillationModifier):
         steps_per_epoch: int,
     ):
         super().update(module, optimizer, epoch, steps_per_epoch)
-        if self.end_epoch > 0 and epoch >= self.end_epoch:
+        if 0 < self.end_epoch <= epoch:
             for handle in self._student_handles:
                 handle.remove()
             for handle in self._teacher_handles:


### PR DESCRIPTION
This PR adds fixes a couple bugs discovered during implementation of distillation for yolov5.

Fixes
- Don't enforce type checking for the final model output when using PerLayerDistillation modifier. Or generally, allow said override for any distillation modifier. This is added to account for instances where a model will produce different output in eval and train mode, such as yolov5, and cause the final output between the student and teacher to not align.
- Don't clear handles immediately when no end epoch is set

Test Plan
Covered by existing unit tests