### PR TITLE
Integration Standardization Tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: build docs test
 
 BUILDDIR := $(PWD)
-CHECKDIRS := integrations src tests utils setup.py
-CHECKGLOBS := 'integrations/**/*.py' 'src/**/*.py' 'tests/**/*.py' 'utils/**/*.py' setup.py
+CHECKDIRS := integrations src tests utils status setup.py
+CHECKGLOBS := 'integrations/**/*.py' 'src/**/*.py' 'tests/**/*.py' 'utils/**/*.py' 'status/**/*.py' setup.py
 DOCDIR := docs
 MDCHECKGLOBS := 'docs/**/*.md' 'docs/**/*.rst' 'integrations/**/*.md'
 MDCHECKFILES := CODE_OF_CONDUCT.md CONTRIBUTING.md DEVELOPING.md README.md

--- a/src/sparseml/openpifpaf/openpifpaf.status.md
+++ b/src/sparseml/openpifpaf/openpifpaf.status.md
@@ -1,0 +1,58 @@
+# OpenPifPaf SparseML Integration Project Status Page
+OpenPifPaf instance segmentation training integration
+
+## Base Training
+
+
+| cli                | api                | dense_training     | gradient_accumulation | DP                 | DDP                |
+| ------------------ | ------------------ | ------------------ | --------------------- | ------------------ | ------------------ |
+| :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x:                   | :heavy_check_mark: | :heavy_check_mark: |
+
+## Sparsification
+Features related to sparsification integration. Notes: 
+* Recipe support should be optional
+* AMP must be disabled during QAT. (`scaler._enabled = False`)
+Distillation:
+* distillation_teacher kwarg must be passed to manager initialzation
+* Call loss = manager.loss_update(...) after loss is computed
+
+| recipe             | recipe_args | EMA | AMP | distillation |
+| ------------------ | ----------- | --- | --- | ------------ |
+| :white_check_mark: | :x:         | :x: | :x: | :x:          |
+
+## Datasets
+
+
+| use_standard_datasets | train_val_test_datasets | auto_download_datasets |
+| --------------------- | ----------------------- | ---------------------- |
+| :heavy_check_mark:    | :heavy_check_mark:      | :heavy_check_mark:     |
+
+## Checkpoints
+Features related to checkpoints. Notes: 
+* best_* checkpoints can only be saved after the entire sparsification step completes
+* update_architecture_from_recipe requires a call to apply_structure() on a torch model before loading sparsified checkpoint
+* staged_recipes requires manager.compose_staged(...) before checkpoint save
+
+| original_integration_checkpoints | sparsezoo_checkpoints | best_checkpoint    | best_pruned_checkpoint | best_pruned_quantized_checkpoint | recipe_saved_to_checkpoint | update_architecture_from_recipe | staged_recipes     |
+| -------------------------------- | --------------------- | ------------------ | ---------------------- | -------------------------------- | -------------------------- | ------------------------------- | ------------------ |
+| :white_check_mark:               | :white_check_mark:    | :white_check_mark: | :x:                    | :x:                              | :x:                        | :white_check_mark:              | :white_check_mark: |
+
+## Logging
+Logging units for x axis in logging should be number of optimizer steps. Notably: `num_optimizer_steps = num_batches / gradient_accum_steps`. So when gradient_accumuluation is not used, the x axis will be number of batches trained on.
+
+| stdout             | weights_and_biases | tensorboard |
+| ------------------ | ------------------ | ----------- |
+| :heavy_check_mark: | :x:                | :x:         |
+
+## Export
+PyTorch export features should use `ModuleExporter` and only require specifying checkpoint path and necessary configuration files
+
+| cli                | api                | one_shot           | onnx               | torch_script | static_batch_size | dynamic_batch_size | static_input_shape | dynamic_input_shape | save_to_simple_deployment_directory | save_to_sparsezoo_directory |
+| ------------------ | ------------------ | ------------------ | ------------------ | ------------ | ----------------- | ------------------ | ------------------ | ------------------- | ----------------------------------- | --------------------------- |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:          | :x:               | :white_check_mark: | :white_check_mark: | :x:                 | :white_check_mark:                  | :x:                         |
+
+### Key
+ * :white_check_mark: - implemented by neuralmagic integration
+ * :heavy_check_mark: - implemented by underlying integration
+ * :x: - not implemented yet
+ * :question: - not sure, not tested, or to be investigated

--- a/src/sparseml/openpifpaf/openpifpaf.status.yaml
+++ b/src/sparseml/openpifpaf/openpifpaf.status.yaml
@@ -6,53 +6,53 @@
 # q: question - not sure, not tested, or to be investigated
 ###########################################################
 
-project_name: project name
-project_description: description
+project_name: OpenPifPaf
+project_description: OpenPifPaf instance segmentation training integration
 
 base_training:
-  cli: n
-  api: n
-  dense_training: n
+  cli: e
+  api: e
+  dense_training: e
   gradient_accumulation: n
-  DP: n
-  DDP: n
+  DP: e
+  DDP: e
 
 sparsification:
-  recipe: n
+  recipe: y
   recipe_args: n
   EMA: n
   AMP: n
   distillation: n
 
 datasets:
