### PR TITLE
Adding check for weight.requires_grad in get_prunable_layers

### DIFF
--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -805,6 +805,7 @@ def get_prunable_layers(module: Module) -> List[Tuple[str, Module]]:
             or (QATConv3d and isinstance(mod, QATConv3d))
             or (GPTConv1D and isinstance(mod, GPTConv1D))
         )
+        and mod.weight.requires_grad
     ]
 
 


### PR DESCRIPTION
This PR resolves an issue (traceback below) I am seeing with yolov8 when using the recipe (also below). The fix is to also add a requirement that `layer.weight.requires_grad == True` in `get_prunable_layers`.

# Recipe

```yaml
version: 1.1.0

# General variables
num_epochs: 55
quantization_epochs: 5
quantization_lr: 1.e-5
final_lr: 1.e-9

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: eval(num_epochs)

  - !LearningRateFunctionModifier
    start_epoch: eval(num_epochs - quantization_epochs)
    end_epoch: eval(num_epochs)
    lr_func: cosine
    init_lr: eval(quantization_lr)
    final_lr: eval(final_lr)

pruning_modifiers:
  - !ConstantPruningModifier
    start_epoch: 0.0
    params: __ALL_PRUNABLE__

quantization_modifiers:
  - !QuantizationModifier
    start_epoch: eval(num_epochs - quantization_epochs)
    submodules:
      - model
    custom_quantizable_module_types: ['SiLU']
    exclude_module_types: ['SiLU']
    quantize_conv_activations: False
    disable_quantization_observer_epoch: eval(num_epochs - quantization_epochs + 2)
    freeze_bn_stats_epoch: eval(num_epochs - quantization_epochs + 1)
```

# Traceback

```python
  File "<snip>/ultralytics/yolo/engine/trainer.py", line 402, in optimizer_step
    self.scaler.step(self.optimizer)
  File "<snip>/sparseml/src/sparseml/pytorch/optim/manager.py", line 172, in step
    return self._perform_wrapped_step(*args, **kwargs)
  File "<snip>/sparseml/src/sparseml/pytorch/optim/manager.py", line 209, in _perform_wrapped_step
    self._wrapped_manager.update(
  File "<snip>/sparseml/src/sparseml/pytorch/optim/manager.py", line 589, in update
    mod.scheduled_update(module, optimizer, epoch, steps_per_epoch)
  File "<snip>/sparseml/src/sparseml/pytorch/sparsification/modifier.py", line 620, in scheduled_update
    self.update(module, optimizer, epoch=epoch, steps_per_epoch=steps_per_epoch)
  File "<snip>/sparseml/src/sparseml/pytorch/sparsification/modifier.py", line 452, in wrapper
    out = func(*args, **kwargs)
  File "<snip>/sparseml/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_base.py", line 354, in update
    self.check_mask_update(module, epoch, steps_per_epoch)
  File "<snip>/sparseml/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_base.py", line 374, in check_mask_update
    self._module_masks.enabled = True
  File "<snip>/sparseml/src/sparseml/pytorch/sparsification/pruning/mask_params.py", line 227, in enabled
    self._create_hooks()
  File "<snip>/sparseml/src/sparseml/pytorch/sparsification/pruning/mask_params.py", line 515, in _create_hooks
    self._gradient_hooks[idx] = param.register_hook(
  File "<snip>/torch/_tensor.py", line 430, in register_hook
    raise RuntimeError("cannot register a hook on a tensor that "
RuntimeError: cannot register a hook on a tensor that doesn't require gradient
```

# Testing plan

The yolov8 training command runs and decreases losses after the fix, and will depend on unit tests on this PR to know if other things won't break.