### PR TITLE
[ModuleSparsificationInfo] Proposal of the main logic

### DIFF
--- a/src/sparseml/pytorch/utils/log_sparsification_info.py
+++ b/src/sparseml/pytorch/utils/log_sparsification_info.py
@@ -15,7 +15,7 @@
 import torch
 
 from sparseml.pytorch.utils.logger import BaseLogger
-from sparseml.pytorch.utils.sparsification_info import ModuleSparsificationInfo
+from sparseml.pytorch.utils.sparsification_info.module_sparsification_info import ModuleSparsificationInfo
 
 
 __all__ = ["log_module_sparsification_info"]
@@ -28,3 +28,6 @@ def log_module_sparsification_info(module: torch.nn.Module, logger: BaseLogger):
     sparsification_info = ModuleSparsificationInfo.from_module(module)
     for tag, value in sparsification_info.loggable_items():
         logger.log_scalar(tag, value)
+
+
+

--- a/src/sparseml/pytorch/utils/log_sparsification_info.py
+++ b/src/sparseml/pytorch/utils/log_sparsification_info.py
@@ -15,7 +15,9 @@
 import torch
 
 from sparseml.pytorch.utils.logger import BaseLogger
-from sparseml.pytorch.utils.sparsification_info.module_sparsification_info import ModuleSparsificationInfo
+from sparseml.pytorch.utils.sparsification_info.module_sparsification_info import (
+    ModuleSparsificationInfo,
+)
 
 
 __all__ = ["log_module_sparsification_info"]
@@ -28,6 +30,3 @@ def log_module_sparsification_info(module: torch.nn.Module, logger: BaseLogger):
     sparsification_info = ModuleSparsificationInfo.from_module(module)
     for tag, value in sparsification_info.loggable_items():
         logger.log_scalar(tag, value)
-
-
-

--- a/src/sparseml/pytorch/utils/sparsification_info/configs.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/configs.py
@@ -12,106 +12,146 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Counter
-from typing import Any, Dict, List, Optional, Tuple
+from collections import Counter, defaultdict
+from typing import Any, Dict, Tuple
 
 import torch.nn
 from pydantic import BaseModel, Field
 
+from sparseml.pytorch.utils.sparsification_info.helpers import (
+    get_dtype,
+    get_leaf_operations,
+    is_quantized,
+)
 
-def is_quantized(operation: torch.nn.Module) -> bool:
-    if hasattr(operation, "qconfig"):
-        return operation.qconfig is not None
-    return False
+
+__all__ = [
+    "SparsificationSummaries",
+    "SparsificationPruning",
+    "SparsificationQuantization",
+]
 
 
-def get_dtype(operation: torch.nn.Module) -> Any:
-    if hasattr(operation, "weight"):
-        return operation.weight.dtype
-    return None
+class CountAndPercent(BaseModel):
+    count: int = Field(description="The count of items")
+    percent: float = Field(description="The percentage of those items out of the total")
 
 
 class SparsificationSummaries(BaseModel):