-  use_standard_datasets: n
-  train_val_test_datasets: n
-  auto_download_datasets: n
+  use_standard_datasets: e
+  train_val_test_datasets: e
+  auto_download_datasets: e
 
 checkpoints:
-  original_integration_checkpoints: n
-  sparsezoo_checkpoints: n
-  best_checkpoint: n
+  original_integration_checkpoints: y
+  sparsezoo_checkpoints: y
+  best_checkpoint: y
   best_pruned_checkpoint: n
   best_pruned_quantized_checkpoint: n
   recipe_saved_to_checkpoint: n
-  update_architecture_from_recipe: n
-  staged_recipes: n
+  update_architecture_from_recipe: y
+  staged_recipes: y
 
 logging:
-  stdout: n
+  stdout: e
   weights_and_biases: n
   tensorboard: n
 
 export:
-  cli: n
-  api: n
-  one_shot: n
-  onnx: n
+  cli: y
+  api: y
+  one_shot: y
+  onnx: y
   torch_script: n
   static_batch_size: n
-  dynamic_batch_size: n
-  static_input_shape: n
+  dynamic_batch_size: y
+  static_input_shape: y
   dynamic_input_shape: n
-  save_to_simple_deployment_directory: n
+  save_to_simple_deployment_directory: y
   save_to_sparsezoo_directory: n

--- a/src/sparseml/pytorch/image_classification/nm_image_classification.status.md
+++ b/src/sparseml/pytorch/image_classification/nm_image_classification.status.md
@@ -1,0 +1,58 @@
+# NM IC SparseML Integration Project Status Page
+Deprecated (in favor of sparseml/pytorch/torchvision) IC training integration
+
+## Base Training
+
+
+| cli                | api                | dense_training     | gradient_accumulation | DP                 | DDP                |
+| ------------------ | ------------------ | ------------------ | --------------------- | ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                   | :white_check_mark: | :white_check_mark: |
+
+## Sparsification
+Features related to sparsification integration. Notes: 
+* Recipe support should be optional
+* AMP must be disabled during QAT. (`scaler._enabled = False`)
+Distillation:
+* distillation_teacher kwarg must be passed to manager initialzation
+* Call loss = manager.loss_update(...) after loss is computed
+
+| recipe             | recipe_args        | EMA | AMP                | distillation |
+| ------------------ | ------------------ | --- | ------------------ | ------------ |
+| :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :x:          |
+
+## Datasets
+
+
+| use_standard_datasets | train_val_test_datasets | auto_download_datasets |
+| --------------------- | ----------------------- | ---------------------- |
+| :white_check_mark:    | :white_check_mark:      | :white_check_mark:     |
+
+## Checkpoints
+Features related to checkpoints. Notes: 
+* best_* checkpoints can only be saved after the entire sparsification step completes
+* update_architecture_from_recipe requires a call to apply_structure() on a torch model before loading sparsified checkpoint
+* staged_recipes requires manager.compose_staged(...) before checkpoint save
+
+| original_integration_checkpoints | sparsezoo_checkpoints | best_checkpoint    | best_pruned_checkpoint | best_pruned_quantized_checkpoint | recipe_saved_to_checkpoint | update_architecture_from_recipe | staged_recipes     |
+| -------------------------------- | --------------------- | ------------------ | ---------------------- | -------------------------------- | -------------------------- | ------------------------------- | ------------------ |
+| :white_check_mark:               | :white_check_mark:    | :white_check_mark: | :x:                    | :x:                              | :x:                        | :white_check_mark:              | :white_check_mark: |
+
+## Logging
+Logging units for x axis in logging should be number of optimizer steps. Notably: `num_optimizer_steps = num_batches / gradient_accum_steps`. So when gradient_accumuluation is not used, the x axis will be number of batches trained on.
+
+| stdout             | weights_and_biases | tensorboard        |
+| ------------------ | ------------------ | ------------------ |
+| :white_check_mark: | :x:                | :white_check_mark: |
+
+## Export
+PyTorch export features should use `ModuleExporter` and only require specifying checkpoint path and necessary configuration files
+
+| cli                | api                | one_shot           | onnx               | torch_script | static_batch_size | dynamic_batch_size | static_input_shape | dynamic_input_shape | save_to_simple_deployment_directory | save_to_sparsezoo_directory |
+| ------------------ | ------------------ | ------------------ | ------------------ | ------------ | ----------------- | ------------------ | ------------------ | ------------------- | ----------------------------------- | --------------------------- |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:          | :x:               | :white_check_mark: | :white_check_mark: | :x:                 | :white_check_mark:                  | :x:                         |
+
+### Key
+ * :white_check_mark: - implemented by neuralmagic integration
+ * :heavy_check_mark: - implemented by underlying integration
+ * :x: - not implemented yet
+ * :question: - not sure, not tested, or to be investigated

--- a/src/sparseml/pytorch/image_classification/nm_image_classification.status.yaml
+++ b/src/sparseml/pytorch/image_classification/nm_image_classification.status.yaml
@@ -6,53 +6,53 @@
 # q: question - not sure, not tested, or to be investigated
 ###########################################################
 
