### PR TITLE
Explicitly setting all parameter requires_grad=True

### DIFF
--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -533,7 +533,6 @@ class SparseYOLO(YOLO):
         else:
             return super()._load(weights)
 
-    @smart_inference_mode()
     def export(self, **kwargs):
         """
         Export model.
@@ -569,6 +568,8 @@ class SparseYOLO(YOLO):
                 f"Detected one-shot recipe: {one_shot}. "
                 "Applying it to the model to be exported..."
             )
+            for p in self.model.parameters():
+                p.requires_grad = True
             manager = ScheduledModifierManager.from_yaml(one_shot)
             manager.apply(self.model)
             recipe = (
@@ -636,9 +637,7 @@ class SparseYOLO(YOLO):
                 "Recipe checkpoint detected, saving the "
                 f"recipe to the deployment directory {deployment_folder}"
             )
-            ScheduledModifierManager.from_yaml(recipe).save(
-                os.path.join(deployment_folder, "recipe.yaml")
-            )
+            recipe.save(os.path.join(deployment_folder, "recipe.yaml"))
 
     def train(self, **kwargs):
         # NOTE: Copied from base class and removed post-training validation


### PR DESCRIPTION
It seems like in upstream yolov8, they explicitly set all param requires_grad to False

https://github.com/ultralytics/ultralytics/blob/790f9c067c9a3548acf7c6925cea14de9ad77787/ultralytics/yolo/engine/exporter.py#L189

So any model we use from upstream we need to set requires_grad to True for exporting


Test plan: Ran `sparseml.ultralytics.export --model yolov8s.pt --recipe <failing recipe from issue>`