### PR TITLE
install extra option for torch_all

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,8 @@ _dev_deps = [
     "flaky~=3.7.0",
     "sphinx-rtd-theme",
     "docutils<0.17",
+    "tensorboard>=1.0,<2.9",
+    "tensorboardX>=1.0",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ _pytorch_deps = [
     "tensorboardX>=1.0",
     "gputils",
 ]
+_pytorch_all_deps = _pytorch_deps + ["torchvision>=0.3.0,<=0.13", "torchaudio<=0.12"]
 _pytorch_vision_deps = _pytorch_deps + ["torchvision>=0.3.0,<=0.13"]
 _tensorflow_v1_deps = ["tensorflow<2.0.0", "tensorboard<2.0.0", "tf2onnx>=1.0.0,<1.6"]
 _tensorflow_v1_gpu_deps = [
@@ -123,6 +124,7 @@ def _setup_extras() -> Dict:
         "deepsparse-ent": _deepsparse_ent_deps,
         "onnxruntime": _onnxruntime_deps,
         "torch": _pytorch_deps,
+        "torch_all": _pytorch_all_deps,
         "torchvision": _pytorch_vision_deps,
         "tf_v1": _tensorflow_v1_deps,
         "tf_v1_gpu": _tensorflow_v1_gpu_deps,

--- a/setup.py
+++ b/setup.py
@@ -63,11 +63,13 @@ _deepsparse_ent_deps = [f"deepsparse-ent~={version_nm_deps}"]
 _onnxruntime_deps = ["onnxruntime>=1.0.0"]
 _pytorch_deps = [
     "torch>=1.1.0,<=1.12.1",
-    "tensorboard>=1.0,<2.9",
-    "tensorboardX>=1.0",
     "gputils",
 ]
-_pytorch_all_deps = _pytorch_deps + ["torchvision>=0.3.0,<=0.13", "torchaudio<=0.12"]
+_pytorch_all_deps = _pytorch_deps + [
+    "torchvision>=0.3.0,<=0.13",
+    "torchaudio<=0.12",
+    "torchvision>=0.3.0,<=0.13",
+]
 _pytorch_vision_deps = _pytorch_deps + ["torchvision>=0.3.0,<=0.13"]
 _tensorflow_v1_deps = ["tensorflow<2.0.0", "tensorboard<2.0.0", "tf2onnx>=1.0.0,<1.6"]
 _tensorflow_v1_gpu_deps = [


### PR DESCRIPTION
* adds `torch_all` extra dependency which includes torch{audio,text,vision}
* removes `tensorboard` as a torch dependency since it is an optional install for torch logging and may cause version conflicts for users with existing dependencies
* moves the tensorboard deps to dev deps to unblock GHA testing

**test_plan:**
@rahul-tuli verified a fresh environment with a few intentionally adversarial preinstalled dependencies (newer tensorflow version, older flask version, older click version) was able to install a fresh build of `sparseml[torch_all]` and kick off an IC training run