### PR TITLE
[BugFix] image-classifiication onnx export

### DIFF
--- a/src/sparseml/pytorch/utils/model.py
+++ b/src/sparseml/pytorch/utils/model.py
@@ -91,7 +91,9 @@ def load_model(
     if recipe:
         from sparseml.pytorch.optim import ScheduledModifierManager
 
-        epoch = model_dict.get("epoch", float("inf"))
+        epoch = model_dict.get("epoch", -1)
+        if epoch == -1:
+            epoch = float("inf")
         checkpoint_manager = ScheduledModifierManager.from_yaml(recipe)
         checkpoint_manager.apply_structure(module=model, epoch=epoch)
 


### PR DESCRIPTION
A bug was recently found by @natuan, in which onnx exports for quantized image classification models were failing when the checkpoint epoch was -1
This PR fixes that, by setting epoch to `float("inf")`  when the checkpoint epoch is -1

Test:

```bash
sparseml.image_classification.export_onnx \
     --arch-key efficientnet_v2_s \
     --checkpoint-path /home/rahul/tuan-efficient/checkpoint.pth
     --dataset-path /home/rahul/datasets/imagenette/imagenette-160 \
     --save-dir /home/rahul/tuan-efficient/exported
```

This command was failing before but now produces the correct onnx with the following contents:

```bash
.
├── deployment
│   ├── config.json
│   └── model.onnx
├── efficientnet_v2_s_imagenette
├── efficientnet_v2_s_imagenette__01
├── efficientnet_v2_s_imagenette__02
├── efficientnet_v2_s_imagenette__03
├── efficientnet_v2_s_imagenette__04
├── efficientnet_v2_s_imagenette__05
├── efficientnet_v2_s_imagenette__06
├── efficientnet_v2_s_imagenette__07
├── efficientnet_v2_s_imagenette__08
└── model.onnx
```