### PR TITLE
[Feature Branch] Yolov8

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 recursive-include src/sparseml/yolov5 *.yaml *.sh
 recursive-include src/sparseml/yolact *.sh
+recursive-include src/sparseml/pytorch/yolov8 *.yaml

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,8 @@ _dev_deps = [
     "docutils<0.17",
 ]
 
+_ultralytics_deps = ["ultralytics==8.0.11"]
+
 
 def _setup_packages() -> List:
     return find_packages(
@@ -127,6 +129,7 @@ def _setup_extras() -> Dict:
         "tf_v1": _tensorflow_v1_deps,
         "tf_v1_gpu": _tensorflow_v1_gpu_deps,
         "tf_keras": _keras_deps,
+        "ultralytics": _ultralytics_deps,
     }
 
 

--- a/src/sparseml/pytorch/yolov8/__init__.py
+++ b/src/sparseml/pytorch/yolov8/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/sparseml/pytorch/yolov8/default.yaml
+++ b/src/sparseml/pytorch/yolov8/default.yaml
@@ -1,0 +1,110 @@
+# Default training settings and hyperparameters for medium-augmentation COCO training
+
+task: "detect" # choices=['detect', 'segment', 'classify', 'init'] # init is a special case. Specify task to run.
+mode: "train" # choices=['train', 'val', 'predict'] # mode to run task in.
+
+# Train settings -------------------------------------------------------------------------------------------------------
+model: "yolov8n.yaml" # i.e. yolov8n.pt, yolov8n.yaml. Path to model file
+data: "coco128.yaml" # i.e. coco128.yaml. Path to data file
+epochs: 100 # number of epochs to train for
+patience: 50  # epochs to wait for no observable improvement for early stopping of training
+batch: 16 # number of images per batch
+imgsz: 640 # size of input images
+save: True # save checkpoints
+cache: False # True/ram, disk or False. Use cache for data loading
+device: null # cuda device, i.e. 0 or 0,1,2,3 or cpu. Device to run on
+workers: 8 # number of worker threads for data loading
+project: null # project name
+name: null # experiment name
+exist_ok: False # whether to overwrite existing experiment
+pretrained: False # whether to use a pretrained model
+optimizer: 'SGD' # optimizer to use, choices=['SGD', 'Adam', 'AdamW', 'RMSProp']
+verbose: False # whether to print verbose output
+seed: 0 # random seed for reproducibility
+deterministic: True # whether to enable deterministic mode
+single_cls: False # train multi-class data as single-class
+image_weights: False # use weighted image selection for training
+rect: False # support rectangular training
+cos_lr: False # use cosine learning rate scheduler
+close_mosaic: 10 # disable mosaic augmentation for final 10 epochs
+resume: False # resume training from last checkpoint
+# Segmentation
+overlap_mask: True # masks should overlap during training
+mask_ratio: 4 # mask downsample ratio
+# Classification
+dropout: 0.0  # use dropout regularization
+
+# Val/Test settings ----------------------------------------------------------------------------------------------------
+val: True # validate/test during training
+save_json: False # save results to JSON file
+save_hybrid: False # save hybrid version of labels (labels + additional predictions)
+conf: null # object confidence threshold for detection (default 0.25 predict, 0.001 val)
+iou: 0.7 # intersection over union (IoU) threshold for NMS
+max_det: 300 # maximum number of detections per image
+half: False # use half precision (FP16)
+dnn: False # use OpenCV DNN for ONNX inference
+plots: True # show plots during training
+
+# Prediction settings --------------------------------------------------------------------------------------------------
+source: null # source directory for images or videos
+show: False # show results if possible
+save_txt: False # save results as .txt file
+save_conf: False # save results with confidence scores
+save_crop: False # save cropped images with results
+hide_labels: False # hide labels
+hide_conf: False # hide confidence scores
+vid_stride: 1 # video frame-rate stride
+line_thickness: 3 # bounding box thickness (pixels)
+visualize: False # visualize results
+augment: False # apply data augmentation to images
+agnostic_nms: False # class-agnostic NMS
+retina_masks: False # use retina masks for object detection
+
+# Export settings ------------------------------------------------------------------------------------------------------
+format: torchscript # format to export to
+keras: False  # use Keras
+optimize: False  # TorchScript: optimize for mobile
+int8: False  # CoreML/TF INT8 quantization
+dynamic: False  # ONNX/TF/TensorRT: dynamic axes
+simplify: False  # ONNX: simplify model
+opset: 17  # ONNX: opset version
+workspace: 4  # TensorRT: workspace size (GB)
+nms: False  # CoreML: add NMS
+
+# Hyperparameters ------------------------------------------------------------------------------------------------------
+lr0: 0.01  # initial learning rate (SGD=1E-2, Adam=1E-3)
+lrf: 0.01  # final OneCycleLR learning rate (lr0 * lrf)
+momentum: 0.937  # SGD momentum/Adam beta1
+weight_decay: 0.0005  # optimizer weight decay 5e-4
+warmup_epochs: 3.0  # warmup epochs (fractions ok)
+warmup_momentum: 0.8  # warmup initial momentum
+warmup_bias_lr: 0.1  # warmup initial bias lr
+box: 7.5  # box loss gain
+cls: 0.5  # cls loss gain (scale with pixels)
+dfl: 1.5  # dfl loss gain
+fl_gamma: 0.0  # focal loss gamma (efficientDet default gamma=1.5)
+label_smoothing: 0.0
+nbs: 64  # nominal batch size
+hsv_h: 0.015  # image HSV-Hue augmentation (fraction)
+hsv_s: 0.7  # image HSV-Saturation augmentation (fraction)
+hsv_v: 0.4  # image HSV-Value augmentation (fraction)
+degrees: 0.0  # image rotation (+/- deg)
+translate: 0.1  # image translation (+/- fraction)
+scale: 0.5  # image scale (+/- gain)
+shear: 0.0  # image shear (+/- deg)
+perspective: 0.0  # image perspective (+/- fraction), range 0-0.001
+flipud: 0.0  # image flip up-down (probability)
+fliplr: 0.5  # image flip left-right (probability)
+mosaic: 1.0  # image mosaic (probability)
+mixup: 0.0  # image mixup (probability)
+copy_paste: 0.0  # segment copy-paste (probability)
+
+# Hydra configs --------------------------------------------------------------------------------------------------------
+cfg: null # for overriding defaults.yaml
+hydra:
+  output_subdir: null  # disable hydra directory creation
+  run:
+    dir: .
+
+# Debug, do not modify -------------------------------------------------------------------------------------------------
+v5loader: False  # use legacy YOLOv5 dataloader

