### PR TITLE
[torchvision][Bug-fix] ignore state dict error on transfer learning tasks + use PythonLogger default logger

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -759,11 +759,33 @@ def _create_model(
             model, arch_key = model
     elif arch_key in torchvision.models.__dict__:
         # fall back to torchvision
-        model = torchvision.models.__dict__[arch_key](
-            pretrained=pretrained, num_classes=num_classes
-        )
+        model = torchvision.models.__dict__[arch_key](num_classes=num_classes)
+        if pretrained is not None:
+            pretrained_model = torchvision.models.__dict__[arch_key](
+                pretrained=pretrained
+            )
+            if (
+                getattr(pretrained_model, "classifier", None)
+                and pretrained_model.classifier.out_features != num_classes
+            ):
+                del pretrained_model.classifier
+            model.load_state_dict(pretrained_model.state_dict(), strict=False)
         if checkpoint_path is not None:
-            load_model(checkpoint_path, model, strict=True)
+            load_model(
+                checkpoint_path,
+                model,
+                strict=True,
+                ignore_error_tensors=[
+                    "classifier.fc.weight",
+                    "classifier.fc.bias",
+                    "classifier.1.weight",
+                    "classifier.1.bias",
+                    "fc.weight",
+                    "fc.bias",
+                    "classifier.weight",
+                    "classifier.bias",
+                ],
+            )
     else:
         raise ValueError(
             f"Unable to find {arch_key} in ModelRegistry or in torchvision.models"


### PR DESCRIPTION
When loading a pre-trained torchvision model, an error will occur if the number of classes in the target dataset doesn't match the number of classes in the pre-trained model. e.g. when using a smaller subset of the original dataset. This PR fixes that issue by ignoring the classification head in the loaded model dict. Note that in some cases (such as inceptionet) it will fail, as for some models the classification head naming doesn't follow the standard naming pattern.

Test plan
`sparseml.image_classification.train --checkpoint-path verizon_dense.pt --arch-key densenet121 --dataset-path /network/datasets/imagenette-160/imagenette-160 --pretrained True`