### PR TITLE
Bugfix: use label smoothing only when torch version is >= 1.10

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -409,12 +409,13 @@ def main(args):
     if args.distributed and args.sync_bn:
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
 
-    min_torch_version_with_label_smoothing = version.parse("1.10")
-    label_smoothing_supported = (
-        version.parse(torch.__version__) >= min_torch_version_with_label_smoothing
-    )
-    if label_smoothing_supported:
+    if version.parse(torch.__version__) >= version.parse("1.10"):
         criterion = nn.CrossEntropyLoss(label_smoothing=args.label_smoothing)
+    elif args.label_smoothing > 0:
+        raise ValueError(
+            f"`label_smoothing` not supported for {torch.__version__}, "
+            f"try upgrading to at-least 1.10"
+        )
     else:
         criterion = nn.CrossEntropyLoss()
 

--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -28,6 +28,7 @@ from typing import Callable, Optional
 import torch
 import torch.utils.data
 import torchvision
+from packaging import version
 from torch import nn
 from torch.utils.data.dataloader import DataLoader, default_collate
 from torchvision.transforms.functional import InterpolationMode
@@ -408,7 +409,14 @@ def main(args):
     if args.distributed and args.sync_bn:
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
 
-    criterion = nn.CrossEntropyLoss(label_smoothing=args.label_smoothing)
+    min_torch_version_with_label_smoothing = version.parse("1.10")
+    label_smoothing_supported = (
+        version.parse(torch.__version__) >= min_torch_version_with_label_smoothing
+    )
+    if label_smoothing_supported:
+        criterion = nn.CrossEntropyLoss(label_smoothing=args.label_smoothing)
+    else:
+        criterion = nn.CrossEntropyLoss()
 
     custom_keys_weight_decay = []
     if args.bias_weight_decay is not None:


### PR DESCRIPTION
# Torchvision integration support for torch < 1.10

[torch] introduced [label_smoothing] argument for [CrossEntropyLoss]
in version `1.10` and greater. Using this parameter in earlier versions  of 
[torch] leads to a `TypeError`

As of now in our torchvision training integration we do not make this 
distinction(rather we always use label_smoothing) which can cause errors with
lower versions of [torch]

For example on running the following command in an environment with torch 1.9
throws an error

**COMMAND**:
```python
sparseml.image_classification.train \
    --recipe "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original" \
    --checkpoint-path "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative" \
    --arch-key resnet50 \
    --dataset-path /XXXX/datasets/imagenette-160
```

**ENVIRONMENT**:
```bash
(sparseml3.8) 🥃 sparseml pip list | grep torch
torch                         1.9.0
torchvision                   0.10.0
```

**ERROR**:
```bash
2023-01-31 11:34:05 __main__     INFO     namespace(amp=False, arch_key='resnet50', augmix_severity=3, auto_augment=None, batch_size=32, bias_weight_decay=None, cache_dataset=False, checkpoint_path='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative', clip_grad_norm=None, cutmix_alpha=0.0, dataset_path='/home/XXXX/datasets/imagenette/imagenette-160', device='cuda', dist_url='env://', distill_teacher=None, distributed=False, epochs=10, eval_steps=None, gradient_accum_steps=1, interpolation='bilinear', label_smoothing=0.0, logging_steps=100, lr=0.1, lr_gamma=0.1, lr_min=0.0, lr_scheduler='steplr', lr_step_size=30, lr_warmup_decay=0.01, lr_warmup_epochs=0, lr_warmup_method='constant', mixup_alpha=0.0, model_ema=False, model_ema_decay=0.99998, model_ema_steps=32, momentum=0.9, norm_weight_decay=None, opt='sgd', output_dir='.', pretrained='True', pretrained_dataset=None, pretrained_teacher_dataset=None, print_freq=None, ra_magnitude=9, ra_reps=3, ra_sampler=False, random_erase=0.0, recipe='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original', recipe_args=None, resume=None, save_best_after=1, start_epoch=0, sync_bn=False, teacher_arch_key=None, test_only=False, train_crop_size=224, transformer_embedding_decay=None, use_deterministic_algorithms=False, val_crop_size=224, val_resize_size=256, weight_decay=0.0001, workers=16, world_size=1)
2023-01-31 11:34:05 __main__     INFO     Loading data
2023-01-31 11:34:05 __main__     INFO     Loading training data
2023-01-31 11:34:05 __main__     INFO     Took 0.032515764236450195
2023-01-31 11:34:05 __main__     INFO     Loading validation data
2023-01-31 11:34:05 __main__     INFO     Creating data loaders
2023-01-31 11:34:05 __main__     INFO     Creating model
Traceback (most recent call last):
  File "/home/XXXX/projects/sparseml/src/sparseml/pytorch/torchvision/train.py", line 1175, in <module>
    cli()
  File "/home/XXXX/projects/sparseml/src/sparseml/pytorch/torchvision/train.py", line 852, in new_func
    return f(*args, **kwargs)
  File "/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/XXXX/projects/sparseml/src/sparseml/pytorch/torchvision/train.py", line 1171, in cli
    main(SimpleNamespace(**kwargs))
  File "/home/XXXX/projects/sparseml/src/sparseml/pytorch/torchvision/train.py", line 411, in main
    criterion = nn.CrossEntropyLoss(label_smoothing=args.label_smoothing)
TypeError: __init__() got an unexpected keyword argument 'label_smoothing'

Process finished with exit code 1
```

