### PR TITLE
Adding `sparseml.ultralytics.val` script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -231,7 +231,10 @@ def _setup_entry_points() -> Dict:
     )
 
     entry_points["console_scripts"].extend(
-        ["sparseml.ultralytics.train=sparseml.pytorch.yolov8.train:main"]
+        [
+            "sparseml.ultralytics.train=sparseml.pytorch.yolov8.train:main",
+            "sparseml.ultralytics.val=sparseml.pytorch.yolov8.val:main",
+        ]
     )
 
     return entry_points

--- a/src/sparseml/pytorch/yolov8/trainers.py
+++ b/src/sparseml/pytorch/yolov8/trainers.py
@@ -28,9 +28,15 @@ import torch
 from sparseml.pytorch.optim.manager import ScheduledModifierManager
 from sparseml.pytorch.utils.helpers import download_framework_model_by_recipe_type
 from sparseml.pytorch.utils.logger import LoggerManager, PythonLogger, WANDBLogger
+from sparseml.pytorch.yolov8.validators import (
+    SparseClassificationValidator,
+    SparseDetectionValidator,
+    SparseSegmentationValidator,
+)
 from sparsezoo import Model
 from ultralytics import __version__
 from ultralytics.nn.tasks import attempt_load_one_weight
+from ultralytics.yolo.configs import get_config
 from ultralytics.yolo.engine.model import YOLO
 from ultralytics.yolo.engine.trainer import BaseTrainer
 from ultralytics.yolo.utils import LOGGER, yaml_load
@@ -40,10 +46,14 @@ from ultralytics.yolo.utils.dist import (
     ddp_cleanup,
     find_free_network_port,
 )
-from ultralytics.yolo.utils.torch_utils import ModelEMA, de_parallel
-from ultralytics.yolo.v8.classify.train import ClassificationTrainer
-from ultralytics.yolo.v8.detect.train import DetectionTrainer
-from ultralytics.yolo.v8.segment.train import SegmentationTrainer
+from ultralytics.yolo.utils.torch_utils import (
+    ModelEMA,
+    de_parallel,
+    smart_inference_mode,
+)
+from ultralytics.yolo.v8.classify import ClassificationTrainer, ClassificationValidator
+from ultralytics.yolo.v8.detect import DetectionTrainer, DetectionValidator
+from ultralytics.yolo.v8.segment import SegmentationTrainer, SegmentationValidator
 
 
 class _NullLRScheduler:
@@ -371,12 +381,6 @@ class SparseTrainer(BaseTrainer):
             torch.save(ckpt, self.best)
         del ckpt
 
-    def validate(self):
-        # skip validation if we are using a recipe
-        if self.manager is None and self.checkpoint_manager is None:
-            return super().validate()
-        return {}, None
-
     def final_eval(self):
         # skip final eval if we are using a recipe
         if self.manager is None and self.checkpoint_manager is None:
@@ -428,6 +432,13 @@ class SparseYOLO(YOLO):
             self.TrainerClass = SparseClassificationTrainer
         elif self.TrainerClass == SegmentationTrainer:
             self.TrainerClass = SparseSegmentationTrainer
+
+        if self.ValidatorClass == DetectionValidator:
+            self.ValidatorClass = SparseDetectionValidator
+        elif self.ValidatorClass == ClassificationValidator:
+            self.ValidatorClass = SparseClassificationValidator
+        elif self.ValidatorClass == SegmentationValidator:
+            self.ValidatorClass = SparseSegmentationValidator
 
     def _load(self, weights: str):
         if self.is_sparseml_checkpoint:
@@ -503,6 +514,18 @@ class SparseYOLO(YOLO):
             )
             self.model = self.trainer.model
         self.trainer.train()
+
+    @smart_inference_mode()
+    def val(self, data=None, **kwargs):
+        overrides = self.overrides.copy()
+        overrides.update(kwargs)
+        overrides["mode"] = "val"
+        args = get_config(config=DEFAULT_SPARSEML_CONFIG, overrides=overrides)
+        args.data = data or args.data
+        args.task = self.task
+
+        validator = self.ValidatorClass(args=args)
+        validator(model=self.model)
 
 
 def generate_ddp_command(world_size, trainer):

