### PR TITLE
Fixing return argument of _create_model for distillation

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -381,7 +381,7 @@ def main(args):
 
     if args.distill_teacher not in ["self", "disable", None]:
         _LOGGER.info("Instantiating teacher")
-        distill_teacher = _create_model(
+        distill_teacher, _ = _create_model(
             arch_key=args.teacher_arch_key,
             local_rank=local_rank,
             pretrained=True,  # teacher is always pretrained


### PR DESCRIPTION
Commit c7cf6b610acc49d30c996a122a205499bf27f747, changed _create_model to return a tuple, however the distillation call to this function was not updated, leading to errors about invalid values for teachers.

# Testing plan

Reproduction:
```
sparseml.image_classification.train --distill-teacher zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none --teacher-arch-key resnet-50 --recipe sparse-efficientnet.yaml --dataset-path ~/.cache/nm_datasets/imagenette/imagenette-320/ --arch-key resnet50
```

with recipe

```yaml
version: 1.1.0

# General Variables
num_epochs: 5

final_finetune_epochs: 0.1
qat_start_epoch: 0.0

init_lr: 2e-4
min_lr: 1e-8

weight_decay: 0.00001

qat_disable_observer_epoch: eval(num_epochs - final_finetune_epochs)
qat_freeze_bn_epoch: eval(num_epochs - final_finetune_epochs)

distill_gain: 1.0

# Modifiers

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: eval(num_epochs)

  - !SetLearningRateModifier
    start_epoch: 0.0
    learning_rate: eval(init_lr)

  - !LearningRateFunctionModifier
    start_epoch: eval(qat_start_epoch)
    end_epoch: eval(qat_disable_observer_epoch)
    lr_func: cosine
    init_lr: eval(init_lr)
    final_lr: eval(min_lr)

quantization_modifiers:
  - !QuantizationModifier
      start_epoch: eval(qat_start_epoch)
      ignore:
      - classifier
      - AdaptiveAvgPool2d
      disable_quantization_observer_epoch: eval(qat_disable_observer_epoch)
      freeze_bn_stats_epoch: eval(qat_freeze_bn_epoch)

distillation_modifiers:
  - !PerLayerDistillationModifier
      gain: eval(distill_gain)

regularization_modifiers:
  - !SetWeightDecayModifier
      start_epoch: 0
      weight_decay: eval(weight_decay)
```