### PR TITLE
Add log printout to announce modifier logging

### DIFF
--- a/src/sparseml/pytorch/utils/logger.py
+++ b/src/sparseml/pytorch/utils/logger.py
@@ -341,7 +341,7 @@ class PythonLogger(LambdaLogger):
             log_path = os.path.join("sparse_logs", f"{dt_string}.log")
             os.makedirs("sparse_logs", exist_ok=True)
 
-            _LOGGER(f"Logging all SparseML modifier-level logs to {log_path}")
+            _LOGGER.info(f"Logging all SparseML modifier-level logs to {log_path}")
 
             handler = logging.FileHandler(
                 log_path,

--- a/src/sparseml/pytorch/utils/logger.py
+++ b/src/sparseml/pytorch/utils/logger.py
@@ -48,6 +48,9 @@ except Exception as err:
 from sparseml.utils import ALL_TOKEN, create_dirs
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 __all__ = [
     "BaseLogger",
     "LambdaLogger",
@@ -332,11 +335,16 @@ class PythonLogger(LambdaLogger):
             self._logger = logger
         else:
             self._logger = logging.getLogger(__name__)
+
             now = datetime.now()
             dt_string = now.strftime("%d-%m-%Y_%H.%M.%S")
+            log_path = os.path.join("sparse_logs", f"{dt_string}.log")
             os.makedirs("sparse_logs", exist_ok=True)
+
+            _LOGGER(f"Logging all SparseML modifier-level logs to {log_path}")
+
             handler = logging.FileHandler(
-                os.path.join("sparse_logs", f"{dt_string}.log"),
+                log_path,
                 delay=True,
             )
             self._logger.addHandler(handler)

--- a/src/sparseml/pytorch/utils/logger.py
+++ b/src/sparseml/pytorch/utils/logger.py
@@ -336,10 +336,15 @@ class PythonLogger(LambdaLogger):
         else:
             self._logger = logging.getLogger(__name__)
 
+            base_log_path = (
+                os.environ.get("NM_TEST_LOG_DIR")
+                if os.environ.get("NM_TEST_MODE")
+                else "sparse_logs"
+            )
             now = datetime.now()
             dt_string = now.strftime("%d-%m-%Y_%H.%M.%S")
-            log_path = os.path.join("sparse_logs", f"{dt_string}.log")
-            os.makedirs("sparse_logs", exist_ok=True)
+            log_path = os.path.join(base_log_path, f"{dt_string}.log")
+            os.makedirs(base_log_path, exist_ok=True)
 
             _LOGGER.info(f"Logging all SparseML modifier-level logs to {log_path}")
 

--- a/tests/sparseml/conftest.py
+++ b/tests/sparseml/conftest.py
@@ -25,7 +25,7 @@ except Exception:
 
 
 os.environ["NM_TEST_MODE"] = "True"
-os.environ["NM_TEST_LOG_DIR"] = "temp_test_logs"
+os.environ["NM_TEST_LOG_DIR"] = "nm_temp_test_logs"
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -35,14 +35,8 @@ def check_for_created_files():
     if wandb:
         wandb.finish()
     log_dir = os.environ.get("NM_TEST_LOG_DIR")
-    log_dir_tensorboard = os.path.join(log_dir, "tensorboard")
-    log_dir_wandb = os.path.join(log_dir, "wandb")
-    if os.path.isdir(log_dir_tensorboard):
-        shutil.rmtree(log_dir_tensorboard)
-    if os.path.isdir(log_dir_wandb):
-        shutil.rmtree(log_dir_wandb)
-    if os.path.isdir(log_dir) and len(os.listdir(log_dir)) == 0:
-        os.rmdir(log_dir)
+    if os.path.isdir(log_dir):
+        shutil.rmtree(log_dir)
     end_file_count = sum(len(files) for _, _, files in os.walk(r"."))
     assert (
         start_file_count >= end_file_count

--- a/utils/conftest.py
+++ b/utils/conftest.py
@@ -20,14 +20,14 @@ import pytest
 # Ignore submodules
 collect_ignore_glob = ["tensorflow_v1-onnx/*"]
 
-
-FAILURE_LOG = "test_logs/failures.log"
+LOG_DIR = os.environ["NM_TEST_LOG_DIR"] or "test_logs"
+FAILURE_LOG = os.path.join(LOG_DIR, "failures.log")
 
 
 def pytest_configure(config):
     if os.path.exists(FAILURE_LOG):
         os.remove(FAILURE_LOG)
-    os.makedirs("test_logs", exist_ok=True)
+    os.makedirs(LOG_DIR, exist_ok=True)
 
 
 def write_to_failure_log(node_id, long_repr):


### PR DESCRIPTION
By default, modifier logs are saved to the directory `sparse_logs` to keep them from cluttering the user's interface while preserving them for debugging purposes. Currently, this is not made known to the user in any way. This PR adds a simple logging message to alert the user of these logs and their save path. 

Includes as a rider fix to prevent tests from generating persisting files 

Test plan
**Existing unit tests**