### PR TITLE
relax click dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ _deps = [
     "toposort>=1.0",
     "GPUtil>=1.4.0",
     "protobuf>=3.12.2,<=3.20.1",
-    "click~=8.0.0",
+    "click>=7.1.2,!=8.0.0",  # latest version < 8.0 + blocked version with reported bug
 ]
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}"]
 _deepsparse_deps = [


### PR DESCRIPTION
strict click dependency has caused issues with users who's environments pin click to less than version 8. this PR allows for enablement of click<8.0 by allowing the latest non 8.0 version only. The maximum version was also lifted as the previous restriction was to avoid installing 8.0.0, a version that had reported issues working with wandb.

*test_plan:**
Click is used only by our main entrypoint CLIs which will be in scope for manual/automated QA testing in the 1.5 release as well as any integration tests