### PR TITLE
Replace view by reshape

### DIFF
--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -1118,9 +1118,9 @@ def memory_aware_threshold(tensor: torch.Tensor, idx: int) -> Tensor:
             MEMORY_BOUNDED in os.environ
             and os.environ[MEMORY_BOUNDED].lower() == "true"
         ):
-            return torch.kthvalue(tensor.view(-1), idx + 1)[0]
+            return torch.kthvalue(tensor.reshape(-1), idx + 1)[0]
         else:
-            return torch.sort(tensor.view(-1))[0][idx]
+            return torch.sort(tensor.reshape(-1))[0][idx]
     except RuntimeError:
         _LOGGER.warning(
             "Finding threshold from sparsity failed due to lack of memory, "


### PR DESCRIPTION
The problem

I've figured out that the [method](https://github.com/neuralmagic/sparseml/blob/cce208500dae13613358d309f2fe0615b19fbb66/src/sparseml/pytorch/sparsification/pruning/mask_creator.py#L178) _threshold_from_sparsity in the UnstructuredPruningMaskCreator
calling inside memory_aware_threshold [function](https://github.com/neuralmagic/sparseml/blob/cce208500dae13613358d309f2fe0615b19fbb66/src/sparseml/pytorch/utils/helpers.py#L1106) may lead to the the following error:

RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.

The issue described above arises when the convolutional layers are switched to channels_last format.

Solution

In order to make the tensor again contigious one has to replace .view by .reshape, i.e:
```
def memory_aware_threshold(tensor: torch.Tensor, idx: int) -> Tensor:
    """
    Finds a threshold at the lookup idx in the most efficient way with available
    resources. Will be phased out when GPU-memory overhead of torch.sort reduces,
    or when torch.kthvalue becomes faster than torch.sort.
    :param tensor: A tensor to find a k-th smallest value in, where k=idx+1
    :param idx: A lookup index
    :return: k-th smallest value from the given tensor, where k=idx+1
    """
    try:
        if (
            MEMORY_BOUNDED in os.environ
            and os.environ[MEMORY_BOUNDED].lower() == "true"
        ):
            return torch.kthvalue(tensor.**reshape**(-1), idx + 1)[0]
        else:
            return torch.sort(tensor.**reshape**(-1))[0][idx]
    except RuntimeError:
        _LOGGER.warning(
            "Finding threshold from sparsity failed due to lack of memory, "
            "will attempt to recover. Consider setting env variable "
            f"{MEMORY_BOUNDED}=True in future runs."
        )
        torch.cuda.empty_cache()
        os.environ[MEMORY_BOUNDED] = "True"
        return torch.kthvalue(tensor.view(-1), idx + 1)[0]

```