### PR TITLE
Removing distill_teacher model from args

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -380,7 +380,7 @@ def main(args):
 
     if args.distill_teacher not in ["self", "disable", None]:
         _LOGGER.info("Instantiating teacher")
-        args.distill_teacher = _create_model(
+        distill_teacher = _create_model(
             arch_key=args.teacher_arch_key,
             local_rank=local_rank,
             pretrained=True,  # teacher is always pretrained
@@ -572,7 +572,7 @@ def main(args):
             model,
             epoch=args.start_epoch,
             loggers=logger,
-            distillation_teacher=args.distill_teacher,
+            distillation_teacher=distill_teacher,
         )
         step_wrapper = manager.modify(
             model,


### PR DESCRIPTION
Fixes the bug `AttributeError: Can't pickle local object '_create_cache_output_hook.<locals>.forward_hook_fn'` with distillation.

This occurred because `args` are pickled in the checkpoint, and the whole distillation teacher model was being put into `args`. Moved it to a local variable instead.

# Test plan

Ran training for 1 epoch with recipe from asana ticket and verified save after fix.