### PR TITLE
[Fix] Fix divergence between student and teacher label mapping

### DIFF
--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -28,7 +28,7 @@ import os
 import sys
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import datasets
 import numpy as np
@@ -382,6 +382,10 @@ def main(**kwargs):
         },
     )
 
+    if teacher:
+        # check whether teacher and student have the corresponding outputs
+        label_to_id, label_list = _check_teacher_student_outputs(teacher, label_to_id)
+
     tokenizer_src = (
         model_args.tokenizer_name
         if model_args.tokenizer_name
@@ -573,6 +577,39 @@ def main(**kwargs):
         trainer.save_sample_inputs_outputs(
             num_samples_to_export=data_args.num_export_samples
         )
+
+
+def _check_teacher_student_outputs(
+    teacher: Module, label_to_id: Dict[str, int]
+) -> Tuple[Dict[str, int], List[str]]:
+    # Check that the teacher and student have the same labels and if they do,
+    # check that the mapping between labels and ids is the same.
+
+    teacher_labels = list(teacher.config.label2id.keys())
+    teacher_ids = list(teacher.config.label2id.values())
+
+    student_labels = list(label_to_id.keys())
+    student_ids = list(label_to_id.values())
+
+    if set(teacher_labels) != set(student_labels):
+        _LOGGER.warning(
+            f"Teacher labels {teacher_labels} do not match "
+            f"student labels {student_labels}. Ignore this warning "
+            "if this is expected behavior."
+        )
+    else:
+        if student_ids != teacher_ids:
+            _LOGGER.warning(
+                "Teacher and student labels match, but the mapping "
+                "between teachers labels and ids does not match the "
+                "mapping between student labels and ids. "
+                "The student's mapping will be overwritten "
+                "by the teacher's mapping."
+            )
+            label_to_id = teacher.config.label2id
+            label_list = teacher_labels
+
+    return label_to_id, label_list
 
 
 def _get_label_list(labels):


### PR DESCRIPTION
Fix for: https://app.asana.com/0/1203126676641557/1204066771103852/f

Testing:
Rerunning the procedure described here: https://colab.research.google.com/drive/1WuWJMYY-_S-JP711bLYSRxBbcb66X1ft
Now, however, I see convergence:
```bash
... lost the upper part of the stack trace
{'eval_loss': 1.1685093641281128, 'eval_precision': 0.9192755805659032, 'eval_recall': 0.9153037267938524, 'eval_f1': 0.9172853541594583, 'eval_accuracy': 0.9135547681165064, 'eval_runtime': 45.5854, 'eval_samples_per_second': 71.295, 'eval_steps_per_second': 0.57, 'epoch': 10.0}
{'eval_loss': 1.1096463203430176, 'eval_precision': 0.9248782427194115, 'eval_recall': 0.9179079448379269, 'eval_f1': 0.9213799112801014, 'eval_accuracy': 0.9186947548771466, 'eval_runtime': 20.9074, 'eval_samples_per_second': 155.447, 'eval_steps_per_second': 1.244, 'epoch': 13.0}
```