### PR TITLE
Fix editing a list inside a loop

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
@@ -263,8 +263,7 @@ def _convert_signed_to_unsigned(model: ModelProto):
 
     for init in to_remove:
         model.graph.initializer.remove(init)
-    for init in to_append:
-        model.graph.initializer.append(init)
+    model.graph.initializer.extend(to_append)
 
 
 def _delete_repeated_qat_blocks(model: ModelProto):


### PR DESCRIPTION
Logic for converting signed to unsigned initializers was editing the initializer list inside a loop. Replaced by 2 stages: first create new initializers and the ones to remove, then edit the initializer list.