-project_name: project name
-project_description: description
+project_name: NM IC
+project_description: Deprecated (in favor of sparseml/pytorch/torchvision) IC training integration
 
 base_training:
-  cli: n
-  api: n
-  dense_training: n
+  cli: y
+  api: y
+  dense_training: y
   gradient_accumulation: n
-  DP: n
-  DDP: n
+  DP: y
+  DDP: y
 
 sparsification:
-  recipe: n
-  recipe_args: n
+  recipe: y
+  recipe_args: y
   EMA: n
-  AMP: n
+  AMP: y
   distillation: n
 
 datasets:
-  use_standard_datasets: n
-  train_val_test_datasets: n
-  auto_download_datasets: n
+  use_standard_datasets: y
+  train_val_test_datasets: y
+  auto_download_datasets: y
 
 checkpoints:
-  original_integration_checkpoints: n
-  sparsezoo_checkpoints: n
-  best_checkpoint: n
+  original_integration_checkpoints: y
+  sparsezoo_checkpoints: y
+  best_checkpoint: y
   best_pruned_checkpoint: n
   best_pruned_quantized_checkpoint: n
   recipe_saved_to_checkpoint: n
-  update_architecture_from_recipe: n
-  staged_recipes: n
+  update_architecture_from_recipe: y
+  staged_recipes: y
 
 logging:
-  stdout: n
+  stdout: y
   weights_and_biases: n
-  tensorboard: n
+  tensorboard: y
 
 export:
-  cli: n
-  api: n
-  one_shot: n
-  onnx: n
+  cli: y
+  api: y
+  one_shot: y
+  onnx: y
   torch_script: n
   static_batch_size: n
-  dynamic_batch_size: n
-  static_input_shape: n
+  dynamic_batch_size: y
+  static_input_shape: y
   dynamic_input_shape: n
-  save_to_simple_deployment_directory: n
+  save_to_simple_deployment_directory: y
   save_to_sparsezoo_directory: n

--- a/src/sparseml/pytorch/torchvision/torchvision.status.md
+++ b/src/sparseml/pytorch/torchvision/torchvision.status.md
@@ -1,0 +1,58 @@
+# Torchvision IC SparseML Integration Project Status Page
+Image classification torchvision native training integration
+
+## Base Training
+
+
+| cli                | api                | dense_training     | gradient_accumulation | DP                 | DDP                |
+| ------------------ | ------------------ | ------------------ | --------------------- | ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:    | :white_check_mark: | :white_check_mark: |
+
+## Sparsification
+Features related to sparsification integration. Notes: 
+* Recipe support should be optional
+* AMP must be disabled during QAT. (`scaler._enabled = False`)
+Distillation:
+* distillation_teacher kwarg must be passed to manager initialzation
+* Call loss = manager.loss_update(...) after loss is computed
+
+| recipe             | recipe_args        | EMA                | AMP                | distillation       |
+| ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+## Datasets
+
+
+| use_standard_datasets | train_val_test_datasets | auto_download_datasets |
+| --------------------- | ----------------------- | ---------------------- |
+| :white_check_mark:    | :white_check_mark:      | :x:                    |
+
+## Checkpoints
+Features related to checkpoints. Notes: 
+* best_* checkpoints can only be saved after the entire sparsification step completes
+* update_architecture_from_recipe requires a call to apply_structure() on a torch model before loading sparsified checkpoint
+* staged_recipes requires manager.compose_staged(...) before checkpoint save
+
+| original_integration_checkpoints | sparsezoo_checkpoints | best_checkpoint    | best_pruned_checkpoint | best_pruned_quantized_checkpoint | recipe_saved_to_checkpoint | update_architecture_from_recipe | staged_recipes     |
+| -------------------------------- | --------------------- | ------------------ | ---------------------- | -------------------------------- | -------------------------- | ------------------------------- | ------------------ |
+| :white_check_mark:               | :white_check_mark:    | :white_check_mark: | :x:                    | :x:                              | :x:                        | :white_check_mark:              | :white_check_mark: |
+
+## Logging
+Logging units for x axis in logging should be number of optimizer steps. Notably: `num_optimizer_steps = num_batches / gradient_accum_steps`. So when gradient_accumuluation is not used, the x axis will be number of batches trained on.
+
+| stdout             | weights_and_biases | tensorboard        |
+| ------------------ | ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+## Export
+PyTorch export features should use `ModuleExporter` and only require specifying checkpoint path and necessary configuration files
+
+| cli                | api                | one_shot           | onnx               | torch_script | static_batch_size | dynamic_batch_size | static_input_shape | dynamic_input_shape | save_to_simple_deployment_directory | save_to_sparsezoo_directory |
+| ------------------ | ------------------ | ------------------ | ------------------ | ------------ | ----------------- | ------------------ | ------------------ | ------------------- | ----------------------------------- | --------------------------- |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:          | :x:               | :white_check_mark: | :white_check_mark: | :x:                 | :white_check_mark:                  | :x:                         |
+
+### Key
+ * :white_check_mark: - implemented by neuralmagic integration
+ * :heavy_check_mark: - implemented by underlying integration
+ * :x: - not implemented yet
+ * :question: - not sure, not tested, or to be investigated

