### PR TITLE
Utility functions for stage epochs

### DIFF
--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -650,6 +650,14 @@ class BaseManager(BaseObject):
 
                 stage_max_min[stage] = (epoch_min, epoch_max)
 
+            # Post-process to replace -1's with their real values
+            epochs_list = list(stage_max_min.values())
+            for i, stage, epochs in enumerate(stage_max_min.items()):
+                if epochs[0] == -1:
+                    stage_max_min[stage][0] = epochs_list[i - 1][1] if i > 0 else 0
+                if epochs[1] == -1 and i < len(epochs_list) - 1:
+                    stage_max_min[stage][1] = epochs_list[i + 1][0]
+
             return stage_max_min
 
     def get_last_start_epoch(self) -> float:

--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -676,4 +676,5 @@ def _max_modifier_epoch(modifiers: Iterable[BaseModifier]) -> float:
         [math.ceil(mod.start_epoch) for mod in modifiers if mod.start_epoch > -1]
     )
     vals.extend([math.ceil(mod.end_epoch) for mod in modifiers if mod.end_epoch > -1])
+
     return max(vals) if len(vals) > 0 else -1

--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -24,7 +24,7 @@ import math
 from collections import OrderedDict
 from copy import deepcopy
 from functools import cmp_to_key
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, Union
 
 from sparseml.optim.modifier import BaseModifier, BaseObject, ModifierProp
 from sparseml.sparsification.types import SparsificationTypes
@@ -343,23 +343,7 @@ class BaseManager(BaseObject):
         """
         :return: the minimum epochs required by any of the modifiers under the manager
         """
-        vals = []
-        vals.extend(
-            [
-                math.floor(mod.start_epoch)
-                for mod in self.iter_modifiers()
-                if mod.start_epoch > -1
-            ]
-        )
-        vals.extend(
-            [
-                math.floor(mod.end_epoch)
-                for mod in self.iter_modifiers()
-                if mod.end_epoch > -1
-            ]
-        )
-
-        return min(vals) if len(vals) > 0 else -1
+        return _min_modifier_epoch(self.iter_modifiers())
 
     @ModifierProp(serializable=False)
     def max_epochs(self) -> int:
@@ -367,23 +351,7 @@ class BaseManager(BaseObject):
         :return: the maximum number of epochs required by any of the modifiers
             under the manager
         """
-        vals = []
-        vals.extend(
-            [
-                math.ceil(mod.start_epoch)
-                for mod in self.iter_modifiers()
-                if mod.start_epoch > -1
-            ]
-        )
-        vals.extend(
-            [
-                math.ceil(mod.end_epoch)
-                for mod in self.iter_modifiers()
-                if mod.end_epoch > -1
-            ]
-        )
-
-        return max(vals) if len(vals) > 0 else -1
+        return _max_modifier_epoch(self.iter_modifiers())
 
     def save(self, file_path: str, include_metadata: bool = True):
         """
@@ -632,27 +600,13 @@ class BaseManager(BaseObject):
         else:
             stage_max_min = OrderedDict()
             for stage, mod_list in self.modifiers.items():
-                epoch_floors = [
-                    math.floor(mod.start_epoch)
-                    for mod in mod_list
-                    if mod.start_epoch > -1
-                ] + [
-                    math.floor(mod.end_epoch) for mod in mod_list if mod.end_epoch > -1
-                ]
-                epoch_min = min(epoch_floors) if epoch_floors else -1
-
-                epoch_ceils = [
-                    math.ceil(mod.start_epoch)
-                    for mod in mod_list
-                    if mod.start_epoch > -1
-                ] + [math.ceil(mod.end_epoch) for mod in mod_list if mod.end_epoch > -1]
-                epoch_max = max(epoch_ceils) if epoch_ceils else -1
-
+                epoch_min = _min_modifier_epoch(mod_list)
+                epoch_max = _max_modifier_epoch(mod_list)
                 stage_max_min[stage] = (epoch_min, epoch_max)
 
             # post-process to replace -1's with their real values
             epochs_list = list(stage_max_min.values())