--- a/src/sparseml/pytorch/yolov8/default.yaml
+++ b/src/sparseml/pytorch/yolov8/default.yaml
@@ -1,5 +1,9 @@
 # Default training settings and hyperparameters for medium-augmentation COCO training
 
+recipe: null
+recipe_args: null
+checkpoint_path: null
+
 task: "detect" # choices=['detect', 'segment', 'classify', 'init'] # init is a special case. Specify task to run.
 mode: "train" # choices=['train', 'val', 'predict'] # mode to run task in.
 

--- a/src/sparseml/pytorch/yolov8/default.yaml
+++ b/src/sparseml/pytorch/yolov8/default.yaml
@@ -2,7 +2,6 @@
 
 recipe: null
 recipe_args: null
-checkpoint_path: null
 
 task: "detect" # choices=['detect', 'segment', 'classify', 'init'] # init is a special case. Specify task to run.
 mode: "train" # choices=['train', 'val', 'predict'] # mode to run task in.

--- a/src/sparseml/pytorch/yolov8/train.py
+++ b/src/sparseml/pytorch/yolov8/train.py
@@ -1,0 +1,247 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from sparseml.pytorch.yolov8.trainers import (
+    ClassificationTrainer,
+    DetectionTrainer,
+    SegmentationTrainer,
+    SparseClassificationTrainer,
+    SparseDetectionTrainer,
+    SparseSegmentationTrainer,
+)
+from ultralytics.yolo.engine.model import YOLO
+
+
+class SparseYOLO(YOLO):
+    def __init__(self, model="yolov8n.yaml", type="v8") -> None:
+        super().__init__(model, type)
+
+        if self.TrainerClass == DetectionTrainer:
+            self.TrainerClass = SparseDetectionTrainer
+        elif self.TrainerClass == ClassificationTrainer:
+            self.TrainerClass = SparseClassificationTrainer
+        elif self.TrainerClass == SegmentationTrainer:
+            self.TrainerClass = SparseSegmentationTrainer
+
+
+# Options generated from
+# https://github.com/ultralytics/ultralytics/blob/main/ultralytics/yolo/configs/default.yaml
+
+
+@click.command(
+    context_settings=(
+        dict(token_normalize_func=lambda x: x.replace("-", "_"), show_default=True)
+    )
+)
+@click.option("--recipe", default=None, type=str, help="Path to recipe")
+@click.option(
+    "--recipe-args",
+    default=None,
+    type=str,
+    help="json parsable dict of recipe variable names to values to overwrite with",
+)
+@click.option(
+    "--resume", default=False, is_flag=True, help="resume training from last checkpoint"
+)
+@click.option(
+    "--checkpoint-path",
+    default=None,
+    type=str,
+    help=(
+        "A path to a previous checkpoint to load the state from "
+        "and resume the state for. If provided, pretrained will "
+        "be ignored. If using a SparseZoo recipe, can also "
+        "provide 'zoo' to load the base weights associated with "
+        "that recipe. Additionally, can also provide a SparseZoo model stub "
+        "to load model weights from SparseZoo"
+    ),
+)
+@click.option(
+    "--task",
+    default="detect",
+    type=click.Choice(["detect", "segment", "classify"]),
+    help="Specify task to run.",
+)
+@click.option(
+    "--model",
+    default="yolov8n.yaml",
+    type=str,
+    help="i.e. yolov8n.pt, yolov8n.yaml. Path to model file",
+)
+@click.option(
+    "--data",
+    default="coco128.yaml",
+    type=str,
+    help="i.e. coco128.yaml. Path to data file",
+)
+@click.option("--epochs", default=100, type=int, help="number of epochs to train for")
+@click.option(
+    "--patience",
+    default=50,
+    type=int,
+    help="epochs to wait for no observable improvement for early stopping of training",
+)
+@click.option("--batch", default=16, type=int, help="number of images per batch")
+@click.option("--imgsz", default=640, type=int, help="size of input images")
+@click.option("--save", default=True, is_flag=True, help="save checkpoints")
+@click.option("--cache", default=False, is_flag=True, help="Use cache for data loading")
+@click.option(
+    "--device",
+    default=None,
+    type=str,
+    help="cuda device, i.e. 0 or 0,1,2,3 or cpu. Device to run on",
+)
+@click.option(
+    "--workers", default=8, type=int, help="number of worker threads for data loading"
+)
+@click.option("--project", default=None, type=str, help="project name")
+@click.option("--name", default=None, type=str, help="experiment name")
+@click.option(
+    "--exist-ok",
+    default=False,
+    is_flag=True,
+    help="whether to overwrite existing experiment",
+)
+@click.option(
+    "--pretrained",
+    default=False,
+    is_flag=True,
+    help="whether to use a pretrained model",
+)
+@click.option(
+    "--optimizer",
+    default="SGD",
+    type=click.Choice(["SGD", "Adam", "AdamW", "RMSProp"]),
+    help="optimizer to use",
+)
+@click.option(
+    "--verbose", default=False, is_flag=True, help="whether to print verbose output"
+)
+@click.option("--seed", default=0, type=int, help="random seed for reproducibility")
+@click.option(
+    "--deterministic",
+    default=True,
+    is_flag=True,
+    help="whether to enable deterministic mode",
+)
+@click.option(
+    "--single-cls",
+    default=False,
+    is_flag=True,
+    help="train multi-class data as single-class",
+)
+@click.option(
+    "--image-weights",
+    default=False,
+    is_flag=True,
+    help="use weighted image selection for training",
+)
+@click.option(
+    "--rect", default=False, is_flag=True, help="support rectangular training"
+)
+@click.option(
+    "--cos-lr", default=False, is_flag=True, help="use cosine learning rate scheduler"
+)
+@click.option(
+    "--close-mosaic",
+    default=10,
+    type=int,
+    help="disable mosaic augmentation for final 10 epochs",
+)
+@click.option(
+    "--overlap-mask",
+    default=True,
+    is_flag=True,
+    help="masks should overlap during training",
+)
+@click.option("--mask-ratio", default=4, type=int, help="mask downsample ratio")
+@click.option("--dropout", default=0.0, type=float, help="use dropout regularization")
+@click.option(
+    "--lr0",
+    default=0.01,
+    type=float,
+    help="initial learning rate (SGD=1E-2, Adam=1E-3)",
+)
+@click.option(
+    "--lrf", default=0.01, type=float, help="final OneCycleLR learning rate (lr0 * lrf)"
+)
+@click.option("--momentum", type=float, default=0.937, help="SGD momentum/Adam beta1")
+@click.option(
+    "--weight-decay", type=float, default=0.0005, help="optimizer weight decay 5e-4"
+)
+@click.option(
+    "--warmup-epochs", type=float, default=3.0, help="warmup epochs (fractions ok)"
+)
+@click.option(
+    "--warmup-momentum", type=float, default=0.8, help="warmup initial momentum"
+)
+@click.option(
+    "--warmup-bias-lr", type=float, default=0.1, help="warmup initial bias lr"
+)
+@click.option("--box", type=float, default=7.5, help="box loss gain")
+@click.option(
+    "--cls", type=float, default=0.5, help="cls loss gain (scale with pixels)"
+)
+@click.option("--dfl", type=float, default=1.5, help="dfl loss gain")
+@click.option(
+    "--fl-gamma",
+    type=float,
+    default=0.0,
+    help="focal loss gamma (efficientDet default gamma=1.5)",
+)
+@click.option("--label-smoothing", type=float, default=0.0)
+@click.option("--nbs", type=float, default=64, help="nominal batch size")
+@click.option(
+    "--hsv-h", type=float, default=0.015, help="image HSV-Hue augmentation (fraction)"
+)
+@click.option(
+    "--hsv-s",
+    type=float,
+    default=0.7,
+    help="image HSV-Saturation augmentation (fraction)",
+)
+@click.option(
+    "--hsv-v", type=float, default=0.4, help="image HSV-Value augmentation (fraction)"
+)
+@click.option("--degrees", type=float, default=0.0, help="image rotation (+/- deg)")
+@click.option(
+    "--translate", type=float, default=0.1, help="image translation (+/- fraction)"
+)
+@click.option("--scale", type=float, default=0.5, help="image scale (+/- gain)")
+@click.option("--shear", type=float, default=0.0, help="image shear (+/- deg)")
+@click.option(
+    "--perspective",
+    type=float,
+    default=0.0,
+    help="image perspective (+/- fraction), range 0-0.001",
+)
+@click.option(
+    "--flipud", type=float, default=0.0, help="image flip up-down (probability)"
+)
+@click.option(
+    "--fliplr", type=float, default=0.5, help="image flip left-right (probability)"
+)
+@click.option("--mosaic", type=float, default=1.0, help="image mosaic (probability)")
+@click.option("--mixup", type=float, default=0.0, help="image mixup (probability)")
+@click.option(
+    "--copy-paste", type=float, default=0.0, help="segment copy-paste (probability)"
+)
+def main(**kwargs):
+    model = SparseYOLO(kwargs["model"])
+    model.train(**kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sparseml/pytorch/yolov8/train.py
+++ b/src/sparseml/pytorch/yolov8/train.py
@@ -13,27 +13,7 @@
 # limitations under the License.
 
 import click
-from sparseml.pytorch.yolov8.trainers import (
-    ClassificationTrainer,
-    DetectionTrainer,
-    SegmentationTrainer,
-    SparseClassificationTrainer,
-    SparseDetectionTrainer,
-    SparseSegmentationTrainer,
-)
-from ultralytics.yolo.engine.model import YOLO
-
-
-class SparseYOLO(YOLO):
-    def __init__(self, model="yolov8n.yaml", type="v8") -> None:
-        super().__init__(model, type)
-
-        if self.TrainerClass == DetectionTrainer:
-            self.TrainerClass = SparseDetectionTrainer
-        elif self.TrainerClass == ClassificationTrainer:
-            self.TrainerClass = SparseClassificationTrainer
-        elif self.TrainerClass == SegmentationTrainer:
-            self.TrainerClass = SparseSegmentationTrainer
+from sparseml.pytorch.yolov8.trainers import SparseYOLO
 
 
 # Options generated from

--- a/src/sparseml/pytorch/yolov8/train.py
+++ b/src/sparseml/pytorch/yolov8/train.py
@@ -36,19 +36,6 @@ from sparseml.pytorch.yolov8.trainers import SparseYOLO
     "--resume", default=False, is_flag=True, help="resume training from last checkpoint"
 )
 @click.option(
-    "--checkpoint-path",
-    default=None,
-    type=str,
-    help=(
-        "A path to a previous checkpoint to load the state from "
-        "and resume the state for. If provided, pretrained will "
-        "be ignored. If using a SparseZoo recipe, can also "
-        "provide 'zoo' to load the base weights associated with "
-        "that recipe. Additionally, can also provide a SparseZoo model stub "
-        "to load model weights from SparseZoo"
-    ),
-)
-@click.option(
     "--task",
     default="detect",
     type=click.Choice(["detect", "segment", "classify"]),

--- a/src/sparseml/pytorch/yolov8/trainers.py
+++ b/src/sparseml/pytorch/yolov8/trainers.py
@@ -489,7 +489,8 @@ class SparseYOLO(YOLO):
         overrides["mode"] = "train"
         if not overrides.get("data"):
             raise AttributeError(
-                "dataset not provided! Please define `data` in config.yaml or pass as an argument."
+                "dataset not provided! Please define `data` "
+                "in config.yaml or pass as an argument."
             )
         if overrides.get("resume"):
             overrides["resume"] = self.ckpt_path

--- a/src/sparseml/pytorch/yolov8/trainers.py
+++ b/src/sparseml/pytorch/yolov8/trainers.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from copy import deepcopy
+from datetime import datetime
+
+import torch
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.optim import lr_scheduler
+
+from ultralytics import __version__
+from ultralytics.yolo.engine.trainer import BaseTrainer
+from ultralytics.yolo.utils import DEFAULT_CONFIG
+from ultralytics.yolo.utils.autobatch import check_train_batch_size
+from ultralytics.yolo.utils.dist import (
+    USER_CONFIG_DIR,
+    ddp_cleanup,
+    find_free_network_port,
+)
+from ultralytics.yolo.utils.torch_utils import ModelEMA, de_parallel, one_cycle
+from ultralytics.yolo.v8.classify.train import ClassificationTrainer
+from ultralytics.yolo.v8.detect.train import DetectionTrainer
+from ultralytics.yolo.v8.segment.train import SegmentationTrainer
+
+
+class SparseTrainer(BaseTrainer):
+    def __init__(self, config=DEFAULT_CONFIG, overrides=None):
+        super().__init__(config, overrides)
+
+    def train(self):
+        # NOTE: overriden to use our version of generate_ddp_command
+        world_size = torch.cuda.device_count()
+        if world_size > 1 and "LOCAL_RANK" not in os.environ:
+            command = generate_ddp_command(world_size, self)
+            try:
+                subprocess.run(command)
+            except Exception as e:
+                self.console(e)
+            finally:
+                ddp_cleanup(command, self)
+        else:
+            self._do_train(int(os.getenv("RANK", -1)), world_size)
+
+    def _setup_train(self, rank, world_size):
+        # model
+        self.run_callbacks("on_pretrain_routine_start")
+        ckpt = self.setup_model()
+        self.model = self.model.to(self.device)
+        self.set_model_attributes()
+        if world_size > 1:
+            self.model = DDP(self.model, device_ids=[rank])
+
+        # Batch size
+        if self.batch_size == -1:
+            if rank == -1:  # single-GPU only, estimate best batch size
+                self.batch_size = check_train_batch_size(
+                    self.model, self.args.imgsz, self.amp
+                )
+            else:
+                raise SyntaxError(
+                    "batch=-1 to use AutoBatch is only available in "
+                    "Single-GPU training. Please pass a valid batch "
+                    "size value for Multi-GPU DDP training, i.e. batch=16"
+                )
+
+        # Optimizer
+        self.accumulate = max(
+            round(self.args.nbs / self.batch_size), 1
+        )  # accumulate loss before optimizing
+        self.args.weight_decay *= (
+            self.batch_size * self.accumulate / self.args.nbs
+        )  # scale weight_decay
+        self.optimizer = self.build_optimizer(
+            model=self.model,
+            name=self.args.optimizer,
+            lr=self.args.lr0,
+            momentum=self.args.momentum,
+            decay=self.args.weight_decay,
+        )
+        # Scheduler
+        if self.args.cos_lr:
+            self.lf = one_cycle(1, self.args.lrf, self.epochs)  # cosine 1->hyp['lrf']
+        else:
+            self.lf = (
+                lambda x: (1 - x / self.epochs) * (1.0 - self.args.lrf) + self.args.lrf
+            )  # linear
+        self.scheduler = lr_scheduler.LambdaLR(self.optimizer, lr_lambda=self.lf)
+        self.scheduler.last_epoch = self.start_epoch - 1  # do not move
+
+        # dataloaders
+        batch_size = (
+            self.batch_size // world_size if world_size > 1 else self.batch_size
+        )
+        self.train_loader = self.get_dataloader(
+            self.trainset, batch_size=batch_size, rank=rank, mode="train"
+        )
+        if rank in {0, -1}:
+            self.test_loader = self.get_dataloader(
+                self.testset, batch_size=batch_size * 2, rank=-1, mode="val"
+            )
+            self.validator = self.get_validator()
+            metric_keys = self.validator.metrics.keys + self.label_loss_items(
+                prefix="val"
+            )
+            self.metrics = dict(
+                zip(metric_keys, [0] * len(metric_keys))
+            )  # TODO: init metrics for plot_results()?
+            self.ema = ModelEMA(self.model)
+        self.resume_training(ckpt)
+        self.run_callbacks("on_pretrain_routine_end")
+
+    def optimizer_step(self):
+        return super().optimizer_step()
+
+    def save_model(self):
+        ckpt = {
+            "epoch": self.epoch,
+            "best_fitness": self.best_fitness,
+            "model": deepcopy(de_parallel(self.model)).half(),
+            "ema": deepcopy(self.ema.ema).half(),
+            "updates": self.ema.updates,
+            "optimizer": self.optimizer.state_dict(),
+            "train_args": self.args,
+            "date": datetime.now().isoformat(),
+            "version": __version__,
+        }
+
+        # Save last, best and delete
+        torch.save(ckpt, self.last)
+        if self.best_fitness == self.fitness:
+            torch.save(ckpt, self.best)
+        del ckpt
+
+
+class SparseDetectionTrainer(SparseTrainer, DetectionTrainer):
+    pass
+
+
+class SparseClassificationTrainer(SparseTrainer, ClassificationTrainer):
+    pass
+
+
+class SparseSegmentationTrainer(SparseTrainer, SegmentationTrainer):
+    pass
+
+
+def generate_ddp_command(world_size, trainer):
+    import __main__  # noqa local import to avoid https://github.com/Lightning-AI/lightning/issues/15218
+
+    file_name = os.path.abspath(sys.argv[0])
+    using_cli = not file_name.endswith(".py")
+    if using_cli:
+        file_name = generate_ddp_file(trainer)
+    return [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--nproc_per_node",
+        f"{world_size}",
+        "--master_port",
+        f"{find_free_network_port()}",
+        file_name,
+    ] + sys.argv[1:]
+
+
+def generate_ddp_file(trainer):
+    import_path = ".".join(str(trainer.__class__).split(".")[1:-1])
+
+    if not trainer.resume:
+        shutil.rmtree(trainer.save_dir)  # remove the save_dir
+    content = f"""config = {dict(trainer.args)} \nif __name__ == "__main__":
+    from ultralytics.{import_path} import {trainer.__class__.__name__}
+
+    trainer = {trainer.__class__.__name__}(config=config)
+    trainer.train()"""
+    (USER_CONFIG_DIR / "DDP").mkdir(exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        prefix="_temp_",
+        suffix=f"{id(trainer)}.py",
+        mode="w+",
+        encoding="utf-8",
+        dir=USER_CONFIG_DIR / "DDP",
+        delete=False,
+    ) as file:
+        file.write(content)
+    return file.name

--- a/src/sparseml/pytorch/yolov8/trainers.py
+++ b/src/sparseml/pytorch/yolov8/trainers.py
@@ -17,34 +17,108 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import warnings
 from copy import deepcopy
 from datetime import datetime
+from pathlib import Path
+from typing import Optional
 
 import torch
-from torch.nn.parallel import DistributedDataParallel as DDP
-from torch.optim import lr_scheduler
 
+from sparseml.pytorch.optim.manager import ScheduledModifierManager
+from sparseml.pytorch.utils.helpers import download_framework_model_by_recipe_type
+from sparseml.pytorch.utils.logger import LoggerManager, PythonLogger, WANDBLogger
+from sparsezoo import Model
 from ultralytics import __version__
 from ultralytics.yolo.engine.trainer import BaseTrainer
-from ultralytics.yolo.utils import DEFAULT_CONFIG
-from ultralytics.yolo.utils.autobatch import check_train_batch_size
+from ultralytics.yolo.utils import LOGGER
 from ultralytics.yolo.utils.dist import (
     USER_CONFIG_DIR,
     ddp_cleanup,
     find_free_network_port,
 )
-from ultralytics.yolo.utils.torch_utils import ModelEMA, de_parallel, one_cycle
+from ultralytics.yolo.utils.torch_utils import ModelEMA, de_parallel
 from ultralytics.yolo.v8.classify.train import ClassificationTrainer
 from ultralytics.yolo.v8.detect.train import DetectionTrainer
 from ultralytics.yolo.v8.segment.train import SegmentationTrainer
 
 
+class _NullLRScheduler:
+    def step(self):
+        pass
+
+
+class _ToggleableEMA(ModelEMA):
+    def __init__(self, ema: ModelEMA):
+        self.ema = ema.ema
+        self.updates = ema.updates
+        self.decay = ema.decay
+        self.enabled = True
+
+    def update(self, **kwargs):
+        if not self.enabled:
+            return
+        return super().update(**kwargs)
+
+    def update_attr(self, **kwargs):
+        if not self.enabled:
+            return
+        return super().update_attr(**kwargs)
+
+
+DEFAULT_SPARSEML_CONFIG = Path(__file__).resolve().parent / "default.yaml"
+
+
 class SparseTrainer(BaseTrainer):
-    def __init__(self, config=DEFAULT_CONFIG, overrides=None):
+    """
+    Adds SparseML support to yolov8 BaseTrainer. This works in the following way:
+
+    1. Handle zoo stubs in `__init__`
+    2. Override `train()` to update the DDP command generation that YOLO has built in,
+        which assumes the trainer class is under `ultralytics` package.
+    3. Override `resume_training()` to create/load sparseml managers
+    3. Override `_setup_train()` to:
+        1. Override lr scheduler logic
+        2. Initializer our sparseml managers
+    4. Add callbacks to properly deactivation of EMA & AMP
+    5. Override `save_model()` to add manager to checkpoints
+    """
+
+    def __init__(self, config=DEFAULT_SPARSEML_CONFIG, overrides=None):
         super().__init__(config, overrides)
 
+        if isinstance(self.model, str) and self.model.startswith("zoo:"):
+            self.model = download_framework_model_by_recipe_type(Model(self.model))
+
+        if (
+            self.args.checkpoint_path is not None
+            and self.args.checkpoint_path.startswith("zoo:")
+        ):
+            self.args.checkpoint_path = download_framework_model_by_recipe_type(
+                Model(self.args.checkpoint_path)
+            )
+
+        self.manager: Optional[ScheduledModifierManager] = None
+        self.checkpoint_manager: Optional[ScheduledModifierManager] = None
+        self.logger_manager: LoggerManager = LoggerManager(log_python=False)
+
+        self.epoch_step: int = 0
+        self.steps_per_epoch: int = 0
+        self.do_emulated_step: bool = False
+
+        self.add_callback(
+            "on_train_epoch_start", SparseTrainer.callback_on_train_epoch_start
+        )
+        self.add_callback(
+            "on_train_batch_start", SparseTrainer.callback_on_train_batch_start
+        )
+        self.add_callback(
+            "on_train_batch_end", SparseTrainer.callback_on_train_batch_end
+        )
+        self.add_callback("teardown", SparseTrainer.callback_teardown)
+
     def train(self):
-        # NOTE: overriden to use our version of generate_ddp_command
+        # NOTE: overriden to use our version of `generate_ddp_command`
         world_size = torch.cuda.device_count()
         if world_size > 1 and "LOCAL_RANK" not in os.environ:
             command = generate_ddp_command(world_size, self)
@@ -58,20 +132,122 @@ class SparseTrainer(BaseTrainer):
             self._do_train(int(os.getenv("RANK", -1)), world_size)
 
     def resume_training(self, ckpt):
-        return super().resume_training(ckpt)
+        # NOTE: this method is called at the end of super()._setup_train()
+        super().resume_training(ckpt)
+
+        if ckpt is not None:
+            # resume - set manager from checkpoint
+            if "recipe" in ckpt:
+                self.manager = ScheduledModifierManager.from_yaml(ckpt["recipe"])
+        elif self.args.checkpoint_path is not None:
+            # previous checkpoint
+            if self.args.recipe is not None:
+                self.manager = ScheduledModifierManager.from_yaml(
+                    self.args.recipe, recipe_variables=self.args.recipe_args
+                )
+            old_ckpt = torch.load(self.args.checkpoint_path)
+            if "recipe" in old_ckpt and old_ckpt["recipe"] is not None:
+                self.checkpoint_manager = ScheduledModifierManager.from_yaml(
+                    old_ckpt["recipe"]
+                )
+        elif self.args.recipe is not None:
+            # normal training
+            self.manager = ScheduledModifierManager.from_yaml(
+                self.args.recipe, recipe_variables=self.args.recipe_args
+            )
 
     def _setup_train(self, rank, world_size):
-        return super()._setup_train(rank, world_size)
+        super()._setup_train(rank, world_size)
+        # NOTE: self.resume_training() was called in ^
+
+        if self.ema is not None:
+            self.ema = _ToggleableEMA(self.ema)
+
+        if rank in {0, -1}:
+            config = dict(self.args)
+            if self.manager is not None:
+                config["manager"] = str(self.manager)
+            loggers = [PythonLogger(logger=LOGGER)]
+            try:
+                loggers.append(WANDBLogger(init_kwargs=dict(config=config)))
+            except ImportError:
+                warnings.warn("Unable to import wandb for logging")
+            self.logger_manager = LoggerManager(loggers)
+
+        if self.manager is not None:
+            self.args.epochs = self.manager.max_epochs
+
+            if self.manager.learning_rate_modifiers:
+                self.scheduler = _NullLRScheduler()
+
+            self.manager.initialize(
+                self.model, epoch=self.start_epoch, loggers=self.logger_manager
+            )
+
+            # NOTE: we intentionally don't divide number of batches by gradient
+            # accumulation.
+            # This is because yolov8 changes size of gradient accumulation during
+            # warmup epochs, which is incompatible with SparseML managers
+            # because they assume a static steps_per_epoch.
+            # Instead, the manager will effectively ignore gradient accumulation,
+            # and we will call self.scaler.emulated_step() if the batch was
+            # accumulated.
+            self.steps_per_epoch = len(self.train_loader)  # / self.accumulate
+
+            self.scaler = self.manager.modify(
+                self.model,
+                self.optimizer,
+                steps_per_epoch=self.steps_per_epoch,
+                epoch=self.start_epoch,
+                wrap_optim=self.scaler,
+            )
+
+    def callback_on_train_epoch_start(self):
+        # NOTE: this callback is registered in __init__
+        if self.manager is not None and self.manager.qat_active(epoch=self.epoch):
+            if self.scaler is not None:
+                self.scaler._enabled = False
+            self.ema.enabled = False
+
+        self.epoch_step = 0
+
+    def callback_on_train_batch_start(self):
+        self.do_emulated_step = True
 
     def optimizer_step(self):
-        return super().optimizer_step()
+        super().optimizer_step()
+        self.do_emulated_step = False
+
+    def callback_on_train_batch_end(self):
+        # Here is where we handle the changing gradient accumulation values by doing
+        # an emulated step if we accumulated gradients of this batch
+        if self.do_emulated_step:
+            self.scaler.emulated_step()
+
+        step = self.epoch * self.steps_per_epoch + self.epoch_step
+        for key, value in self.label_loss_items(self.tloss).items():
+            self.logger_manager.log_scalar(key, value, step=step)
 
     def save_model(self):
+        # NOTE: identical to super().save_model() with the addition of recipe key
+        # in the checkpoint
+
+        epoch = -1 if self.epoch == self.epochs - 1 else self.epoch
+
+        if self.checkpoint_manager is not None:
+            if epoch >= 0:
+                epoch += self.checkpoint_manager.max_epochs
+            manager = ScheduledModifierManager.compose_staged(
+                self.checkpoint_manager, self.manager
+            )
+        else:
+            manager = self.manager if self.manager is not None else None
+
         ckpt = {
-            "epoch": self.epoch,
+            "epoch": epoch,
             "best_fitness": self.best_fitness,
-            "model": deepcopy(de_parallel(self.model)).half(),
-            "ema": deepcopy(self.ema.ema).half(),
+            "model": deepcopy(de_parallel(self.model)).half().state_dict(),
+            "ema": deepcopy(self.ema.ema).half().state_dict(),
             "updates": self.ema.updates,
             "optimizer": self.optimizer.state_dict(),
             "train_args": self.args,
@@ -79,11 +255,19 @@ class SparseTrainer(BaseTrainer):
             "version": __version__,
         }
 
+        if manager is not None:
+            ckpt["recipe"] = str(manager)
+
         # Save last, best and delete
         torch.save(ckpt, self.last)
         if self.best_fitness == self.fitness:
             torch.save(ckpt, self.best)
         del ckpt
+
+    def callback_teardown(self):
+        # NOTE: this callback is registered in __init__
+        if self.manager is not None:
+            self.manager.finalize()
 
 
 class SparseDetectionTrainer(SparseTrainer, DetectionTrainer):
@@ -99,6 +283,7 @@ class SparseSegmentationTrainer(SparseTrainer, SegmentationTrainer):
 
 
 def generate_ddp_command(world_size, trainer):
+    # NOTE: copied from ultralytics.yolo.utils.dist.generate_ddp_command
     import __main__  # noqa local import to avoid https://github.com/Lightning-AI/lightning/issues/15218
 
     file_name = os.path.abspath(sys.argv[0])
@@ -118,15 +303,16 @@ def generate_ddp_command(world_size, trainer):
 
 
 def generate_ddp_file(trainer):
-    import_path = ".".join(str(trainer.__class__).split(".")[1:-1])
+    # NOTE: adapted from ultralytics.yolo.utils.dist.generate_ddp_file
 
     if not trainer.resume:
         shutil.rmtree(trainer.save_dir)  # remove the save_dir
-    content = f"""config = {dict(trainer.args)} \nif __name__ == "__main__":
-    from ultralytics.{import_path} import {trainer.__class__.__name__}
 
-    trainer = {trainer.__class__.__name__}(config=config)
-    trainer.train()"""
+    content = f"""if __name__ == "__main__":
+    from sparseml.pytorch.yolov8.trainers import {trainer.__class__.__name__}
+    trainer = {trainer.__class__.__name__}(config={dict(trainer.args)})
+    trainer.train()
+"""
     (USER_CONFIG_DIR / "DDP").mkdir(exist_ok=True)
     with tempfile.NamedTemporaryFile(
         prefix="_temp_",


### PR DESCRIPTION
Adds yolov8 training script to the repo.

# Test plan

## Recipe

```yaml
version: 1.1.0

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: 15

pruning_modifiers:
  - !GMPruningModifier
    init_sparsity: 0.05
    final_sparsity: 0.10
    start_epoch: 5.0
    end_epoch: 10.0
    update_frequency: 1.0
    params: ["model.0.conv.weight", "model.1.conv.weight"]

quantization_modifiers:
  - !QuantizationModifier
    start_epoch: 11.0
    freeze_bn_stats_epoch: 12.0
    disable_quantization_observer_epoch: 13.0
    ignore: ["Upsample", "Concat", "SiLU"]
```

There are two parts to this:
1. the DFL final layer in the yolo models are detached (they do not require grads). Therefore, the pruner must ignore them as this currently crashes (see potential fix in #1329).
2. Due to ultralytics adding special attributes to top layer modules of the model, we must ignore Upsample & Concat for quantization. These attributes are [set on this line](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py#L451), and [used on this line](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/nn/tasks.py#L53). Without ignoring Upsample & Concat, these two layers get replaced with `QuantWrapper`, which does not have these special attributes set.

## Dense training ✅

### Base ✅

`CUDA_VISIBLE_DEVICES=0 python src/sparseml/pytorch/yolov8/train.py --name dense-base`

### From local yolo checkpoint ✅

After running the base training command above:

`CUDA_VISIBLE_DEVICES=0 python src/sparseml/pytorch/yolov8/train.py --name dense-local-yolo --model runs/detect/dense-base/weights/best.pt`

Should properly print:
```
...
Transferred 355/355 items from pretrained weights
...
```

### Continuing an interrupted run ✅

After running the base training command above:
`CUDA_VISIBLE_DEVICES=0 python src/sparseml/pytorch/yolov8/train.py --name dense-local-yolo --resume --model runs/detect/dense-base/weights/last.pt`

Properly prints:
```
...
Loading local ultralytics checkpoint
...
Transferred 355/355 items from pretrained weights
...
Resuming training from <path>/weights/last.pt from epoch 5 to 15 total epochs
```

## Pruned/Quantized Training

### Base ✅

`CUDA_VISIBLE_DEVICES=0 python src/sparseml/pytorch/yolov8/train.py --name pq --recipe yolov8-pq.yaml`

- Should train for 15 epochs.
- Pruning should be logged & change in wandb
- QuantizationModifier should be logged & wandb after it is applied

### Continuing from an interrupted run before quantization ✅

Run training for a few epochs, ctrl+c, then use the following command:

`CUDA_VISIBLE_DEVICES=0 python src/sparseml/pytorch/yolov8/train.py --resume --model <path>/weights/last.pt`

You should see the following message:

```
...
Loading local sparseml checkpoint
...
Applying structure from un-finished recipe in checkpoint at epoch <>
Loaded previous weights from sparseml checkpoint
...
```

### Continuing from an interrupted run after quantization ✅

Run training for a few epochs until quantization is applied, ctrl+c, then use the following command:

`CUDA_VISIBLE_DEVICES=0 python src/sparseml/pytorch/yolov8/train.py --resume --model <path>/weights/last.pt`

You should see:
```
...
Loading local sparseml checkpoint
...
Applying structure from un-finished recipe in checkpoint at epoch <>
...
```

### **NOT SUPPORTED** Fine tuning a quantized model with no recipe provided ❌ 

Run training with recipe to completion, then run:

`CUDA_VISIBLE_DEVICES=0 python src/sparseml/pytorch/yolov8/train.py --model <path>/weights/last.pt`

You should see:
```
...
Loading local sparseml checkpoint
...
Applying structure from completed recipe in checkpoint at epoch <>
...
```