### PR TITLE
[YOLOv8] Add flag to save pt models with one-shot applied during export

### DIFF
--- a/src/sparseml/yolov8/export.py
+++ b/src/sparseml/yolov8/export.py
@@ -51,7 +51,7 @@ from sparseml.yolov8.trainers import SparseYOLO
     "--one-shot",
     default=None,
     type=str,
-    help="Path to recipe to apply in a zero shot " "fashion. Defaults to None.",
+    help="Path to recipe to apply in a zero shot fashion. Defaults to None.",
 )
 @click.option(
     "--export-samples",

--- a/src/sparseml/yolov8/export.py
+++ b/src/sparseml/yolov8/export.py
@@ -51,13 +51,20 @@ from sparseml.yolov8.trainers import SparseYOLO
     "--one-shot",
     default=None,
     type=str,
-    help="Path to recipe to apply in a zero shot fashion. " "Defaults to None.",
+    help="Path to recipe to apply in a zero shot " "fashion. Defaults to None.",
 )
 @click.option(
     "--export-samples",
     type=int,
     default=0,
     help="Number of samples to export with onnx",
+)
+@click.option(
+    "--save-one-shot-torch",
+    default=True,
+    help="If one-shot recipe is supplied and "
+    "this flag is set to True,mthe torch model with "
+    "the one-shot recipe applied will be exported.",
 )
 def main(**kwargs):
     model = SparseYOLO(kwargs["model"])

--- a/src/sparseml/yolov8/export.py
+++ b/src/sparseml/yolov8/export.py
@@ -61,7 +61,7 @@ from sparseml.yolov8.trainers import SparseYOLO
 )
 @click.option(
     "--save-one-shot-torch",
-    default=True,
+    default=False,
     help="If one-shot recipe is supplied and "
     "this flag is set to True,mthe torch model with "
     "the one-shot recipe applied will be exported.",

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -535,6 +535,7 @@ class SparseYOLO(YOLO):
         source = self.ckpt.get("source")
         recipe = self.ckpt.get("recipe")
         one_shot = args.get("one_shot")
+        save_one_shot_torch = args.get("save_one_shot_torch")
 
         if source == "sparseml":
             LOGGER.info(
@@ -559,6 +560,16 @@ class SparseYOLO(YOLO):
         save_dir = args["save_dir"]
 
         exporter = ModuleExporter(self.model, save_dir)
+        if save_one_shot_torch:
+            if not one_shot:
+                warnings.warn(
+                    "No one-shot recipe detected; skipping one-shot model torch export..."
+                )
+            else:
+                torch_name = name.replace(".onnx", ".pt")
+                LOGGER.info(f"Saving one-shot torch model to {torch_name}...")
+                exporter.export_pytorch(name=torch_name)
+
         exporter.export_onnx(
             sample_batch=torch.randn(1, 3, args["imgsz"], args["imgsz"]),
             opset=args["opset"],

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -555,6 +555,11 @@ class SparseYOLO(YOLO):
             )
             manager = ScheduledModifierManager.from_yaml(one_shot)
             manager.apply(self.model)
+            recipe = (
+                ScheduledModifierManager.compose_staged(recipe, manager)
+                if recipe
+                else manager
+            )
 
         name = args.get("name", f"{type(self.model).__name__}.onnx")
         save_dir = args["save_dir"]
@@ -563,7 +568,8 @@ class SparseYOLO(YOLO):
         if save_one_shot_torch:
             if not one_shot:
                 warnings.warn(
-                    "No one-shot recipe detected; skipping one-shot model torch export..."
+                    "No one-shot recipe detected; "
+                    "skipping one-shot model torch export..."
                 )
             else:
                 torch_name = name.replace(".onnx", ".pt")


### PR DESCRIPTION
## Feature Preview
```bash
sparseml.ultralytics.export --model yolov8.pt --one-shot recipe.yaml --save-one-shot-torch True
```
Result
```bash
....
Source: 'sparseml' detected; Exporting model from SparseML checkpoint...
Detected one-shot recipe: hehe.yaml. Applying it to the model to be exported...
Saving one-shot torch model to DetectionModel.pt...
...
```
Resulting `export` folder
.
├── deployment
│   ├── config.json
│   ├── DetectionModel.onnx
│   ├── recipe.yaml
│   ├── sample_inputs
│   │   ├── inp-0000.npz
│   │   ├── inp-0001.npz
│   │   ├── inp-0002.npz
│   │   ├── inp-0003.npz
│   │   ├── inp-0004.npz
...
│   ├── sample_outputs_onnxruntime
│   │   ├── out-0000.npz
│   │   ├── out-0001.npz
│   │   ├── out-0002.npz
│   │   ├── out-0003.npz
│   │   ├── out-0004.npz
...
│   └── sample_outputs_torch
│       ├── out-0000.npz
│       ├── out-0001.npz
│       ├── out-0002.npz
│       ├── out-0003.npz
│       ├── out-0004.npz
...
├── DetectionModel.onnx
└── training
    └── DetectionModel.pt
```

Upon inspection, the `DetectionModel.pt` model only has a state dict with the
- appropriately quantized weights.
- (staged) recipe
- epoch equal to -1 