### PR TITLE
Use more robust reshape instead of view

### DIFF
--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_obs.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_obs.py
@@ -433,7 +433,9 @@ class OBSPruningParamsScorer(PruningParamsGradScorer):
                         / (2.0 * finv.diag() + self._eps)
                     ).reshape(self._params[i].shape)
                 else:  # self._mask_type == "block4":
-                    block_w = self._params[i].data.reshape(-1, 4).to(finv.dev)  # (d/Q, Q)
+                    block_w = (
+                        self._params[i].data.reshape(-1, 4).to(finv.dev)
+                    )  # (d/Q, Q)
                     block_finv = (
                         torch.cat(
                             [

--- a/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_obs.py
+++ b/src/sparseml/pytorch/sparsification/pruning/modifier_pruning_obs.py
@@ -429,11 +429,11 @@ class OBSPruningParamsScorer(PruningParamsGradScorer):
             for i, finv in enumerate(self._finvs):
                 if self._mask_type == "unstructured":
                     scores[i] = (
-                        (self._params[i].data.view(-1) ** 2).to(self._devices[i])
+                        (self._params[i].data.reshape(-1) ** 2).to(self._devices[i])
                         / (2.0 * finv.diag() + self._eps)
-                    ).view(self._params[i].shape)
+                    ).reshape(self._params[i].shape)
                 else:  # self._mask_type == "block4":
-                    block_w = self._params[i].data.view(-1, 4).to(finv.dev)  # (d/Q, Q)
+                    block_w = self._params[i].data.reshape(-1, 4).to(finv.dev)  # (d/Q, Q)
                     block_finv = (
                         torch.cat(
                             [
@@ -486,7 +486,7 @@ class OBSPruningParamsScorer(PruningParamsGradScorer):
 
         for i, finv in enumerate(self._finvs):
             self._params[i].grad.mul_(masks[i])
-            finv.add_grad(self._params[i].grad.view(-1).to(self._devices[i]))
+            finv.add_grad(self._params[i].grad.reshape(-1).to(self._devices[i]))
 
     @torch.no_grad()
     def mask_update(self, masks: List[Tensor], mask_diffs: List[Tensor]):
@@ -506,20 +506,20 @@ class OBSPruningParamsScorer(PruningParamsGradScorer):
                         self._finvs[i]
                         .mul(
                             (param.data * (mask_diffs[i] == -1))
-                            .view(-1)
+                            .reshape(-1)
                             .to(self._devices[i])
                             / (self._finvs[i].diag() + self._eps)
                         )
-                        .view(param.data.shape)
+                        .reshape(param.data.shape)
                     )
                 else:  # self._mask_type == "block4":
                     obs_updates[i] = (
                         self._finvs[i]
                         .mul(
-                            self._block_finv_w[i].view(-1)
-                            * (mask_diffs[i] == -1).view(-1).to(self._devices[i])
+                            self._block_finv_w[i].reshape(-1)
+                            * (mask_diffs[i] == -1).reshape(-1).to(self._devices[i])
                         )
-                        .view(param.data.shape)
+                        .reshape(param.data.shape)
                     )
 
         self._broadcast_list_from_main(obs_updates)
@@ -588,7 +588,7 @@ class EmpiricalBlockFisherInverse:
             )
 
         # prepare grad for batch calculations
-        g = g.view(self.num_blocks, self.B)
+        g = g.reshape(self.num_blocks, self.B)
 
         # batched f_inv x g: (batch, B, B) x (batch, B) -> (batch, B)
         finv_g = torch.einsum("bij,bj->bi", self.f_inv, g)
@@ -617,5 +617,5 @@ class EmpiricalBlockFisherInverse:
                 [v, torch.zeros(self.num_blocks * self.B - v.numel(), device=v.device)]
             )
         return torch.bmm(
-            self.f_inv, v.view(self.num_blocks, self.B).unsqueeze_(2)
+            self.f_inv, v.reshape(self.num_blocks, self.B).unsqueeze_(2)
         ).flatten()[: self.d]


### PR DESCRIPTION
Fixes https://github.com/neuralmagic/sparseml/issues/1347 by replacing `.view` calls with more robust `.reshape`.