### PR TITLE
`DataParallel` support for `torchvision`

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -893,8 +893,7 @@ def _deprecate_old_arguments(f):
     default=None,
     type=str,
     help=(
-        "device (Use cuda for all gpus, else use `cuda:device_id,device_id` "
-        "or cpu)"
+        "device (Use cuda for all gpus, else use `cuda:device_id,device_id` " "or cpu)"
     ),
 )
 @click.option(


### PR DESCRIPTION
This PR adds support for DataParallel in sparseml's torchvision integration, if no devices are specified, all devices are used by default, else devices can be specified as "cuda:0,1,2,3"


The bug w.r.t multi-gpu environments occurred because the device info wasn't propagated correctly after wrapping the model in DataParallel

The bug has been fixed and the following command was run in a multi-gpu setup to verify all GPU's were picked up; manually verified GPU usage

```
sparseml.image_classification.train \
    --recipe "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none?recipe_type=transfer-classification" --checkpoint-path "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_quant-none" --arch-key resnet50 --dataset-path /home/XXXX/sparseml/imagenette/imagenette-160
``` 
![Screenshot 2023-02-08 at 9 58 45 AM](https://user-images.githubusercontent.com/25380596/217566350-4b9746d9-1250-42d7-92b1-98e4ade099e7.png)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203759380764619