-            for i, stage, epochs in enumerate(stage_max_min.items()):
+            for i, (stage, epochs) in enumerate(stage_max_min.items()):
                 # replace start epochs that are -1 with the last epoch of the previous
                 # stage, or 0 if it's the first stage
                 if epochs[0] == -1:
@@ -699,3 +653,25 @@ def _nested_dict_to_lines(
             # reached maximum nesting level.
             yaml_str_lines.append(indentation * nesting_depth + f"{key}: {value}")
     return yaml_str_lines
+
+
+def _min_modifier_epoch(modifiers: Iterable[BaseModifier]) -> float:
+    """
+    :return: the minimum epochs required by any of the modifiers provided
+    """
+    vals = [math.floor(mod.start_epoch) for mod in modifiers if mod.start_epoch > -1]
+
+    return min(vals) if len(vals) > 0 else -1
+
+
+def _max_modifier_epoch(modifiers: Iterable[BaseModifier]) -> float:
+    """
+    :return: the maximum number of epochs required by any of the modifiers provided
+    """
+    vals = []
+    vals.extend(
+        [math.ceil(mod.start_epoch) for mod in modifiers if mod.start_epoch > -1]
+    )
+    vals.extend([math.ceil(mod.end_epoch) for mod in modifiers if mod.end_epoch > -1])
+
+    return max(vals) if len(vals) > 0 else -1

--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -659,7 +659,8 @@ class BaseManager(BaseObject):
         """
         stage_max_min = self.get_start_end_epochs()
         last_stage_epochs = stage_max_min[next(reversed(stage_max_min))]
-        return last_stage_epochs[0]
+        last_start_epoch = last_stage_epochs[0]
+        return last_start_epoch if last_start_epoch > -1 else 0
 
     def _info_log_metadata(self):
         metadata_str = json.dumps(self._metadata, indent=1)

--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -650,11 +650,15 @@ class BaseManager(BaseObject):
 
                 stage_max_min[stage] = (epoch_min, epoch_max)
 
-            # Post-process to replace -1's with their real values
+            # post-process to replace -1's with their real values
             epochs_list = list(stage_max_min.values())
             for i, stage, epochs in enumerate(stage_max_min.items()):
+                # replace start epochs that are -1 with the last epoch of the previous
+                # stage, or 0 if it's the first stage
                 if epochs[0] == -1:
                     stage_max_min[stage][0] = epochs_list[i - 1][1] if i > 0 else 0
+                # replace end epochs that are -1 with the next stage's start epoch,
+                # unless it's the last stage
                 if epochs[1] == -1 and i < len(epochs_list) - 1:
                     stage_max_min[stage][1] = epochs_list[i + 1][0]
 

--- a/src/sparseml/optim/manager.py
+++ b/src/sparseml/optim/manager.py
@@ -668,10 +668,12 @@ def _max_modifier_epoch(modifiers: Iterable[BaseModifier]) -> float:
     """
     :return: the maximum number of epochs required by any of the modifiers provided
     """
+    # save modifiers as list so it can iterated over multiple times
+    modifiers = [mod for mod in modifiers]
+
     vals = []
     vals.extend(
         [math.ceil(mod.start_epoch) for mod in modifiers if mod.start_epoch > -1]
     )
     vals.extend([math.ceil(mod.end_epoch) for mod in modifiers if mod.end_epoch > -1])
-
     return max(vals) if len(vals) > 0 else -1


### PR DESCRIPTION
When applying recipes at intermediate epochs, it can be non-intuitive how to select the correct epoch, as the epoch used during and saved by training scripts is not the same one that should be used in a staged recipe, as epochs for later stages are shifted up by epochs from prior stages. The intent of the addition of these utility functions is to create a standard approach, where recipes applied at intermediate epochs should always be applied at `manager.get_last_start_epoch() + train_epoch`

**Test plan**
Tested with a Yolov5 usecase. See the associated Yolov5 PR here: neuralmagic/yolov5#189