--- a/src/sparseml/pytorch/yolov8/val.py
+++ b/src/sparseml/pytorch/yolov8/val.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+from sparseml.pytorch.yolov8.trainers import SparseYOLO
+
+
+@click.command(
+    context_settings=(
+        dict(token_normalize_func=lambda x: x.replace("-", "_"), show_default=True)
+    )
+)
+@click.option(
+    "--task",
+    default="detect",
+    type=click.Choice(["detect", "segment", "classify"]),
+    help="Specify task to run.",
+)
+@click.option(
+    "--model",
+    default="yolov8n.yaml",
+    type=str,
+    help="i.e. yolov8n.pt, yolov8n.yaml. Path to model file",
+)
+@click.option(
+    "--data",
+    default="coco128.yaml",
+    type=str,
+    help="i.e. coco128.yaml. Path to data file",
+)
+@click.option(
+    "--save-json", default=False, is_flag=True, help="save results to JSON file"
+)
+@click.option(
+    "--save-hybrid",
+    default=False,
+    is_flag=True,
+    help="save hybrid version of labels (labels + additional predictions)",
+)
+@click.option(
+    "--conf",
+    default=None,
+    type=float,
+    help="object confidence threshold for detection (default 0.25 predict, 0.001 val)",
+)
+@click.option(
+    "--iou",
+    default=0.7,
+    type=float,
+    help="intersection over union (IoU) threshold for NMS",
+)
+@click.option(
+    "--max_det", default=300, type=int, help="maximum number of detections per image"
+)
+@click.option("--half", default=False, is_flag=True, help="use half precision (FP16)")
+@click.option(
+    "--dnn", default=False, is_flag=True, help="use OpenCV DNN for ONNX inference"
+)
+@click.option("--plots", default=False, is_flag=True, help="show plots during training")
+def main(**kwargs):
+    model = SparseYOLO(kwargs["model"])
+    model.val(**kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sparseml/pytorch/yolov8/val.py
+++ b/src/sparseml/pytorch/yolov8/val.py
@@ -50,7 +50,7 @@ from sparseml.pytorch.yolov8.trainers import SparseYOLO
 )
 @click.option(
     "--conf",
-    default=None,
+    default=0.001,
     type=float,
     help="object confidence threshold for detection (default 0.25 predict, 0.001 val)",
 )

--- a/src/sparseml/pytorch/yolov8/validators.py
+++ b/src/sparseml/pytorch/yolov8/validators.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import torch
+from tqdm import tqdm
+
+from ultralytics.nn.autobackend import AutoBackend
+from ultralytics.yolo.data.utils import check_dataset, check_dataset_yaml
+from ultralytics.yolo.engine.validator import BaseValidator
+from ultralytics.yolo.utils import TQDM_BAR_FORMAT, callbacks
+from ultralytics.yolo.utils.checks import check_imgsz
+from ultralytics.yolo.utils.ops import Profile
+from ultralytics.yolo.utils.torch_utils import de_parallel, select_device
+from ultralytics.yolo.v8.classify.val import ClassificationValidator
+from ultralytics.yolo.v8.detect.val import DetectionValidator
+from ultralytics.yolo.v8.segment.val import SegmentationValidator
+
+
+class SparseValidator(BaseValidator):
+    def __call__(self, trainer=None, model=None):
+        # the **only** difference in this call is that we pass fuse=False to AutoBackend
+        self.training = trainer is not None
+        if self.training:
+            self.device = trainer.device
+            self.data = trainer.data
+            model = trainer.ema.ema or trainer.model
+            self.args.half = self.device.type != "cpu"  # force FP16 val during training
+            model = model.half() if self.args.half else model.float()
+            self.model = model
+            self.loss = torch.zeros_like(trainer.loss_items, device=trainer.device)
+            self.args.plots = (
+                trainer.epoch == trainer.epochs - 1
+            )  # always plot final epoch
+            model.eval()
+        else:
+            callbacks.add_integration_callbacks(self)
+            self.run_callbacks("on_val_start")
+            assert model is not None, "Either trainer or model is needed for validation"
+            self.device = select_device(self.args.device, self.args.batch)
+            self.args.half &= self.device.type != "cpu"
+            model = AutoBackend(
+                model,
+                device=self.device,
+                dnn=self.args.dnn,
+                fp16=self.args.half,
+                fuse=False,
+            )
+            self.model = model
+            stride, pt, jit, engine = model.stride, model.pt, model.jit, model.engine
+            imgsz = check_imgsz(self.args.imgsz, stride=stride)
+            if engine:
+                self.args.batch = model.batch_size
+            else:
+                self.device = model.device
+                if not pt and not jit:
+                    self.args.batch = 1  # export.py models default to batch-size 1
+                    self.logger.info(
+                        "Forcing --batch-size 1 square inference (1,3,"
+                        f"{imgsz},{imgsz}) for non-PyTorch models"
+                    )
+
+            if isinstance(self.args.data, str) and self.args.data.endswith(".yaml"):
+                self.data = check_dataset_yaml(self.args.data)
+            else:
+                self.data = check_dataset(self.args.data)
+
+            if self.device.type == "cpu":
+                self.args.workers = (
+                    0  # faster CPU val as time dominated by inference, not dataloading
+                )
+            self.dataloader = self.dataloader or self.get_dataloader(
+                self.data.get("val") or self.data.set("test"), self.args.batch
+            )
+
+            model.eval()
+            model.warmup(
+                imgsz=(1 if pt else self.args.batch, 3, imgsz, imgsz)
+            )  # warmup
+
+        dt = Profile(), Profile(), Profile(), Profile()
+        n_batches = len(self.dataloader)
+        desc = self.get_desc()
+        # NOTE: keeping `not self.training` in tqdm will eliminate pbar after
+        # segmentation evaluation during training,
+        # which may affect classification task since this arg
+        # is in yolov5/classify/val.py.
+        # bar = tqdm(self.dataloader, desc, n_batches, not self.training,
+        # bar_format=TQDM_BAR_FORMAT)
+        bar = tqdm(self.dataloader, desc, n_batches, bar_format=TQDM_BAR_FORMAT)
+        self.init_metrics(de_parallel(model))
+        self.jdict = []  # empty before each val
+        for batch_i, batch in enumerate(bar):
+            self.run_callbacks("on_val_batch_start")
+            self.batch_i = batch_i
+            # pre-process
+            with dt[0]:
+                batch = self.preprocess(batch)
+
+            # inference
+            with dt[1]:
+                preds = model(batch["img"])
+
+            # loss
+            with dt[2]:
+                if self.training:
+                    self.loss += trainer.criterion(preds, batch)[1]
+
+            # pre-process predictions
+            with dt[3]:
+                preds = self.postprocess(preds)
+
+            self.update_metrics(preds, batch)
+            if self.args.plots and batch_i < 3:
+                self.plot_val_samples(batch, batch_i)
+                self.plot_predictions(batch, preds, batch_i)
+
+            self.run_callbacks("on_val_batch_end")
+        stats = self.get_stats()
+        self.check_stats(stats)
+        self.print_results()
+        self.speed = tuple(
+            x.t / len(self.dataloader.dataset) * 1e3 for x in dt
+        )  # speeds per image
+        self.run_callbacks("on_val_end")
+        if self.training:
+            model.float()
+            results = {
+                **stats,
+                **trainer.label_loss_items(
+                    self.loss.cpu() / len(self.dataloader), prefix="val"
+                ),
+            }
+            return {
+                k: round(float(v), 5) for k, v in results.items()
+            }  # return results as 5 decimal place floats
+        else:
+            self.logger.info(
+                (
+                    "Speed: %.1fms pre-process, %.1fms inference, %.1fms loss, %.1fms "
+                    "post-process per image"
+                ),
+                *self.speed,
+            )
+            if self.args.save_json and self.jdict:
+                with open(str(self.save_dir / "predictions.json"), "w") as f:
+                    self.logger.info(f"Saving {f.name}...")
+                    json.dump(self.jdict, f)  # flatten and save
+                stats = self.eval_json(stats)  # update stats
+            return stats
+
+
+class SparseDetectionValidator(SparseValidator, DetectionValidator):
+    ...
+
+
+class SparseClassificationValidator(SparseValidator, ClassificationValidator):
+    ...
+
+
+class SparseSegmentationValidator(SparseValidator, SegmentationValidator):
+    ...


