### PR TITLE
Update text_classification.py

### DIFF
--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -652,6 +652,7 @@ def main(**kwargs):
 
 def _get_label_info(data_args, raw_datasets):
     label_column = data_args.label_column_name
+    label_list = []
     if data_args.task_name is not None:
         is_regression = data_args.task_name == "stsb"
         is_multi_label_classification = False


### PR DESCRIPTION
Small bug related to regression text_classification training. The `label_list` is not instantiated if `is_regression` is true.

After this change, you can run the following regression task:

```
!sparseml.transformers.train.text_classification \
  --model_name_or_path zoo:nlp/masked_language_modeling/obert-base/pytorch/huggingface/wikipedia_bookcorpus/pruned90-none \
  --recipe zoo:nlp/sentiment_analysis/obert-base/pytorch/huggingface/sst2/pruned90_quant-none \
  --distill_teacher disable \
  --task stsb \
  --output_dir test \
  --do_train --do_eval --max_seq_length 128 --evaluation_strategy epoch --logging_steps 1000 --save_steps 1000 \
  --per_device_train_batch_size 8 --per_device_eval_batch_size 32 --gradient_accumulation_steps 4 --preprocessing_num_workers 32 \
  --seed 5114 \
  --max_train_samples 100
```