-    quantization: Tuple[int, float] = Field(
-        description="A tuple that displays of the number of "
-        "layers/the percent of layers that are quantized."
+    """
+    A model that contains the sparsification summaries for a torch module.
+    """
+
+    quantization: CountAndPercent = Field(
+        description="A model that contains the number of "
+        "operations/the percent of operations that are quantized."
     )
-    pruning: Tuple[int, float] = Field(
+    pruning: CountAndPercent = Field(
         description="A tuple that displays of the number of "
-        "layers/the percent of layers that are pruned."
+        "parameters/the percent of parameters that are pruned."
     )
-    ops: Dict[str, int] = Field(
+    count_parameters: Dict[str, int] = Field(
+        description="A dictionary that maps the name of a parameter "
+        "to the number of elements in that parameter."
+    )
+    count_operations: Dict[str, int] = Field(
         description="A dictionary that maps the name of an operation "
         "to the number of times that operation is used in the model."
     )
 
     @classmethod
-    def from_module_info(
+    def from_module(
         cls,
-        param_information: Dict[str, Any],
-        operations: List[torch.nn.Module],
-        is_pruned_threshold: Tuple[float, float] = (0.1, 0.99),
+        module=torch.nn.Module,
+        pruning_thresholds: Tuple[float, float] = (0.05, 0.99),
     ) -> "SparsificationSummaries":
+        """
+        Factory method to create a SparsificationSummaries object from a module.
 
-        # Compute quantization summary statistics
-        num_quantized_layers = len([op for op in operations if is_quantized(op)])
-        percentage_quantized_layers = num_quantized_layers / len(operations)
+        :param module: The module to create the SparsificationSummaries object from.
+        :param pruning_thresholds: The lower and upper thresholds used to determine
+            whether a parameter is pruned. If it's percentage of zero weights is between
+            the lower and upper thresholds, it is considered pruned.
+        :return: A SparsificationSummaries object.
+        """
+        operations = get_leaf_operations(module)
+        num_quantized_ops = sum([is_quantized(op) for op in operations])
+        total_num_params = len(list(module.parameters()))
 
-        # Compute pruning summary statistics
-        lower_treshold = min(is_pruned_threshold)
-        upper_treshold = max(is_pruned_threshold)
-        num_pruned_layers = 0
-        for param_info in param_information.values():
+        lower_threshold_pruning = min(pruning_thresholds)
+        upper_threshold_pruning = max(pruning_thresholds)
+        total_num_params_pruned = 0
+        count_parameters = defaultdict(int)
+
+        for param_name, param in module.named_parameters():
+            num_parameters = param.numel()
+            num_zero_parameters = param.numel() - param.count_nonzero().item()
+
             if (
-                lower_treshold
-                <= param_info["percentage_zero_weights"]
-                <= upper_treshold
+                lower_threshold_pruning
+                <= num_zero_parameters / num_parameters
+                <= upper_threshold_pruning
             ):
-                num_pruned_layers += 1
-        percentage_pruned_layers = num_pruned_layers / len(param_information.keys())
+                total_num_params_pruned += 1
 
-        # Compute ops summary statistics
-        operations = [op.__class__.__name__ for op in operations]
+            count_parameters[param_name] = num_parameters
 
         return cls(
-            quantization=(num_quantized_layers, percentage_quantized_layers),
-            pruning=(num_pruned_layers, percentage_pruned_layers),
-            ops=Counter(operations),
+            pruning=CountAndPercent(
+                count=total_num_params_pruned,
+                percent=total_num_params_pruned / total_num_params,
+            ),
+            quantization=CountAndPercent(
+                count=num_quantized_ops, percent=num_quantized_ops / len(operations)
+            ),
+            count_parameters=count_parameters,
+            count_operations=Counter([op.__class__.__name__ for op in operations]),
         )
 
 
 class SparsificationPruning(BaseModel):
-    zero_count_percent: Dict[str, float] = Field(
-        description="A dictionary that maps the name of a layer "
-        "to the percent of weights that are zeroed out "
-        "in that layer."
-    )
-    zero_count: Dict[str, int] = Field(
-        description="A dictionary that maps the name of a layer "
-        "to the number of weights that are zeroed out "
+    """
+    A model that contains the pruning information for a torch module.
+    """
+
+    zero_parameters: Dict[str, CountAndPercent] = Field(
+        description="A dictionary that maps the name of a parameter "
+        "to the number/percent of weights that are zeroed out "
         "in that layer."
     )
 
     @classmethod
-    def from_module_info(cls, param_information: Dict[str, Any]):
-        zero_count = {
-            layer_name: layer_info["num_zero_elements"]
-            for layer_name, layer_info in param_information.items()
-        }
-        zero_count_percent = {
-            layer_name: layer_info["percentage_zero_weights"]
-            for layer_name, layer_info in param_information.items()
-        }
-        return cls(
-            zero_count=zero_count,
-            zero_count_percent=zero_count_percent,
-        )
+    def from_module(cls, module: torch.nn.Module) -> "SparsificationPruning":
+        """
+        Factory method to create a SparsificationPruning object from a module.
+
+        :param module: The module to create the SparsificationPruning object from.
+        :return: A SparsificationPruning object.
+        """
+        zero_parameters_count = defaultdict(CountAndPercent)
+        for param_name, param in module.named_parameters():
+            num_parameters = param.numel()
+            num_zero_parameters = param.numel() - param.count_nonzero().item()
+
+            zero_count = num_zero_parameters
+            zero_count_percent = num_zero_parameters / num_parameters
+
+            zero_parameters_count[param_name] = CountAndPercent(
+                count=zero_count, percent=zero_count_percent
+            )
+
+        return cls(zero_parameters=zero_parameters_count)
 
 
 class SparsificationQuantization(BaseModel):
+    """
+    A model that contains the quantization information for a torch module.
+    """
+
     enabled: Dict[str, bool] = Field(
-        description="A dictionary that maps the name of a layer "
-        "to whether or not that layer is quantized."
+        description="A dictionary that maps the name of an "
+        "operation to a boolean flag that indicates whether "
+        "the operation is quantized or not."
     )
     dtype: Dict[str, Any] = Field(
         description="A dictionary that maps the name of a layer"
@@ -119,15 +159,21 @@ class SparsificationQuantization(BaseModel):
     )
 
     @classmethod
-    def from_module_info(
-        cls, operations: List[torch.nn.Module]
+    def from_module(
+        cls,
+        module: torch.nn.Module,
     ) -> "SparsificationQuantization":
+        """
+        Factory method to create a SparsificationQuantization object from a module.
 
-        enabled = {op.__class__.__name__: is_quantized(op) for op in operations}
-        dtype = {op.__class__.__name__: get_dtype(op) for op in operations}
+        :param module: The module to create the SparsificationQuantization object from.
+        :return: A SparsificationQuantization object.
+        """
+        operations = get_leaf_operations(module)
+        enabled = defaultdict(bool)
+        dtype = defaultdict(str)
+        for op in operations:
+            enabled[op.__class__.__name__] = is_quantized(op)
+            dtype[op.__class__.__name__] = get_dtype(op)
 
         return cls(enabled=enabled, dtype=dtype)
-
-
-class SparsificationDistillation(BaseModel):
-    losses: Optional[Any] = None

--- a/src/sparseml/pytorch/utils/sparsification_info/configs.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/configs.py
@@ -12,20 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pydantic import BaseModel
+from typing import Any, Dict, Tuple
+
+from pydantic import BaseModel, Field
 
 
 class SparsificationSummaries(BaseModel):
-    pass
+    quantization: Tuple[int, float] = Field(
+        description="A tuple that displays of the number of "
+        "layers/the percent of layers that are quantized."
+    )
+    pruning: Tuple[int, float] = Field(
+        description="A tuple that displays of the number of "
+        "layers/the percent of layers that are pruned."
+    )
+    ops: Dict[str, int] = Field(
+        description="A dictionary that holds the counts for "
+        "each type of operation present in the module."
+    )
 
 
 class SparsificationPruning(BaseModel):
-    pass
+    zero_count_percent: Dict[str, float] = Field(
+        description="A dictionary that maps the name of a layer "
+        "to the percent of weights that are zeroed out "
+        "in that layer."
+    )
+    zero_count: Dict[str, int] = Field(
+        description="A dictionary that maps the name of a layer "
+        "to the number of weights that are zeroed out "
+        "in that layer."
+    )
 
 
 class SparsificationQuantization(BaseModel):
-    pass
+    enabled: Dict[str, bool] = Field(
+        description="A dictionary that maps the name of a layer "
+        "to whether or not that layer is quantized."
+    )
+    precision: Dict[str, Any] = Field(
+        description="A dictionary that maps the name of a layer "
+        "to the precision of that layer."
+    )
 
 
 class SparsificationDistillation(BaseModel):
-    pass
+    losses: Dict[str, str] = Field(
+        description="A dictionary that maps the name of a layer "
+        "to the loss function used for that layer."
+    )

--- a/src/sparseml/pytorch/utils/sparsification_info/configs.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/configs.py
@@ -63,7 +63,7 @@ class SparsificationSummaries(BaseModel):
     def from_module(
         cls,
         module=torch.nn.Module,
-        pruning_thresholds: Tuple[float, float] = (0.05, 0.99),
+        pruning_thresholds: Tuple[float, float] = (0.05, 1 - 1e-9),
     ) -> "SparsificationSummaries":
         """
         Factory method to create a SparsificationSummaries object from a module.

--- a/src/sparseml/pytorch/utils/sparsification_info/configs.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/configs.py
@@ -50,11 +50,11 @@ class SparsificationSummaries(BaseModel):
         description="A tuple that displays of the number of "
         "parameters/the percent of parameters that are pruned."
     )
-    count_parameters: Dict[str, int] = Field(
+    parameter_counts: Dict[str, int] = Field(
         description="A dictionary that maps the name of a parameter "
         "to the number of elements in that parameter."
     )
-    count_operations: Dict[str, int] = Field(
+    operation_counts: Dict[str, int] = Field(
         description="A dictionary that maps the name of an operation "
         "to the number of times that operation is used in the model."
     )

--- a/src/sparseml/pytorch/utils/sparsification_info/configs.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/configs.py
@@ -114,7 +114,7 @@ class SparsificationPruning(BaseModel):
     A model that contains the pruning information for a torch module.
     """
 
-    zero_parameters: Dict[str, CountAndPercent] = Field(
+    sparse_parameters: Dict[str, CountAndPercent] = Field(
         description="A dictionary that maps the name of a parameter "
         "to the number/percent of weights that are zeroed out "
         "in that layer."
@@ -128,7 +128,7 @@ class SparsificationPruning(BaseModel):
         :param module: The module to create the SparsificationPruning object from.
         :return: A SparsificationPruning object.
         """
-        zero_parameters_count = defaultdict(CountAndPercent)
+        sparse_parameters_count = defaultdict(CountAndPercent)
         for param_name, param in module.named_parameters():
             num_parameters = param.numel()
             num_zero_parameters = param.numel() - param.count_nonzero().item()
@@ -136,11 +136,11 @@ class SparsificationPruning(BaseModel):
             zero_count = num_zero_parameters
             zero_count_percent = num_zero_parameters / num_parameters
 
-            zero_parameters_count[param_name] = CountAndPercent(
+            sparse_parameters_count[param_name] = CountAndPercent(
                 count=zero_count, percent=zero_count_percent
             )
 
-        return cls(zero_parameters=zero_parameters_count)
+        return cls(sparse_parameters=sparse_parameters_count)
 
 
 class SparsificationQuantization(BaseModel):
@@ -153,7 +153,7 @@ class SparsificationQuantization(BaseModel):
         "operation to a boolean flag that indicates whether "
         "the operation is quantized or not."
     )
-    quantization_schema: Dict[str, Union[BaseModel, None]] = Field(
+    quantization_scheme: Dict[str, Union[BaseModel, None]] = Field(
         description="A dictionary that maps the name of a layer"
         "to the dtype (precision) of that layer."
     )
@@ -171,7 +171,7 @@ class SparsificationQuantization(BaseModel):
         """
         operations = get_leaf_operations(module)
         enabled = defaultdict(bool)
-        quantization_schema = defaultdict(str)
+        quantization_scheme = defaultdict(str)
         for op in operations:
             operation_name = op.__class__.__name__
             operation_counter = 0
@@ -181,6 +181,6 @@ class SparsificationQuantization(BaseModel):
                 operation_name = f"{op.__class__.__name__}_{operation_counter}"
 
             enabled[operation_name] = is_quantized(op)
-            quantization_schema[operation_name] = get_quantization_scheme(op)
+            quantization_scheme[operation_name] = get_quantization_scheme(op)
 
-        return cls(enabled=enabled, quantization_schema=quantization_schema)
+        return cls(enabled=enabled, quantization_scheme=quantization_scheme)

--- a/src/sparseml/pytorch/utils/sparsification_info/helpers.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/helpers.py
@@ -14,9 +14,8 @@
 from typing import List, Optional
 
 import torch
+from torch.nn.modules.linear import Identity
 from torch.quantization import QuantWrapper
-
-from sparseml.pytorch.nn import Identity
 
 
 __all__ = ["get_leaf_operations", "is_quantized", "get_quantization_scheme"]
@@ -43,7 +42,7 @@ def get_leaf_operations(
     leaf_operations = []
     children = list(model.children())
 
-    if children == [] and model not in operations_to_skip:
+    if children == []:
         return model
     else:
         for child in children:
@@ -54,6 +53,9 @@ def get_leaf_operations(
                 leaf_operations.extend(get_leaf_operations(child))
             except TypeError:
                 leaf_operations.append(get_leaf_operations(child))
+    leaf_operations = [
+        op for op in leaf_operations if not isinstance(op, tuple(operations_to_skip))
+    ]
     return leaf_operations
 
 

--- a/src/sparseml/pytorch/utils/sparsification_info/helpers.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/helpers.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import List, Optional
+
+import torch
+from pydantic import BaseModel, Field
+
+
+__all__ = ["get_leaf_operations", "is_quantized"]
+
+
+def get_leaf_operations(model: torch.nn.Module) -> List[torch.nn.Module]:
+    """
+    Get the leaf operations in the model
+    (those that do not have operations as children)
+
+    :param model: the model to get the leaf operations from
+    :return: a list of the leaf operations
+    """
+    return [
+        submodule
+        for submodule in model.modules()
+        if len(list(submodule.children())) == 0
+    ]
+
+
+def is_quantized(operation: torch.nn.Module) -> bool:
+    """
+    Check whether the operation is quantized
+    """
+    if hasattr(operation, "qscheme"):
+        return operation.qscheme is not None
+    return False
+
+
+class QuantizationDtype(BaseModel):
+    """
+    Model for the quantization dtype of a model
+    """
+
+    activation: Optional[torch.dtype] = Field(
+        default=None, description="The quantization dtype of activation function"
+    )
+    weight: Optional[torch.dtype] = Field(
+        default=None, description="The quantization dtype of weight function"
+    )
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+def get_dtype(operation: torch.nn.Module) -> QuantizationDtype:
+    """
+    Get the quantization dtype of the operation (both activation and weight).
+    If the operation is not quantized, return None for activation dtype and
+    original dtype of weight.
+
+    :param operation: the operation to get the quantization dtype from
+    :return: the quantization dtype of the operation
+    """
+    if hasattr(operation, "qconfig"):
+        if operation.qconfig is None:
+            pass
+        else:
+            return QuantizationDtype(
+                activation=operation.qconfig.activation.p.keywords["dtype"],
+                weight=operation.qconfig.weight.p.keywords["dtype"],
+            )
+    elif hasattr(operation, "weight"):
+        return QuantizationDtype(weight=operation.weight.dtype)
+
+    return QuantizationDtype()

--- a/src/sparseml/pytorch/utils/sparsification_info/helpers.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/helpers.py
@@ -14,10 +14,10 @@
 from typing import List, Optional
 
 import torch
-from pydantic import BaseModel, Field
+from torch.quantization import QuantWrapper
 
 
-__all__ = ["get_leaf_operations", "is_quantized"]
+__all__ = ["get_leaf_operations", "is_quantized", "get_quantization_scheme"]
 
 
 def get_leaf_operations(model: torch.nn.Module) -> List[torch.nn.Module]:
@@ -28,56 +28,43 @@ def get_leaf_operations(model: torch.nn.Module) -> List[torch.nn.Module]:
     :param model: the model to get the leaf operations from
     :return: a list of the leaf operations
     """
-    return [
-        submodule
-        for submodule in model.modules()
-        if len(list(submodule.children())) == 0
-    ]
+    leaf_operations = []
+    children = list(model.children())
+
+    if children == []:
+        return model
+    else:
+        for child in children:
+            if isinstance(child, QuantWrapper):
+                # if QuantWrapper encountered, treat the wrapped
+                # module as a leaf operation
+                leaf_operations.append(child.module)
+                continue
+            try:
+                leaf_operations.extend(get_leaf_operations(child))
+            except TypeError:
+                leaf_operations.append(get_leaf_operations(child))
+    return leaf_operations
 
 
 def is_quantized(operation: torch.nn.Module) -> bool:
     """
-    Check whether the operation is quantized
+    Check whether the operation is quantized (contains
+    a quantization scheme)
     """
-    if hasattr(operation, "qscheme"):
-        return operation.qscheme is not None
-    return False
+    return hasattr(operation, "quantization_scheme")
 
 
-class QuantizationDtype(BaseModel):
+def get_quantization_scheme(
+    operation: torch.nn.Module,
+) -> Optional["QuantizationScheme"]:  # noqa F821
     """
-    Model for the quantization dtype of a model
+    Get the quantization scheme of the operation.
+    If the operation is not quantized, return None.
+
+    :param operation: the operation to get the quantization scheme from
+    :return: the quantization scheme of the operation or None if not quantized
     """
-
-    activation: Optional[torch.dtype] = Field(
-        default=None, description="The quantization dtype of activation function"
-    )
-    weight: Optional[torch.dtype] = Field(
-        default=None, description="The quantization dtype of weight function"
-    )
-
-    class Config:
-        arbitrary_types_allowed = True
-
-
-def get_dtype(operation: torch.nn.Module) -> QuantizationDtype:
-    """
-    Get the quantization dtype of the operation (both activation and weight).
-    If the operation is not quantized, return None for activation dtype and
-    original dtype of weight.
-
-    :param operation: the operation to get the quantization dtype from
-    :return: the quantization dtype of the operation
-    """
-    if hasattr(operation, "qconfig"):
-        if operation.qconfig is None:
-            pass
-        else:
-            return QuantizationDtype(
-                activation=operation.qconfig.activation.p.keywords["dtype"],
-                weight=operation.qconfig.weight.p.keywords["dtype"],
-            )
-    elif hasattr(operation, "weight"):
-        return QuantizationDtype(weight=operation.weight.dtype)
-
-    return QuantizationDtype()
+    if hasattr(operation, "quantization_scheme"):
+        return operation.quantization_scheme
+    return None

--- a/src/sparseml/pytorch/utils/sparsification_info/helpers.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/helpers.py
@@ -77,6 +77,4 @@ def get_quantization_scheme(
     :param operation: the operation to get the quantization scheme from
     :return: the quantization scheme of the operation or None if not quantized
     """
-    if hasattr(operation, "quantization_scheme"):
-        return operation.quantization_scheme
-    return None
+    return getattr(operation, "quantization_scheme", None)

--- a/src/sparseml/pytorch/utils/sparsification_info/helpers.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/helpers.py
@@ -23,8 +23,8 @@ __all__ = ["get_leaf_operations", "is_quantized", "get_quantization_scheme"]
 
 def get_leaf_operations(
     model: torch.nn.Module,
-    operations_to_skip: List[torch.nn.Module] = [Identity],
-    operations_to_unwrap: List[torch.nn.Module] = [QuantWrapper],
+    operations_to_skip: Optional[List[torch.nn.Module]] = None,
+    operations_to_unwrap: Optional[List[torch.nn.Module]] = None,
 ) -> List[torch.nn.Module]:
     """
     Get the leaf operations in the model
@@ -32,13 +32,22 @@ def get_leaf_operations(
 
     :param model: the model to get the leaf operations from
     :param operations_to_skip: a list of leaf operations that will be
-        omitted when getting the leaf operations
+        omitted when getting the leaf operations. If None passed, by
+        default the Identity operation will be skipped
     :param operations_to_unwrap: a list of operations that will be unwrapped
         when getting the leaf operations. Unwrapping means that we directly
-        add the module(s) that is/are wrapped by the operation to the list
-        of leaf operations
+        add the module(s) that is/are wrapped by the operation (i.e. operation's
+        `module` attribute) to the list
+        of leaf operations. If None passed, by default the QuantWrapper
+        operation will be unwrapped
     :return: a list of the leaf operations
     """
+    if operations_to_skip is None:
+        operations_to_skip = [Identity]
+
+    if operations_to_unwrap is None:
+        operations_to_unwrap = [QuantWrapper]
+
     leaf_operations = []
     children = list(model.children())
 

--- a/tests/sparseml/pytorch/utils/test_sparsification_info/__init__.py
+++ b/tests/sparseml/pytorch/utils/test_sparsification_info/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/sparseml/pytorch/utils/test_sparsification_info/test_configs.py
+++ b/tests/sparseml/pytorch/utils/test_sparsification_info/test_configs.py
@@ -105,11 +105,11 @@ class TestSparsificationModels:
         sparsification_pruning = SparsificationPruning.from_module(module=setup)
         for name, _ in setup.named_parameters():
             if name == "1.1.module.weight":
-                assert sparsification_pruning.zero_parameters[name].count == 31360
-                assert sparsification_pruning.zero_parameters[name].percent == 0.5
+                assert sparsification_pruning.sparse_parameters[name].count == 31360
+                assert sparsification_pruning.sparse_parameters[name].percent == 0.5
             else:
-                assert sparsification_pruning.zero_parameters[name].count == 0
-                assert sparsification_pruning.zero_parameters[name].percent == 0.0
+                assert sparsification_pruning.sparse_parameters[name].count == 0
+                assert sparsification_pruning.sparse_parameters[name].percent == 0.0
 
     def test_sparsification_quantization(self, setup):
         sparsification_quantization = SparsificationQuantization.from_module(
@@ -126,17 +126,17 @@ class TestSparsificationModels:
         for operation in is_quantization_enabled.keys():
             if operation == "Flatten":
                 assert (
-                    sparsification_quantization.quantization_schema[operation] is None
+                    sparsification_quantization.quantization_scheme[operation] is None
                 )
             else:
                 assert (
-                    sparsification_quantization.quantization_schema[
+                    sparsification_quantization.quantization_scheme[
                         operation
                     ].weights.num_bits
                     == 4
                 )
                 assert (
-                    sparsification_quantization.quantization_schema[
+                    sparsification_quantization.quantization_scheme[
                         operation
                     ].input_activations.num_bits
                     == 8

--- a/tests/sparseml/pytorch/utils/test_sparsification_info/test_configs.py
+++ b/tests/sparseml/pytorch/utils/test_sparsification_info/test_configs.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from sparseml.pytorch.optim import ScheduledModifierManager
+from sparseml.pytorch.utils.sparsification_info.configs import (
+    SparsificationPruning,
+    SparsificationQuantization,
+    SparsificationSummaries,
+)
+
+
+QUANT_RECIPE = """
+!QuantizationModifier
+    start_epoch: 0.0
+    scheme:
+        input_activations:
+            num_bits: 8
+            symmetric: False
+        weights:
+            num_bits: 4
+            symmetric: True
+        scheme_overrides:
+            classifier:
+                input_activations:
+                    num_bits: 8
+                    symmetric: False
+                weights: null
+            Conv2d:
+                input_activations:
+                    num_bits: 8
+                    symmetric: True
+        ignore: ["ReLU", "input"]
+        """
+
+
+def _create_test_model(quantization_recipe: str) -> torch.nn.Module:
+    sub_model_1 = torch.nn.Sequential(
+        torch.nn.Conv2d(1, 16, 3, padding=1),
+        torch.nn.ReLU(),
+        torch.nn.Conv2d(16, 32, 3, padding=1),
+        torch.nn.ReLU(),
+        torch.nn.MaxPool2d(2),
+    )
+    sub_model_2 = torch.nn.Sequential(
+        torch.nn.Flatten(), torch.nn.Linear(32 * 14 * 14, 10)
+    )
+
+    model = torch.nn.ModuleList([sub_model_1, sub_model_2])
+
+    # set some weights to zero to simulate pruning
+    named_parameters = dict(model.named_parameters())
+    named_parameters["1.1.weight"].data[:5, :] = torch.zeros_like(
+        named_parameters["1.1.weight"].data
+    )[:5, :]
+
+    manager = ScheduledModifierManager.from_yaml(quantization_recipe)
+    manager.apply(model)
+    return model
+
+
+@pytest.mark.parametrize(
+    "model", [_create_test_model(quantization_recipe=QUANT_RECIPE)]
+)
+class TestSparsificationModels:
+    @pytest.fixture()
+    def setup(self, model):
+        yield model
+
+    def test_sparsification_summaries(self, setup):
+        sparsification_summary = SparsificationSummaries.from_module(module=setup)
+        assert sparsification_summary.operation_counts == {
+            "ConvReLU2d": 2,
+            "Linear": 1,
+            "MaxPool2d": 1,
+            "Flatten": 1,
+        }
+        assert sparsification_summary.parameter_counts == {
+            "0.0.module.weight": 144,
+            "0.0.module.bias": 16,
+            "0.2.module.weight": 4608,
+            "0.2.module.bias": 32,
+            "1.1.module.weight": 62720,
+            "1.1.module.bias": 10,
+        }
+        assert sparsification_summary.pruned.count == 1
+        assert pytest.approx(0.166, sparsification_summary.pruned.percent)
+        assert sparsification_summary.quantized.count == 4
+        assert sparsification_summary.quantized.percent == 0.8
+
+    def test_sparsification_pruning(self, setup):
+        sparsification_pruning = SparsificationPruning.from_module(module=setup)
+        for name, _ in setup.named_parameters():
+            if name == "1.1.module.weight":
+                assert sparsification_pruning.zero_parameters[name].count == 31360
+                assert sparsification_pruning.zero_parameters[name].percent == 0.5
+            else:
+                assert sparsification_pruning.zero_parameters[name].count == 0
+                assert sparsification_pruning.zero_parameters[name].percent == 0.0
+
+    def test_sparsification_quantization(self, setup):
+        sparsification_quantization = SparsificationQuantization.from_module(
+            module=setup
+        )
+        is_quantization_enabled = {
+            "ConvReLU2d": True,
+            "ConvReLU2d_1": True,
+            "Linear": True,
+            "MaxPool2d": True,
+            "Flatten": False,
+        }
+        assert sparsification_quantization.enabled == is_quantization_enabled
+        for operation in is_quantization_enabled.keys():
+            if operation == "Flatten":
+                assert (
+                    sparsification_quantization.quantization_schema[operation] is None
+                )
+            else:
+                assert (
+                    sparsification_quantization.quantization_schema[
+                        operation
+                    ].weights.num_bits
+                    == 4
+                )
+                assert (
+                    sparsification_quantization.quantization_schema[
+                        operation
+                    ].input_activations.num_bits
+                    == 8
+                )


### PR DESCRIPTION
## Testing

### Example code

```python
ZOO_STUB = "zoo:cv/classification/resnet_v1-18/pytorch/sparseml/imagenet/pruned-conservative"
QUANT_RECIPE = """
!QuantizationModifier
    start_epoch: 0.0
    scheme:
        input_activations:
            num_bits: 8
            symmetric: False
        weights:
            num_bits: 8
            symmetric: True
        scheme_overrides:
            feature_extractor: "default"
            classifier:
                input_activations:
                    num_bits: 8
                    symmetric: False
                weights: null
            Conv2d:
                input_activations:
                    num_bits: 8
                    symmetric: True
        ignore: ["ReLU", "input"]
        disable_quantization_observer_epoch: 2.0
        freeze_bn_stats_epoch: 3.0
        model_fuse_fn_name: 'fuse_module'
        strict: True"""

# SparseZoo stub to pre-trained sparse-quantized ResNet-50 for imagenet dataset
model = ModelRegistry.create(
    key="resnet18",
    pretrained_path=ZOO_STUB,
)

manager = ScheduledModifierManager.from_yaml(QUANT_RECIPE)
manager.apply(model)

info = ModuleSparsificationInfo.from_module(model)
param_names = list(info.pruning_info.sparse_parameters.keys())
operations = list(info.quantization_info.enabled.keys())
for param_idx, param_name in enumerate(param_names):
    print(f"Param {param_idx}: {param_name}")
    print("Pruning information:")
    print(f"Count zero parameters: {info.pruning_info.sparse_parameters[param_name].count} / {info.pruning_info.sparse_parameters[param_name].percent} %")
    print(f"Count all parameters: {info.summary_info.parameter_counts[param_name]}")
    print('-------')
    if param_idx == 10:
        break
print("\n")
for op_idx, op_name in enumerate(operations):
    print(f"Operation {op_idx}: {op_name}")
    print("Quantization information:")
    print(f"Is operation quantized: {info.quantization_info.enabled[op_name]} / Quantization Scheme: {info.quantization_info.quantization_scheme[op_name]}")
    print('-------')

    if op_idx == 10:
        break

print("SUMMARY:")
print(f" Number/percentage of quantized ops: {info.summary_info.quantized}")
print(f" Number/percentage of pruned params: {info.summary_info.pruned}")
print(f"Operation count:")
for op, count in info.summary_info.operation_counts.items():
    print(f" {op}: {count}")
```
### Output

```bash
Param 0: input.conv.module.weight
Pruning information:
Count zero parameters: 0 / 0.0 %
Count all parameters: 9408
-------
Param 1: input.conv.module.bn.weight
Pruning information:
Count zero parameters: 0 / 0.0 %
Count all parameters: 64
-------
Param 2: input.conv.module.bn.bias
Pruning information:
Count zero parameters: 0 / 0.0 %
Count all parameters: 64
-------
Param 3: sections.0.0.conv1.module.weight
Pruning information:
Count zero parameters: 30412 / 0.8249782986111112 %
Count all parameters: 36864
-------
Param 4: sections.0.0.conv1.module.bn.weight
Pruning information:
Count zero parameters: 0 / 0.0 %
Count all parameters: 64
-------
Param 5: sections.0.0.conv1.module.bn.bias
Pruning information:
Count zero parameters: 0 / 0.0 %
Count all parameters: 64
-------
Param 6: sections.0.0.conv2.module.weight
Pruning information:
Count zero parameters: 32256 / 0.875 %
Count all parameters: 36864
-------
Param 7: sections.0.0.conv2.module.bn.weight
Pruning information:
Count zero parameters: 0 / 0.0 %
Count all parameters: 64
-------
Param 8: sections.0.0.conv2.module.bn.bias
Pruning information:
Count zero parameters: 0 / 0.0 %
Count all parameters: 64
-------
Param 9: sections.0.1.conv1.module.weight
Pruning information:
Count zero parameters: 33177 / 0.8999837239583334 %
Count all parameters: 36864
-------
Param 10: sections.0.1.conv1.module.bn.weight
Pruning information:
Count zero parameters: 0 / 0.0 %
Count all parameters: 64
-------


Operation 0: ConvBnReLU2d
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
Operation 1: MaxPool2d
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
Operation 2: ConvBnReLU2d_1
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
Operation 3: ConvBn2d
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
Operation 4: ConvBnReLU2d_2
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
Operation 5: ConvBn2d_1
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
Operation 6: ConvBnReLU2d_3
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
Operation 7: ConvBn2d_2
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
Operation 8: ConvBn2d_3
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
Operation 9: ConvBnReLU2d_4
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
Operation 10: ConvBn2d_4
Quantization information:
Is operation quantized: True / Quantization Scheme: {'input_activations': {'num_bits': 8, 'symmetric': False, 'kwargs': {}}, 'weights': {'num_bits': 8, 'symmetric': True, 'kwargs': {}}, 'output_activations': 'null', 'target_hardware': 'null'}
-------
SUMMARY:
 Number/percentage of quantized ops: count=24 percent=1.0
 Number/percentage of pruned params: count=19 percent=0.3064516129032258
Operation count:
 ConvBnReLU2d: 9
 MaxPool2d: 1
 ConvBn2d: 11
 AdaptiveAvgPool2d: 1
 Linear: 1
 Softmax: 1
```