--- a/src/sparseml/pytorch/torchvision/torchvision.status.yaml
+++ b/src/sparseml/pytorch/torchvision/torchvision.status.yaml
@@ -1,0 +1,58 @@
+###########################################################
+# Status Keys:
+# y: yes - implemented by NM
+# e: external - implemented by external integration
+# n: no - not implemented yet
+# q: question - not sure, not tested, or to be investigated
+###########################################################
+
+project_name: Torchvision IC
+project_description: Image classification torchvision native training integration
+
+base_training:
+  cli: y
+  api: y
+  dense_training: y
+  gradient_accumulation: y
+  DP: y
+  DDP: y
+
+sparsification:
+  recipe: y
+  recipe_args: y
+  EMA: y
+  AMP: y
+  distillation: y
+
+datasets:
+  use_standard_datasets: y
+  train_val_test_datasets: y
+  auto_download_datasets: n
+
+checkpoints:
+  original_integration_checkpoints: y
+  sparsezoo_checkpoints: y
+  best_checkpoint: y
+  best_pruned_checkpoint: n
+  best_pruned_quantized_checkpoint: n
+  recipe_saved_to_checkpoint: n
+  update_architecture_from_recipe: y
+  staged_recipes: y
+
+logging:
+  stdout: y
+  weights_and_biases: y
+  tensorboard: y
+
+export:
+  cli: y
+  api: y
+  one_shot: y
+  onnx: y
+  torch_script: n
+  static_batch_size: n
+  dynamic_batch_size: y
+  static_input_shape: y
+  dynamic_input_shape: n
+  save_to_simple_deployment_directory: y
+  save_to_sparsezoo_directory: n

--- a/src/sparseml/transformers/transformers.status.md
+++ b/src/sparseml/transformers/transformers.status.md
@@ -1,0 +1,58 @@
+# Transformers SparseML Integration Project Status Page
+Transformers NLP integration for tasks such as QA, text classification, and token classification
+
+## Base Training
+
+
+| cli                | api                | dense_training     | gradient_accumulation | DP                 | DDP                |
+| ------------------ | ------------------ | ------------------ | --------------------- | ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_check_mark:    | :white_check_mark: | :white_check_mark: |
+
+## Sparsification
+Features related to sparsification integration. Notes: 
+* Recipe support should be optional
+* AMP must be disabled during QAT. (`scaler._enabled = False`)
+Distillation:
+* distillation_teacher kwarg must be passed to manager initialzation
+* Call loss = manager.loss_update(...) after loss is computed
+
+| recipe             | recipe_args        | EMA | AMP                | distillation       |
+| ------------------ | ------------------ | --- | ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark: |
+
+## Datasets
+
+
+| use_standard_datasets | train_val_test_datasets | auto_download_datasets |
+| --------------------- | ----------------------- | ---------------------- |
+| :white_check_mark:    | :white_check_mark:      | :heavy_check_mark:     |
+
+## Checkpoints
+Features related to checkpoints. Notes: 
+* best_* checkpoints can only be saved after the entire sparsification step completes
+* update_architecture_from_recipe requires a call to apply_structure() on a torch model before loading sparsified checkpoint
+* staged_recipes requires manager.compose_staged(...) before checkpoint save
+
+| original_integration_checkpoints | sparsezoo_checkpoints | best_checkpoint    | best_pruned_checkpoint | best_pruned_quantized_checkpoint | recipe_saved_to_checkpoint | update_architecture_from_recipe | staged_recipes     |
+| -------------------------------- | --------------------- | ------------------ | ---------------------- | -------------------------------- | -------------------------- | ------------------------------- | ------------------ |
+| :white_check_mark:               | :white_check_mark:    | :white_check_mark: | :x:                    | :x:                              | :x:                        | :white_check_mark:              | :white_check_mark: |
+
+## Logging
+Logging units for x axis in logging should be number of optimizer steps. Notably: `num_optimizer_steps = num_batches / gradient_accum_steps`. So when gradient_accumuluation is not used, the x axis will be number of batches trained on.
+
+| stdout             | weights_and_biases | tensorboard        |
+| ------------------ | ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+## Export
+PyTorch export features should use `ModuleExporter` and only require specifying checkpoint path and necessary configuration files
+
+| cli                | api                | one_shot           | onnx               | torch_script | static_batch_size | dynamic_batch_size | static_input_shape | dynamic_input_shape | save_to_simple_deployment_directory | save_to_sparsezoo_directory |
+| ------------------ | ------------------ | ------------------ | ------------------ | ------------ | ----------------- | ------------------ | ------------------ | ------------------- | ----------------------------------- | --------------------------- |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:          | :x:               | :white_check_mark: | :white_check_mark: | :x:                 | :white_check_mark:                  | :x:                         |
+
+### Key
+ * :white_check_mark: - implemented by neuralmagic integration
+ * :heavy_check_mark: - implemented by underlying integration
+ * :x: - not implemented yet
+ * :question: - not sure, not tested, or to be investigated