### PR DESCRIPTION
Adds support for validating quantized models by adding sparseml.ultralytics.val entry point.

# Test Plan

## Validate yolo checkpoints

```sparseml.ultralytics.val --model https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt```

Outputs:
```bash
Found https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt locally at yolov8n.pt
Ultralytics YOLOv8.0.11 🚀 Python-3.9.5 torch-1.12.1+cu113 CUDA:0 (NVIDIA RTX A4000, 16117MiB)
val: Scanning /home/corey/datasets/coco128/labels/train2017.cache... 126 images, 2 backgrounds, 0 corrupt: 100%|██████████| 128/128 [00:00<?, ?it/s]
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100%|██████████| 8/8 [00:01<00:00,  4.59it/s]
                   all        128        929       0.64      0.537      0.605      0.446
```

## Validate during sparse/quantized training

```sparseml.ultralytics.train --model https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt --recipe yolov8-pq.yaml```

with recipe
```yaml
version: 1.1.0

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: 15

pruning_modifiers:
  - !GMPruningModifier
    init_sparsity: 0.05
    final_sparsity: 0.95
    start_epoch: 0.0
    end_epoch: 10.0
    update_frequency: 1.0
    params: ["model.0.conv.weight", "model.1.conv.weight"]

quantization_modifiers:
  - !QuantizationModifier
    start_epoch: 11.0
    freeze_bn_stats_epoch: 12.0
    disable_quantization_observer_epoch: 13.0
    ignore: ["Upsample", "Concat", "SiLU"]
```

See wandb log: https://wandb.ai/neuralmagic/sparseml/runs/j35r94jk/overview?workspace=user-neuralmagic

## Validate quantized model

Run training command above ^

Then run
```
sparseml.ultralytics.val --model runs/detect/train/weights/last.pt
```

And see:

```bash
...
Applying structure from sparseml checkpoint at epoch 10
Loaded previous weights from checkpoint
Ultralytics YOLOv8.0.11 🚀 Python-3.9.5 torch-1.12.1+cu113 CUDA:0 (NVIDIA RTX A4000, 16117MiB)
val: Scanning /home/corey/datasets/coco128/labels/train2017.cache... 126 images, 2 backgrounds, 0 corrupt: 100%|██████████| 128/128 [00:00<?, ?it/s]
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100%|██████████| 8/8 [00:01<00:00,  4.77it/s]
                   all        128        929       0.01     0.0474     0.0112    0.00588
```
