### PR TITLE
Fix referenced before assignment error

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -389,6 +389,8 @@ def main(args):
             device=device,
             num_classes=num_classes,
         )
+    else:
+        distill_teacher = args.distill_teacher
 
     if args.distributed and args.sync_bn:
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)


### PR DESCRIPTION
This should not reverse, but just fix: https://github.com/neuralmagic/sparseml/pull/1338