## After Current Pull Request

Current PR fixes the issue by adding a check for `torch.__version__` and 
passing in [label-smoothing] argument only if it is supported.

After described change, the original command works with both 
[torch] `<1.10` and [torch] `>= 1.10` 

### With Torch > 1.10

**ENVIRONMENT**:
```bash
(sparseml3.8) 🥃 sparseml pip list | grep torch
torch                         1.12.0
torchvision                   0.13.0
```

**OUTPUT**:
```bash
2023-01-31 11:22:51 __main__     INFO     namespace(amp=False, arch_key='resnet50', augmix_severity=3, auto_augment=None, batch_size=32, bias_weight_decay=None, cache_dataset=False, checkpoint_path='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative', clip_grad_norm=None, cutmix_alpha=0.0, dataset_path='/home/XXXX/datasets/imagenette/imagenette-160', device='cuda', dist_url='env://', distill_teacher=None, distributed=False, epochs=10, eval_steps=None, gradient_accum_steps=1, interpolation='bilinear', label_smoothing=0.0, logging_steps=100, lr=0.1, lr_gamma=0.1, lr_min=0.0, lr_scheduler='steplr', lr_step_size=30, lr_warmup_decay=0.01, lr_warmup_epochs=0, lr_warmup_method='constant', mixup_alpha=0.0, model_ema=False, model_ema_decay=0.99998, model_ema_steps=32, momentum=0.9, norm_weight_decay=None, opt='sgd', output_dir='.', pretrained='True', pretrained_dataset=None, pretrained_teacher_dataset=None, print_freq=None, ra_magnitude=9, ra_reps=3, ra_sampler=False, random_erase=0.0, recipe='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original', recipe_args=None, resume=None, save_best_after=1, start_epoch=0, sync_bn=False, teacher_arch_key=None, test_only=False, train_crop_size=224, transformer_embedding_decay=None, use_deterministic_algorithms=False, val_crop_size=224, val_resize_size=256, weight_decay=0.0001, workers=16, world_size=1)
2023-01-31 11:22:51 __main__     INFO     Loading data
2023-01-31 11:22:51 __main__     INFO     Loading training data
2023-01-31 11:22:51 __main__     INFO     Took 0.025443077087402344
2023-01-31 11:22:51 __main__     INFO     Loading validation data
2023-01-31 11:22:51 __main__     INFO     Creating data loaders
2023-01-31 11:22:51 __main__     INFO     Creating model
/home/XXXX/projects/sparseml/src/sparseml/pytorch/torchvision/train.py:576: UserWarning: Unable to import wandb for logging
  warnings.warn("Unable to import wandb for logging")
2023-01-31 11:22:55 __main__     INFO     Start training
INFO:__main__:Start training
2023-01-31 11:22:57 __main__     INFO     Epoch: [0]  [  0/403]  eta: 0:13:26  lr: 0.008  imgs_per_sec: 23.440476040780343  loss: 0.0141 (0.0141)  acc1: 100.0000 (100.0000)  acc5: 100.0000 (100.0000)  time: 2.0010  data: 0.6358  max mem: 5263
INFO:__main__:Epoch: [0]  [  0/403]  eta: 0:13:26  lr: 0.008  imgs_per_sec: 23.440476040780343  loss: 0.0141 (0.0141)  acc1: 100.0000 (100.0000)  acc5: 100.0000 (100.0000)  time: 2.0010  data: 0.6358  max mem: 5263
2023-01-31 11:23:08 __main__     INFO     Epoch: [0]  [100/403]  eta: 0:00:39  lr: 0.008  imgs_per_sec: 282.44055327467817  loss: 1.9750 (1.6036)  acc1: 43.7500 (51.6089)  acc5: 81.2500 (89.3255)  time: 0.1134  data: 0.0001  max mem: 5263
INFO:__main__:Epoch: [0]  [100/403]  eta: 0:00:39  lr: 0.008  imgs_per_sec: 282.44055327467817  loss: 1.9750 (1.6036)  acc1: 43.7500 (51.6089)  acc5: 81.2500 (89.3255)  time: 0.1134  data: 0.0001  max mem: 5263
2023-01-31 11:23:20 __main__     INFO     Epoch: [0]  [200/403]  eta: 0:00:24  lr: 0.008  imgs_per_sec: 280.5965086864717  loss: 1.0415 (1.4364)  acc1: 59.3750 (56.2811)  acc5: 96.8750 (91.3713)  time: 0.1139  data: 0.0001  max mem: 5263
INFO:__main__:Epoch: [0]  [200/403]  eta: 0:00:24  lr: 0.008  imgs_per_sec: 280.5965086864717  loss: 1.0415 (1.4364)  acc1: 59.3750 (56.2811)  acc5: 96.8750 (91.3713)  time: 0.1139  data: 0.0001  max mem: 5263
2023-01-31 11:23:31 __main__     INFO     Epoch: [0]  [300/403]  eta: 0:00:12  lr: 0.008  imgs_per_sec: 280.01345222249574  loss: 0.8138 (1.2772)  acc1: 75.0000 (60.8908)  acc5: 96.8750 (92.7741)  time: 0.1143  data: 0.0001  max mem: 5263
INFO:__main__:Epoch: [0]  [300/403]  eta: 0:00:12  lr: 0.008  imgs_per_sec: 280.01345222249574  loss: 0.8138 (1.2772)  acc1: 75.0000 (60.8908)  acc5: 96.8750 (92.7741)  time: 0.1143  data: 0.0001  max mem: 5263
2023-01-31 11:23:43 __main__     INFO     Epoch: [0]  [400/403]  eta: 0:00:00  lr: 0.008  imgs_per_sec: 279.4828542633205  loss: 0.7589 (1.1680)  acc1: 71.8750 (64.0430)  acc5: 100.0000 (93.6409)  time: 0.1145  data: 0.0000  max mem: 5263
INFO:__main__:Epoch: [0]  [400/403]  eta: 0:00:00  lr: 0.008  imgs_per_sec: 279.4828542633205  loss: 0.7589 (1.1680)  acc1: 71.8750 (64.0430)  acc5: 100.0000 (93.6409)  time: 0.1145  data: 0.0000  max mem: 5263
2023-01-31 11:23:43 __main__     INFO     Epoch: [0] Total time: 0:00:48
INFO:__main__:Epoch: [0] Total time: 0:00:48
```


