### PR TITLE
Adding version guard to yolov8

### DIFF
--- a/src/sparseml/yolov8/__init__.py
+++ b/src/sparseml/yolov8/__init__.py
@@ -11,3 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import ultralytics
+
+
+if "8.0.30" not in ultralytics.__version__:
+    raise ValueError(
+        f"ultralytics==8.0.30 is required, found {ultralytics.__version__}. "
+        "To fix run `pip install sparseml[ultralytics]`."
+    )


### PR DESCRIPTION
Tested by installing newer version of yolov8 and running sparseml.ultralytics.train/export/val --help and verified there was an error.

Then install 8.0.30 and verified no error