--- a/src/sparseml/transformers/transformers.status.yaml
+++ b/src/sparseml/transformers/transformers.status.yaml
@@ -1,0 +1,58 @@
+###########################################################
+# Status Keys:
+# y: yes - implemented by NM
+# e: external - implemented by external integration
+# n: no - not implemented yet
+# q: question - not sure, not tested, or to be investigated
+###########################################################
+
+project_name: Transformers
+project_description: Transformers NLP integration for tasks such as QA, text classification, and token classification
+
+base_training:
+  cli: y
+  api: y
+  dense_training: y
+  gradient_accumulation: e
+  DP: y
+  DDP: y
+
+sparsification:
+  recipe: y
+  recipe_args: y
+  EMA: n
+  AMP: y
+  distillation: y
+
+datasets:
+  use_standard_datasets: y
+  train_val_test_datasets: y
+  auto_download_datasets: e
+
+checkpoints:
+  original_integration_checkpoints: y
+  sparsezoo_checkpoints: y
+  best_checkpoint: y
+  best_pruned_checkpoint: n
+  best_pruned_quantized_checkpoint: n
+  recipe_saved_to_checkpoint: n
+  update_architecture_from_recipe: y
+  staged_recipes: y
+
+logging:
+  stdout: y
+  weights_and_biases: y
+  tensorboard: y
+
+export:
+  cli: y
+  api: y
+  one_shot: y
+  onnx: y
+  torch_script: n
+  static_batch_size: n
+  dynamic_batch_size: y
+  static_input_shape: y
+  dynamic_input_shape: n
+  save_to_simple_deployment_directory: y
+  save_to_sparsezoo_directory: n

--- a/src/sparseml/yolov5/yolov5.status.md
+++ b/src/sparseml/yolov5/yolov5.status.md
@@ -1,0 +1,58 @@
+# YOLOv5 SparseML Integration Project Status Page
+YOLOv5 integration for object detection
+
+## Base Training
+
+
+| cli                | api                | dense_training     | gradient_accumulation | DP                 | DDP                |
+| ------------------ | ------------------ | ------------------ | --------------------- | ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:    | :white_check_mark: | :white_check_mark: |
+
+## Sparsification
+Features related to sparsification integration. Notes: 
+* Recipe support should be optional
+* AMP must be disabled during QAT. (`scaler._enabled = False`)
+Distillation:
+* distillation_teacher kwarg must be passed to manager initialzation
+* Call loss = manager.loss_update(...) after loss is computed
+
+| recipe             | recipe_args        | EMA                | AMP                | distillation       |
+| ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+## Datasets
+
+
+| use_standard_datasets | train_val_test_datasets | auto_download_datasets |
+| --------------------- | ----------------------- | ---------------------- |
+| :white_check_mark:    | :white_check_mark:      | :white_check_mark:     |
+
+## Checkpoints
+Features related to checkpoints. Notes: 
+* best_* checkpoints can only be saved after the entire sparsification step completes
+* update_architecture_from_recipe requires a call to apply_structure() on a torch model before loading sparsified checkpoint
+* staged_recipes requires manager.compose_staged(...) before checkpoint save
+
+| original_integration_checkpoints | sparsezoo_checkpoints | best_checkpoint    | best_pruned_checkpoint | best_pruned_quantized_checkpoint | recipe_saved_to_checkpoint | update_architecture_from_recipe | staged_recipes     |
+| -------------------------------- | --------------------- | ------------------ | ---------------------- | -------------------------------- | -------------------------- | ------------------------------- | ------------------ |
+| :white_check_mark:               | :white_check_mark:    | :white_check_mark: | :question:             | :question:                       | :question:                 | :white_check_mark:              | :white_check_mark: |
+
+## Logging
+Logging units for x axis in logging should be number of optimizer steps. Notably: `num_optimizer_steps = num_batches / gradient_accum_steps`. So when gradient_accumuluation is not used, the x axis will be number of batches trained on.
+
+| stdout             | weights_and_biases | tensorboard        |
+| ------------------ | ------------------ | ------------------ |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+## Export
+PyTorch export features should use `ModuleExporter` and only require specifying checkpoint path and necessary configuration files
+
+| cli                | api                | one_shot           | onnx               | torch_script       | static_batch_size  | dynamic_batch_size | static_input_shape | dynamic_input_shape | save_to_simple_deployment_directory | save_to_sparsezoo_directory |
+| ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------- | ----------------------------------- | --------------------------- |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :x:                 | :white_check_mark:                  | :x:                         |
+
+### Key
+ * :white_check_mark: - implemented by neuralmagic integration
+ * :heavy_check_mark: - implemented by underlying integration
+ * :x: - not implemented yet
+ * :question: - not sure, not tested, or to be investigated