### With Torch < 1.10

**ENVIRONMENT**:
```bash
(sparseml3.8) 🥃 sparseml pip list | grep torch
torch                         1.9.0
torchvision                   0.10.0
```

**OUTPUT**:
(Works with warnings)
```bash
2023-01-31 11:30:44 __main__     INFO     namespace(amp=False, arch_key='resnet50', augmix_severity=3, auto_augment=None, batch_size=32, bias_weight_decay=None, cache_dataset=False, checkpoint_path='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative', clip_grad_norm=None, cutmix_alpha=0.0, dataset_path='/home/XXXX/datasets/imagenette/imagenette-160', device='cuda', dist_url='env://', distill_teacher=None, distributed=False, epochs=10, eval_steps=None, gradient_accum_steps=1, interpolation='bilinear', label_smoothing=0.0, logging_steps=100, lr=0.1, lr_gamma=0.1, lr_min=0.0, lr_scheduler='steplr', lr_step_size=30, lr_warmup_decay=0.01, lr_warmup_epochs=0, lr_warmup_method='constant', mixup_alpha=0.0, model_ema=False, model_ema_decay=0.99998, model_ema_steps=32, momentum=0.9, norm_weight_decay=None, opt='sgd', output_dir='.', pretrained='True', pretrained_dataset=None, pretrained_teacher_dataset=None, print_freq=None, ra_magnitude=9, ra_reps=3, ra_sampler=False, random_erase=0.0, recipe='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original', recipe_args=None, resume=None, save_best_after=1, start_epoch=0, sync_bn=False, teacher_arch_key=None, test_only=False, train_crop_size=224, transformer_embedding_decay=None, use_deterministic_algorithms=False, val_crop_size=224, val_resize_size=256, weight_decay=0.0001, workers=16, world_size=1)
2023-01-31 11:30:44 __main__     INFO     Loading data
2023-01-31 11:30:44 __main__     INFO     Loading training data
2023-01-31 11:30:44 __main__     INFO     Took 0.03237438201904297
2023-01-31 11:30:44 __main__     INFO     Loading validation data
2023-01-31 11:30:44 __main__     INFO     Creating data loaders
2023-01-31 11:30:44 __main__     INFO     Creating model
/home/XXXX/projects/sparseml/src/sparseml/pytorch/torchvision/train.py:576: UserWarning: Unable to import wandb for logging
  warnings.warn("Unable to import wandb for logging")
2023-01-31 11:30:48 __main__     INFO     Start training
INFO:__main__:Start training
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torchvision/transforms/functional.py:165: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)
  img = torch.as_tensor(np.asarray(pic))
/home/XXXX/virtual_environments/sparseml3.8/lib/python3.8/site-packages/torch/nn/functional.py:718: UserWarning: Named tensors and all their associated APIs are an experimental feature and subject to change. Please do not use them for anything important until they are released as stable. (Triggered internally at  /pytorch/c10/core/TensorImpl.h:1156.)
  return torch.max_pool2d(input, kernel_size, stride, padding, dilation, ceil_mode)
2023-01-31 11:30:49 __main__     INFO     Epoch: [0]  [  0/403]  eta: 0:11:22  lr: 0.008  imgs_per_sec: 35.85223777097987  loss: 0.2452 (0.2452)  acc1: 93.7500 (93.7500)  acc5: 100.0000 (100.0000)  time: 1.6936  data: 0.8010  max mem: 5925
INFO:__main__:Epoch: [0]  [  0/403]  eta: 0:11:22  lr: 0.008  imgs_per_sec: 35.85223777097987  loss: 0.2452 (0.2452)  acc1: 93.7500 (93.7500)  acc5: 100.0000 (100.0000)  time: 1.6936  data: 0.8010  max mem: 5925
2023-01-31 11:31:01 __main__     INFO     Epoch: [0]  [100/403]  eta: 0:00:38  lr: 0.008  imgs_per_sec: 283.3199530536253  loss: 1.3282 (1.4030)  acc1: 59.3750 (57.4567)  acc5: 93.7500 (90.5941)  time: 0.1131  data: 0.0001  max mem: 5925
INFO:__main__:Epoch: [0]  [100/403]  eta: 0:00:38  lr: 0.008  imgs_per_sec: 283.3199530536253  loss: 1.3282 (1.4030)  acc1: 59.3750 (57.4567)  acc5: 93.7500 (90.5941)  time: 0.1131  data: 0.0001  max mem: 5925
2023-01-31 11:31:12 __main__     INFO     Epoch: [0]  [200/403]  eta: 0:00:24  lr: 0.008  imgs_per_sec: 282.5368712437769  loss: 0.7458 (1.2122)  acc1: 84.3750 (62.9664)  acc5: 100.0000 (92.8793)  time: 0.1135  data: 0.0001  max mem: 5925
INFO:__main__:Epoch: [0]  [200/403]  eta: 0:00:24  lr: 0.008  imgs_per_sec: 282.5368712437769  loss: 0.7458 (1.2122)  acc1: 84.3750 (62.9664)  acc5: 100.0000 (92.8793)  time: 0.1135  data: 0.0001  max mem: 5925
2023-01-31 11:31:23 __main__     INFO     Epoch: [0]  [300/403]  eta: 0:00:12  lr: 0.008  imgs_per_sec: 281.64931527546366  loss: 1.3638 (1.0843)  acc1: 62.5000 (66.6528)  acc5: 90.6250 (94.1549)  time: 0.1139  data: 0.0001  max mem: 5925
INFO:__main__:Epoch: [0]  [300/403]  eta: 0:00:12  lr: 0.008  imgs_per_sec: 281.64931527546366  loss: 1.3638 (1.0843)  acc1: 62.5000 (66.6528)  acc5: 90.6250 (94.1549)  time: 0.1139  data: 0.0001  max mem: 5925
2023-01-31 11:31:35 __main__     INFO     Epoch: [0]  [400/403]  eta: 0:00:00  lr: 0.008  imgs_per_sec: 280.0876629542215  loss: 0.5327 (0.9901)  acc1: 81.2500 (69.3189)  acc5: 96.8750 (94.9112)  time: 0.1142  data: 0.0000  max mem: 5925
INFO:__main__:Epoch: [0]  [400/403]  eta: 0:00:00  lr: 0.008  imgs_per_sec: 280.0876629542215  loss: 0.5327 (0.9901)  acc1: 81.2500 (69.3189)  acc5: 96.8750 (94.9112)  time: 0.1142  data: 0.0000  max mem: 5925
2023-01-31 11:31:36 __main__     INFO     Epoch: [0] Total time: 0:00:48
INFO:__main__:Epoch: [0] Total time: 0:00:48
```

The proposed fixes are in relation to the following [Ticket](https://app.asana.com/0/1201735099598270/1203858996860827/f)


[torch]: https://pytorch.org/
[label-smoothing]: https://github.com/pytorch/pytorch/blob/71f889c7d265b9636b93ede9d651c0a9c4bee191/torch/nn/modules/loss.py#L1107
[label_smoothing]: https://github.com/pytorch/pytorch/blob/71f889c7d265b9636b93ede9d651c0a9c4bee191/torch/nn/modules/loss.py#L1107
[CrossEntropyLoss]: https://github.com/pytorch/pytorch/blob/71f889c7d265b9636b93ede9d651c0a9c4bee191/torch/nn/modules/loss.py#L1016