### PR TITLE
Better Error Message for distillation

### DIFF
--- a/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
@@ -56,7 +56,7 @@ def kl_logsoftmax(
             log_target=True,
             reduction="sum",
         )
-        * (temperature ** 2)
+        * (temperature**2)
         / number_items
     )
 

--- a/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
+++ b/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py
@@ -44,6 +44,11 @@ def kl_logsoftmax(
     x: Tensor, y: Tensor, temperature: Union[float, Tensor], dim: int = -1
 ) -> Tensor:
     number_items = x.numel() / y.size(dim)
+    if x.shape != y.shape:
+        raise ValueError(
+            "The teacher/student outputs must be of the same shape for distilation"
+            f" but got Tensors of size {x.shape} and {y.shape}"
+        )
     return (
         TF.kl_div(
             input=TF.log_softmax(x / temperature, dim=dim),
@@ -51,7 +56,7 @@ def kl_logsoftmax(
             log_target=True,
             reduction="sum",
         )
-        * (temperature**2)
+        * (temperature ** 2)
         / number_items
     )
 


### PR DESCRIPTION
Expected  Behaviour:

During distillation if the teacher and student outputs differ in shapes an 
appropriate error message should be displayed and the running program must exit

Current Status:

During distillation if the teacher and student outputs differ in shapes
no warning is displayed, this eventually causes an error down the line, 
which is not very intuitive and does not describe what went wrong.

This PR fixes that.

Command with mis-matching teacher/student:

```bash
sparseml.transformers.train.token_classification \
  --model_name_or_path zoo:nlp/masked_language_modeling/obert-base/pytorch/huggingface/wikipedia_bookcorpus/pruned90-none \
  --recipe zoo:nlp/token_classification/obert-base/pytorch/huggingface/conll2003/pruned90_quant-none \
  --distill_teacher zoo:nlp/question_answering/mobilebert-none/pytorch/huggingface/squad/14layer_pruned50_quant-none-vnni \
  --dataset_name conll2003 \
  --output_dir sparse_bert-token_classification_conll2003 \
  --per_device_train_batch_size 32 --per_device_eval_batch_size 32 --preprocessing_num_workers 6 \
  --do_train --do_eval --evaluation_strategy epoch --fp16 --seed 29204  \
  --save_strategy epoch --save_total_limit 1
```

Now an appropriate value error is raised:

```bash
    kl_logsoftmax(
  File "/home/ubuntu/projects/sparseml/src/sparseml/pytorch/sparsification/distillation/modifier_distillation_base.py", line 48, in kl_logsoftmax
    raise ValueError(
ValueError: The teacher/student outputs must be of the same shape for distilation but got Tensors of size torch.Size([32, 56, 9]) and torch.Size([32, 56, 2])
../aten/src/ATen/native/cuda/Loss.cu:271: nll_loss_forward_reduce_cuda_kernel_2d: block: [0,0,0], thread: [15,0,0] Assertion `t >= 0 && t < n_classes` failed.
../aten/src/ATen/native/cuda/Loss.cu:271: nll_loss_forward_reduce_cuda_kernel_2d: block: [0,0,0], thread: [16,0,0] Assertion `t >= 0 && t < n_classes` failed.
../aten/src/ATen/native/cuda/Loss.cu:271: nll_loss_forward_reduce_cuda_kernel_2d: block: [0,0,0], thread: [17,0,0] Assertion `t >= 0 && t < n_classes` failed.
  0%|                                                  | 0/5707 [00:00<?, ?it/s]
```
