### PR TITLE
Saving both original and final recipes in torchvision train script

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -24,7 +24,6 @@ import warnings
 from functools import update_wrapper
 from types import SimpleNamespace
 from typing import Callable, Optional
-from sparseml.optim.helpers import load_recipe_yaml_str
 
 import torch
 import torch.utils.data
@@ -34,6 +33,7 @@ from torch.utils.data.dataloader import DataLoader, default_collate
 from torchvision.transforms.functional import InterpolationMode
 
 import click
+from sparseml.optim.helpers import load_recipe_yaml_str
 from sparseml.pytorch.models.registry import ModelRegistry
 from sparseml.pytorch.optim import ScheduledModifierManager
 from sparseml.pytorch.torchvision import presets, transforms, utils

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -24,6 +24,7 @@ import warnings
 from functools import update_wrapper
 from types import SimpleNamespace
 from typing import Callable, Optional
+from sparseml.optim.helpers import load_recipe_yaml_str
 
 import torch
 import torch.utils.data
@@ -556,7 +557,14 @@ def main(args):
         logger = LoggerManager(log_python=False)
 
     if args.recipe is not None:
-        logger.save(args.recipe)
+        base_path = os.path.join(args.output_dir, "original_recipe.yaml")
+        with open(base_path, "w") as fp:
+            fp.write(load_recipe_yaml_str(args.recipe))
+        logger.save(base_path)
+
+        full_path = os.path.join(args.output_dir, "final_recipe.yaml")
+        manager.save(full_path)
+        logger.save(full_path)
 
     steps_per_epoch = len(data_loader) / args.gradient_accum_steps
 


### PR DESCRIPTION
Feature request was for any arguments passed via `--recipe-args` to be reflected in saved file in wandb.

This PR does the following:
1. Always saves a file for recipe, regardless of if args.recipe is a zoo stub or actual file
2. Saves the original unmodified/unsubstituted recipe as `{args.output_dir}/original_recipe.yaml`
3. Saves final recipe with variables from `--recipe-args` and other variables substituted as `{args.output_dir}/final_recipe.yaml`

Example in wandb:
<img width="555" alt="image" src="https://user-images.githubusercontent.com/109536191/214352459-a05ff6e5-0bd5-4636-a409-9aab73fd8b99.png">

<img width="746" alt="image" src="https://user-images.githubusercontent.com/109536191/214352560-39e24dc3-ce58-4953-95a7-510783a57ae0.png">


<img width="764" alt="image" src="https://user-images.githubusercontent.com/109536191/214352638-5af6b8b7-668e-41b4-aac4-63272c0900d3.png">

# Testing plan

Tested with command from README with both no recipe-args and recipe-args specified.