--- a/src/sparseml/yolov5/yolov5.status.yaml
+++ b/src/sparseml/yolov5/yolov5.status.yaml
@@ -1,0 +1,58 @@
+###########################################################
+# Status Keys:
+# y: yes - implemented by NM
+# e: external - implemented by external integration
+# n: no - not implemented yet
+# q: question - not sure, not tested, or to be investigated
+###########################################################
+
+project_name: YOLOv5
+project_description: YOLOv5 integration for object detection
+
+base_training:
+  cli: y
+  api: y
+  dense_training: y
+  gradient_accumulation: y
+  DP: y
+  DDP: y
+
+sparsification:
+  recipe: y
+  recipe_args: y
+  EMA: y
+  AMP: y
+  distillation: y
+
+datasets:
+  use_standard_datasets: y
+  train_val_test_datasets: y
+  auto_download_datasets: y
+
+checkpoints:
+  original_integration_checkpoints: y
+  sparsezoo_checkpoints: y
+  best_checkpoint: y
+  best_pruned_checkpoint: q
+  best_pruned_quantized_checkpoint: q
+  recipe_saved_to_checkpoint: q
+  update_architecture_from_recipe: y
+  staged_recipes: y
+
+logging:
+  stdout: y
+  weights_and_biases: y
+  tensorboard: y
+
+export:
+  cli: y
+  api: y
+  one_shot: y
+  onnx: y
+  torch_script: e
+  static_batch_size: e
+  dynamic_batch_size: y
+  static_input_shape: y
+  dynamic_input_shape: n
+  save_to_simple_deployment_directory: y
+  save_to_sparsezoo_directory: n

--- a/status/README.md
+++ b/status/README.md
@@ -1,0 +1,31 @@
+# SparseML Integration Status Tooling
+This directory contains a status page across all SparseML integration statuses
+as well as tooling to generate status pages
+
+## Status Pages
+The aggregated status page is found in this directory in `STATUS.MD`.
+Individual integration status pages are found in specific integration directories
+with the extension `.status.md`.
+
+## Adding a New Status Page
+To create a status page for a new integration:
+* Copy `status_template.status.yaml` into a file named `{integration_name}.status.yaml` in the same directory as the integration in `src/`
+* All fields will default to `n`. Follow the key to update features to the proper status 
+* Run `make status` to update and create the auto generated markdown file
+* Check in to git and open a PR
+
+## Updating an Existing Status Page
+To update an existing status page due to a feature change:
+* Locate the integration's `{integration}.status.yaml` file in the integration directory in SparseML source
+* Update the line item(s) of the changed features according to the status key
+* run `make status` to update the auto generated markdown files
+* Check in to git and open a PR
+
+## Add a new Feature to a Table or new Table
+To add a new feature to a table or a new table:
+* Open `status/integration_status.py` and either create a new `FeatureStatus` Field in an existing table or create a table
+* Follow existing conventions
+* Update all existing `.status.yaml` files nested under `src/` to include the new feature(s)
+* Run `make status` (if any errors occur, make sure the old configs were properly updated)
+* Check `git diff` to make sure the new feature(s) had the intended effect on the auto generated markdown files and auto generated template
+* Check in to git and open a PR

--- a/status/STATUS.MD
+++ b/status/STATUS.MD
@@ -1,0 +1,88 @@
+#  SparseML Integration Project Status Page
+Feature status tables related to required and target features for SparseML sparsification aware training integrations
+
+## Base Training
+
+
+|                           | NM IC              | OpenPifPaf         | YOLOv5             | Transformers       | Torchvision IC     |
+| ------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| **cli**                   | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **api**                   | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **dense_training**        | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **gradient_accumulation** | :x:                | :x:                | :white_check_mark: | :heavy_check_mark: | :white_check_mark: |
+| **DP**                    | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **DDP**                   | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+## Sparsification
+Features related to sparsification integration. Notes: 
+* Recipe support should be optional
+* AMP must be disabled during QAT. (`scaler._enabled = False`)
+Distillation:
+* distillation_teacher kwarg must be passed to manager initialzation
+* Call loss = manager.loss_update(...) after loss is computed
+
+|                  | NM IC              | OpenPifPaf         | YOLOv5             | Transformers       | Torchvision IC     |
+| ---------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| **recipe**       | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **recipe_args**  | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **EMA**          | :x:                | :x:                | :white_check_mark: | :x:                | :white_check_mark: |
+| **AMP**          | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **distillation** | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+## Datasets
+
+
+|                             | NM IC              | OpenPifPaf         | YOLOv5             | Transformers       | Torchvision IC     |
+| --------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| **use_standard_datasets**   | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **train_val_test_datasets** | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **auto_download_datasets**  | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :heavy_check_mark: | :x:                |
+
+## Checkpoints
+Features related to checkpoints. Notes: 
+* best_* checkpoints can only be saved after the entire sparsification step completes
+* update_architecture_from_recipe requires a call to apply_structure() on a torch model before loading sparsified checkpoint
+* staged_recipes requires manager.compose_staged(...) before checkpoint save
+
+|                                      | NM IC              | OpenPifPaf         | YOLOv5             | Transformers       | Torchvision IC     |
+| ------------------------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| **original_integration_checkpoints** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **sparsezoo_checkpoints**            | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **best_checkpoint**                  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **best_pruned_checkpoint**           | :x:                | :x:                | :question:         | :x:                | :x:                |
+| **best_pruned_quantized_checkpoint** | :x:                | :x:                | :question:         | :x:                | :x:                |
+| **recipe_saved_to_checkpoint**       | :x:                | :x:                | :question:         | :x:                | :x:                |
+| **update_architecture_from_recipe**  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **staged_recipes**                   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+## Logging
+Logging units for x axis in logging should be number of optimizer steps. Notably: `num_optimizer_steps = num_batches / gradient_accum_steps`. So when gradient_accumuluation is not used, the x axis will be number of batches trained on.
+
+|                        | NM IC              | OpenPifPaf         | YOLOv5             | Transformers       | Torchvision IC     |
+| ---------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| **stdout**             | :white_check_mark: | :heavy_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **weights_and_biases** | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **tensorboard**        | :white_check_mark: | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+## Export
+PyTorch export features should use `ModuleExporter` and only require specifying checkpoint path and necessary configuration files
+
+|                                         | NM IC              | OpenPifPaf         | YOLOv5             | Transformers       | Torchvision IC     |
+| --------------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| **cli**                                 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **api**                                 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **one_shot**                            | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **onnx**                                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **torch_script**                        | :x:                | :x:                | :heavy_check_mark: | :x:                | :x:                |
+| **static_batch_size**                   | :x:                | :x:                | :heavy_check_mark: | :x:                | :x:                |
+| **dynamic_batch_size**                  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **static_input_shape**                  | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **dynamic_input_shape**                 | :x:                | :x:                | :x:                | :x:                | :x:                |
+| **save_to_simple_deployment_directory** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| **save_to_sparsezoo_directory**         | :x:                | :x:                | :x:                | :x:                | :x:                |
+
+### Key
+ * :white_check_mark: - implemented by neuralmagic integration
+ * :heavy_check_mark: - implemented by underlying integration
+ * :x: - not implemented yet
+ * :question: - not sure, not tested, or to be investigated

