### PR TITLE
[torchvision IC] catch import error for instantiation of optional tensorboard logger

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -578,8 +578,11 @@ def main(args):
     if utils.is_main_process():
         loggers = [
             PythonLogger(logger=_LOGGER),
-            TensorBoardLogger(log_path=args.output_dir),
         ]
+        try:
+            loggers.append(TensorBoardLogger(log_path=args.output_dir))
+        except (ModuleNotFoundError, ImportError):
+            warnings.warn("Unable to import tensorboard for logging")
         try:
             config = vars(args)
             if manager is not None:


### PR DESCRIPTION
tensorboard is now an optional dependency and the logger should only be instantiated during torchvision training if it is present. this patch catches the error and raises a warning


**test_plan:**
manually verified for example command:
```bash
sparseml.image_classification.train     --recipe "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/pruned-conservative?recipe_type=original"     --dataset-path /home/data/imagenette/imagenette-320     --pretrained True     --arch-key resnet50     --batch-size 128     --workers 8     --output-dir sparsification_example/resnet50-imagenette-pruned     --save-best-after 8
Not using distributed mode
```

warnings before training:
```bash
sparseml/src/sparseml/pytorch/torchvision/train.py:585: UserWarning: Unable to import tensorboard for logging
  warnings.warn("Unable to import tensorboard for logging")
sparseml/src/sparseml/pytorch/torchvision/train.py:592: UserWarning: Unable to import wandb for logging
  warnings.warn("Unable to import wandb for logging")
```