### PR TITLE
[IC old][bug] export double checkpoint load fix

### DIFF
--- a/src/sparseml/pytorch/image_classification/export.py
+++ b/src/sparseml/pytorch/image_classification/export.py
@@ -387,9 +387,8 @@ def main(
 
     if recipe is not None:
         ScheduledModifierManager.from_yaml(recipe).apply_structure(model)
-
-    if checkpoint_path:
-        load_model(checkpoint_path, model, strict=True)
+        if checkpoint_path:
+            load_model(checkpoint_path, model, strict=True)
 
     if one_shot is not None:
         ScheduledModifierManager.from_yaml(file_path=one_shot).apply(module=model)


### PR DESCRIPTION
fixes a minor bug in the old IC export flow where checkpoints would be loaded both on `ModelRegistry.create` and later in `load_model` if no recipe override was provided. the original intent for the recipe override pathway was to be used if no recipe was serialized. we run into issues here where quantization is included in serialized recipes, double quantization would be applied which leads to model bugs

**test_plan:**
manual