### PR TITLE
[Fix] label_list not being set for NLP token classification training if distillation teacher and student labels do not match

### DIFF
--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -597,21 +597,7 @@ def _check_teacher_student_outputs(
             f"student labels {student_labels}. Ignore this warning "
             "if this is expected behavior."
         )
-        is_teacher_label_str = isinstance(teacher_labels[0], str)
-        is_student_label_str = isinstance(student_labels[0], str)
-
-        if is_teacher_label_str and not is_student_label_str:
-            # If the teacher labels are strings and the student labels are ints,
-            # we will assume that the teacher labels are the correct labels.
-            label_list = teacher_labels
-            models_labels_to_use = "teacher"
-        else:
-            label_list = student_labels
-            models_labels_to_use = "student"
-        _LOGGER.warning(
-            "From this point forward, the "
-            f"{models_labels_to_use}'s labels will be used."
-        )
+        label_list = student_labels
     else:
         if student_ids != teacher_ids:
             _LOGGER.warning(
@@ -780,7 +766,9 @@ def _get_tokenized_dataset(
     # Map that sends B-Xxx label to its I-Xxx counterpart
     b_to_i_label = []
     for idx, label in enumerate(label_list):
-        if label.startswith("B-") and label.replace("B-", "I-") in label_list:
+        if isinstance(label, str) and (
+            label.startswith("B-") and label.replace("B-", "I-") in label_list
+        ):
             b_to_i_label.append(label_list.index(label.replace("B-", "I-")))
         else:
             b_to_i_label.append(idx)

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -382,7 +382,7 @@ def main(**kwargs):
         },
     )
 
-    if teacher:
+    if teacher and not isinstance(teacher, str):
         # check whether teacher and student have the corresponding outputs
         label_to_id, label_list = _check_teacher_student_outputs(teacher, label_to_id)
 
@@ -597,7 +597,21 @@ def _check_teacher_student_outputs(
             f"student labels {student_labels}. Ignore this warning "
             "if this is expected behavior."
         )
-        label_list = student_labels
+        is_teacher_label_str = isinstance(teacher_labels[0], str)
+        is_student_label_str = isinstance(student_labels[0], str)
+
+        if is_teacher_label_str and not is_student_label_str:
+            # If the teacher labels are strings and the student labels are ints,
+            # we will assume that the teacher labels are the correct labels.
+            label_list = teacher_labels
+            models_labels_to_use = "teacher"
+        else:
+            label_list = student_labels
+            models_labels_to_use = "student"
+        _LOGGER.warning(
+            "From this point forward, the "
+            f"{models_labels_to_use}'s labels will be used."
+        )
     else:
         if student_ids != teacher_ids:
             _LOGGER.warning(

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -597,6 +597,7 @@ def _check_teacher_student_outputs(
             f"student labels {student_labels}. Ignore this warning "
             "if this is expected behavior."
         )
+        label_list = student_labels
     else:
         if student_ids != teacher_ids:
             _LOGGER.warning(

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -384,7 +384,9 @@ def main(**kwargs):
 
     if teacher and not isinstance(teacher, str):
         # check whether teacher and student have the corresponding outputs
-        label_to_id, label_list = _check_teacher_student_outputs(teacher, label_to_id)
+        label_to_id, label_list = _check_teacher_student_outputs(
+            teacher, label_to_id, label_list
+        )
 
     tokenizer_src = (
         model_args.tokenizer_name
@@ -580,7 +582,7 @@ def main(**kwargs):
 
 
 def _check_teacher_student_outputs(
-    teacher: Module, label_to_id: Dict[str, int]
+    teacher: Module, label_to_id: Dict[str, int], label_list: List[str]
 ) -> Tuple[Dict[str, int], List[str]]:
     # Check that the teacher and student have the same labels and if they do,
     # check that the mapping between labels and ids is the same.
@@ -597,7 +599,6 @@ def _check_teacher_student_outputs(
             f"student labels {student_labels}. Ignore this warning "
             "if this is expected behavior."
         )
-        label_list = student_labels
     else:
         if student_ids != teacher_ids:
             _LOGGER.warning(


### PR DESCRIPTION
Fix for: https://app.asana.com/0/1204070232568744/1204101088568500/f

Testing:
Rerunning the procedure described here and ensuring convergence: https://colab.research.google.com/drive/1WuWJMYY-_S-JP711bLYSRxBbcb66X1ft

Rerunning the following example and ensuring there isn't a crash:
```
sparseml.transformers.train.token_classification \
  --model_name_or_path zoo:nlp/masked_language_modeling/obert-base/pytorch/huggingface/wikipedia_bookcorpus/pruned90-none \
  --recipe zoo:nlp/token_classification/obert-base/pytorch/huggingface/conll2003/pruned90_quant-none \
  --distill_teacher zoo:nlp/token_classification/obert-base/pytorch/huggingface/conll2003/base-none \
  --dataset_name conll2003 \
  --output_dir sparse_bert-token_classification_conll2003 \
  --per_device_train_batch_size 32 --per_device_eval_batch_size 32 --preprocessing_num_workers 6 \
  --do_train --do_eval --evaluation_strategy epoch --fp16 --seed 29204  \
  --save_strategy epoch --save_total_limit 1
```