### PR TITLE
[Fix] Add more verbose`wandb` import error

### DIFF
--- a/src/sparseml/pytorch/utils/logger.py
+++ b/src/sparseml/pytorch/utils/logger.py
@@ -534,7 +534,14 @@ class WANDBLogger(LambdaLogger):
         init_kwargs: Optional[Dict] = None,
         name: str = "wandb",
         enabled: bool = True,
+        wandb_err: Optional[Exception] = wandb_err,
     ):
+        if wandb_err:
+            raise ModuleNotFoundError(
+                "Error: Failed to import wandb. "
+                "Please install the wandb library in order to use it."
+            ) from wandb_err
+
         super().__init__(
             lambda_func=self._log_lambda,
             name=name,


### PR DESCRIPTION
More verbose error message instructing the user to install wandb. Fix for https://app.asana.com/0/1201735099598270/1203877616112261/f

```bash
Traceback (most recent call last):
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/utils/logger.py", line 41, in <module>
    import wandb
ModuleNotFoundError: No module named 'wandb'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/damian/sparseml/src/sparseml/transformers/text_classification.py", line 55, in <module>
    from sparseml.pytorch.utils.distributed import record
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/__init__.py", line 51, in <module>
    from .framework import detect_framework, framework_info, is_supported
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/framework/__init__.py", line 24, in <module>
    from .info import *
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/framework/info.py", line 26, in <module>
    from sparseml.pytorch.sparsification import sparsification_info
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/sparsification/__init__.py", line 24, in <module>
    from .distillation import *
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/sparsification/distillation/__init__.py", line 17, in <module>
    from .modifier_distillation import *
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/sparsification/distillation/modifier_distillation.py", line 24, in <module>
    from sparseml.pytorch.sparsification.distillation.modifier_distillation_base import (
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py", line 30, in <module>
    from sparseml.pytorch.sparsification.modifier import (
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/sparsification/modifier.py", line 36, in <module>
    from sparseml.pytorch.utils import LOGGING_LEVELS, BaseLogger, LoggerManager
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/utils/__init__.py", line 26, in <module>
    from .logger import *
  File "/home/ubuntu/damian/sparseml/src/sparseml/pytorch/utils/logger.py", line 47, in <module>
    raise ModuleNotFoundError(
ModuleNotFoundError: Error: Failed to import wandb. Please install the wandb library in order to use it.
```