--- a/status/integration_status.py
+++ b/status/integration_status.py
@@ -130,6 +130,7 @@ class ExportStatusTable(FeatureStatusTable):
     cli: FeatureStatus = Field()
     api: FeatureStatus = Field()
     one_shot: FeatureStatus = Field()
+    onnx: FeatureStatus = Field()
     torch_script: FeatureStatus = Field()
     static_batch_size: FeatureStatus = Field()
     dynamic_batch_size: FeatureStatus = Field()

--- a/status/integration_status.py
+++ b/status/integration_status.py
@@ -1,0 +1,4 @@
+"""
+Definition of integration status table and CLI util to udpate status tables and 
+templates from yaml configs
+"""

--- a/status/integration_status.py
+++ b/status/integration_status.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Definition of integration status table and CLI util to udpate status tables and 
+Definition of integration status table and CLI util to udpate status tables and
 templates from yaml configs
 """
 
@@ -103,7 +103,8 @@ class CheckpointsStatusTable(FeatureStatusTable):
             "step completes\n"
             "* update_architecture_from_recipe requires a call to apply_structure() "
             "on a torch model before loading sparsified checkpoint\n"
-            "* staged_recipes requires manager.compose_staged(...) before checkpoint save"
+            "* staged_recipes requires manager.compose_staged(...) "
+            "before checkpoint save"
         )
 
 

--- a/status/integration_status.py
+++ b/status/integration_status.py
@@ -1,4 +1,185 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Definition of integration status table and CLI util to udpate status tables and 
 templates from yaml configs
 """
