### PR TITLE
[Export] Keep user-provided dynamic axes

### DIFF
--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -498,19 +498,20 @@ def export_onnx(
     if "output_names" not in export_kwargs:
         export_kwargs["output_names"] = _get_output_names(out)
 
+    # Set all batch sizes to be dynamic
     if dynamic_axes is not None:
-        warnings.warn(
-            "`dynamic_axes` is deprecated and does not affect anything. "
-            "The 0th axis is always treated as dynamic.",
-            category=DeprecationWarning,
-        )
-
-    dynamic_axes = {
-        tensor_name: {0: "batch"}
-        for tensor_name in (
-            export_kwargs["input_names"] + export_kwargs["output_names"]
-        )
-    }
+        for tensor_name in export_kwargs["input_names"] + export_kwargs["output_names"]:
+            if tensor_name not in dynamic_axes:
+                dynamic_axes[tensor_name] = {0: "batch"}
+            else:
+                dynamic_axes[tensor_name][0] = "batch"
+    else:
+        dynamic_axes = {
+            tensor_name: {0: "batch"}
+            for tensor_name in (
+                export_kwargs["input_names"] + export_kwargs["output_names"]
+            )
+        }
 
     # disable active quantization observers because they cannot be exported
     disabled_observers = []


### PR DESCRIPTION
When exporting models, we currently ignore user-provided dynamic axes argument and instead default to always making batch size dynamic. This overwrites other dynamic inputs, such as image size in yolov5. 

The change here preserves the default of always setting the batch size to dynamic and preserves the user/integration input, giving preferences to dynamic batch size.

Test plan
Covered by existing tests

Local test
Running the command below and creating a deepspare pipeline with the resulting model and a custom image size.
`sparseml.yolov5.export_onnx --weights zoo:cv/detection/yolov5-l/pytorch/ultralytics/coco/pruned94_quant-none --dynamic`
