### PR TITLE
Adding config to wandb logger and calling LoggerManager.save(recipe)

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -545,12 +545,18 @@ def main(args):
             TensorBoardLogger(log_path=args.output_dir),
         ]
         try:
-            loggers.append(WANDBLogger())
+            config = vars(args)
+            if manager is not None:
+                config["manager"] = str(manager)
+            loggers.append(WANDBLogger(init_kwargs=dict(config=config)))
         except ImportError:
             warnings.warn("Unable to import wandb for logging")
         logger = LoggerManager(loggers)
     else:
         logger = LoggerManager(log_python=False)
+
+    if args.recipe is not None:
+        logger.save(args.recipe)
 
     steps_per_epoch = len(data_loader) / args.gradient_accum_steps
 


### PR DESCRIPTION
1. If args.recipe is a local file path, it will appear under the files section of wandb:
<img width="419" alt="image" src="https://user-images.githubusercontent.com/109536191/212130812-2be4461d-70e7-4ba1-b44d-04aec3131019.png">

2. In the overview tab you can now view all command line parameters in the config table

<img width="600" alt="image" src="https://user-images.githubusercontent.com/109536191/212130953-3dfdc1d7-cbf0-4a64-9e7b-a0e4e9947709.png">
 