+
+import os
+from pathlib import Path
+
+from pydantic import Field
+
+from sparsezoo.utils.standardization import (
+    FeatureStatus,
+    FeatureStatusPage,
+    FeatureStatusTable,
+    write_status_pages,
+)
+
+
+class BaseTrainingStatusTable(FeatureStatusTable):
+
+    cli: FeatureStatus = Field()
+    api: FeatureStatus = Field()
+    dense_training: FeatureStatus = Field()
+    gradient_accumulation: FeatureStatus = Field()
+    DP: FeatureStatus = Field()
+    DDP: FeatureStatus = Field()
+
+    @property
+    def name(self) -> str:
+        return "Base Training"
+
+
+class SparsificationStatusTable(FeatureStatusTable):
+
+    recipe: FeatureStatus = Field()
+    recipe_args: FeatureStatus = Field()
+    EMA: FeatureStatus = Field()
+    AMP: FeatureStatus = Field()
+    distillation: FeatureStatus = Field()
+
+    @property
+    def name(self) -> str:
+        return "Sparsification"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Features related to sparsification integration. "
+            "Notes: \n"
+            "* Recipe support should be optional\n"
+            "* AMP must be disabled during QAT. (`scaler._enabled = False`)\n"
+            "Distillation:\n"
+            "* distillation_teacher kwarg must be passed to manager initialzation\n"
+            "* Call loss = manager.loss_update(...) after loss is computed"
+        )
+
+
+class DatasetsStatusTable(FeatureStatusTable):
+
+    use_standard_datasets: FeatureStatus = Field()
+    train_val_test_datasets: FeatureStatus = Field()
+    auto_download_datasets: FeatureStatus = Field()
+
+    @property
+    def name(self) -> str:
+        return "Datasets"
+
+
+class CheckpointsStatusTable(FeatureStatusTable):
+    original_integration_checkpoints: FeatureStatus = Field()
+    sparsezoo_checkpoints: FeatureStatus = Field()
+    best_dense_checkpoint: FeatureStatus = Field()
+    best_pruned_checkpoint: FeatureStatus = Field()
+    best_pruned_quantized_checkpoint: FeatureStatus = Field()
+    recipe_saved_to_checkpoint: FeatureStatus = Field()
+    update_architecture_from_recipe: FeatureStatus = Field()
+    staged_recipes: FeatureStatus = Field()
+
+    @property
+    def name(self) -> str:
+        return "Checkpoints"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Features related to checkpoints. "
+            "Notes: \n"
+            "* best_* checkpoints can only be saved after the entire sparsification "
+            "step completes\n"
+            "* update_architecture_from_recipe requires a call to apply_structure() "
+            "on a torch model before loading sparsified checkpoint\n"
+            "* staged_recipes requires manager.compose_staged(...) before checkpoint save"
+        )
+
+
+class LoggingStatusTable(FeatureStatusTable):
+    stdout: FeatureStatus = Field()
+    weights_and_biases: FeatureStatus = Field()
+    tensorboard: FeatureStatus = Field()
+
+    @property
+    def name(self) -> str:
+        return "Logging"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Logging units for x axis in logging should be number of optimizer steps. "
+            "Notably: `num_optimizer_steps = num_batches / gradient_accum_steps`. "
+            "So when gradient_accumuluation is not used, the x axis will be number "
+            "of batches trained on."
+        )
+
+
+class ExportStatusTable(FeatureStatusTable):
+    cli: FeatureStatus = Field()
+    api: FeatureStatus = Field()
+    one_shot: FeatureStatus = Field()
+    torch_script: FeatureStatus = Field()
+    static_batch_size: FeatureStatus = Field()
+    dynamic_batch_size: FeatureStatus = Field()
+    static_input_shape: FeatureStatus = Field()
+    dynamic_input_shape: FeatureStatus = Field()
+    save_to_simple_deployment_directory: FeatureStatus = Field()
+    save_to_sparsezoo_directory: FeatureStatus = Field()
+
+    @property
+    def name(self) -> str:
+        return "Export"
+
+    @property
+    def description(self) -> str:
+        return (
+            "PyTorch export features should use `ModuleExporter` and only require "
+            "specifying checkpoint path and necessary configuration files"
+        )
+
+
+class SparseMLIntegrationStatusPage(FeatureStatusPage):
+    base_training: BaseTrainingStatusTable = Field()
+    sparsification: SparsificationStatusTable = Field()
+    datasets: DatasetsStatusTable = Field()
+    checkpoints: CheckpointsStatusTable = Field()
+    logging: LoggingStatusTable = Field()
+    export: ExportStatusTable = Field()
+
+    @property
+    def name(self) -> str:
+        return "SparseML Integration Project"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Feature status tables related to required and target features "
+            "for SparseML sparsification aware training integrations"
+        )
+
+
+if __name__ == "__main__":
+    status_dir = Path(__file__).parent.resolve()
+    src_dir = os.path.join(Path(__file__).parent.parent.resolve(), "src")
+
+    main_status_page_path = os.path.join(status_dir, "STATUS.MD")
+    yaml_template_path = os.path.join(status_dir, "status_template.status.yaml")
+
+    write_status_pages(
+        status_page_class=SparseMLIntegrationStatusPage,
+        root_directory=src_dir,
+        main_status_page_path=main_status_page_path,
+        yaml_template_path=yaml_template_path,
+    )

--- a/status/status_template.status.yaml
+++ b/status/status_template.status.yaml
@@ -1,0 +1,57 @@
+###########################################################
+# Status Keys:
+# y: yes - implemented by NM
+# e: external - implemented by external integration
+# n: no - not implemented yet
+# q: question - not sure, not tested, or to be investigated
+###########################################################
+
+project_name: project name
+project_description: description
+
+base_training:
+  cli: n
+  api: n
+  dense_training: n
+  gradient_accumulation: n
+  DP: n
+  DDP: n
+
+sparsification:
+  recipe: n
+  recipe_args: n
+  EMA: n
+  AMP: n
+  distillation: n
+
+datasets:
+  use_standard_datasets: n
+  train_val_test_datasets: n
+  auto_download_datasets: n
+
+checkpoints:
+  original_integration_checkpoints: n
+  sparsezoo_checkpoints: n
+  best_checkpoint: n
+  best_pruned_checkpoint: n
+  best_pruned_quantized_checkpoint: n
+  recipe_saved_to_checkpoint: n
+  update_architecture_from_recipe: n
+  staged_recipes: n
+
+logging:
+  stdout: n
+  weights_and_biases: n
+  tensorboard: n
+
+export:
+  cli: n
+  api: n
+  one_shot: n
+  torch_script: n
+  static_batch_size: n
+  dynamic_batch_size: n
+  static_input_shape: n
+  dynamic_input_shape: n
+  save_to_simple_deployment_directory: n
+  save_to_sparsezoo_directory: n


### PR DESCRIPTION
Support for creating and maintaining integration and repo level feature status tables using tooling added by https://github.com/neuralmagic/sparsezoo/pull/255

Contributors will maintain `.status.yaml` files in `src/` at the integration directory level and run `status/integration_status.py` to generate/update the markdown status tables from them

see auto generated markdown files to see end result

**tasks:**
 - [x] #1385 
 - [x] #1386
 - [x] #1387
 - [x] #1388

**test_plan:**
Manual inspection of auto generated files