### PR TITLE
Fix hook registration when some parameters do not require grad

### DIFF
--- a/src/sparseml/pytorch/optim/mask_pruning.py
+++ b/src/sparseml/pytorch/optim/mask_pruning.py
@@ -540,7 +540,7 @@ class ModuleParamPruningMask(object):
             if self._gradient_hooks[idx] is None:
                 self._gradient_hooks[idx] = param.register_hook(
                     partial(self._hook_mask_gradient, idx)
-                )
+                ) if param.requires_grad else None
 
     def _delete_hooks(self):
         if not hasattr(self, "_params"):

--- a/src/sparseml/pytorch/sparsification/pruning/mask_params.py
+++ b/src/sparseml/pytorch/sparsification/pruning/mask_params.py
@@ -514,7 +514,7 @@ class ModuleParamPruningMask(object):
             if self._gradient_hooks[idx] is None:
                 self._gradient_hooks[idx] = param.register_hook(
                     partial(self._hook_mask_gradient, idx)
-                )
+                ) if param.requires_grad else None
 
     def _delete_hooks(self):
         if not hasattr(self, "_params"):


### PR DESCRIPTION
This PR fixes https://github.com/neuralmagic/sparseml/issues/1438

When setting trainable=false to some parameters using a Training Modifier, the training fails because SparseML tries to create hooks on parameters that do not require grad.

I do not know if this is the correct way to do that, but it fixed the issue I had