### PR TITLE
Disable EMA for YOLOv8 during QAT

### DIFF
--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -427,10 +427,6 @@ class SparseTrainer(BaseTrainer):
             else None,
             "updates": self.ema.updates if self.ema and self.ema.enabled else None,
             "optimizer": self.optimizer.state_dict(),
-            "ema": deepcopy(self.ema.ema).state_dict()
-            if self.ema and self.ema.enabled
-            else None,
-            "updates": self.ema.updates if self.ema and self.ema.enabled else None,
             "train_args": vars(self.args),
             "date": datetime.now().isoformat(),
             "version": __version__,

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -417,15 +417,16 @@ class SparseTrainer(BaseTrainer):
             manager = self.manager if self.manager is not None else None
 
         model = de_parallel(self.model)
-        is_quant = manager.quantization_modifiers
         ckpt = {
             "epoch": epoch,
             "best_fitness": self.best_fitness,
             "model": deepcopy(model).state_dict(),
             "model_yaml": dict(model.yaml),
             "optimizer": self.optimizer.state_dict(),
-            "ema": deepcopy(self.ema.ema).state_dict() if not is_quant else None,
-            "updates": self.ema.updates if not is_quant else None,
+            "ema": deepcopy(self.ema.ema).state_dict()
+            if self.ema and self.ema.enabled
+            else None,
+            "updates": self.ema.updates if self.ema and self.ema.enabled else None,
             "train_args": vars(self.args),
             "date": datetime.now().isoformat(),
             "version": __version__,

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -311,12 +311,6 @@ class SparseTrainer(BaseTrainer):
             if self.manager.learning_rate_modifiers:
                 self.scheduler = _NullLRScheduler()
 
-            if self.manager.quantization_modifiers and self.ema is not None:
-                # Training loop upstream does not always check the validity of
-                # the EMA model at every callsites. We therefore cannot simply
-                # turn it into None without breaking the code.
-                self.ema.enabled = False
-
             # NOTE: we intentionally don't divide number of batches by gradient
             # accumulation.
             # This is because yolov8 changes size of gradient accumulation during

--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -36,7 +36,7 @@ class SparseValidator(BaseValidator):
         if self.training:
             self.device = trainer.device
             self.data = trainer.data
-            if trainer.manager.quantization_modifiers:
+            if trainer.manager and trainer.manager.quantization_modifiers:
                 # Since we disable the EMA model for QAT, we validate the non-averaged
                 # QAT model
                 model = de_parallel(trainer.model)

--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -39,7 +39,7 @@ class SparseValidator(BaseValidator):
             if trainer.manager.quantization_modifiers:
                 # Since we disable the EMA model for QAT, we validate the non-averaged
                 # QAT model
-                model = trainer.model
+                model = de_parallel(trainer.model)
             else:
                 model = trainer.ema.ema or trainer.model
 

--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -36,7 +36,13 @@ class SparseValidator(BaseValidator):
         if self.training:
             self.device = trainer.device
             self.data = trainer.data
-            model = trainer.ema.ema or trainer.model
+            if trainer.manager.quantization_modifiers:
+                # Since we disable the EMA model for QAT, we validate the non-averaged
+                # QAT model
+                model = trainer.model
+            else:
+                model = trainer.ema.ema or trainer.model
+
             # self.args.half = self.device.type != "cpu"
             model = model.half() if self.args.half else model.float()
             self.model = model
@@ -128,10 +134,14 @@ class SparseValidator(BaseValidator):
             with dt[3]:
                 preds = self.postprocess(preds)
 
-            self.update_metrics(preds, batch)
+            # During QAT the resulting preds are grad required, breaking
+            # the update metrics function.
+            detached_preds = [p.detach() for p in preds]
+            self.update_metrics(detached_preds, batch)
+
             if self.args.plots and batch_i < 3:
                 self.plot_val_samples(batch, batch_i)
-                self.plot_predictions(batch, preds, batch_i)
+                self.plot_predictions(batch, detached_preds, batch_i)
 
             self.run_callbacks("on_val_batch_end")
         stats = self.get_stats()


### PR DESCRIPTION
This PR disables EMA for quantization with QAT and uses the (non-averaged) model during validation (otherwise, by the fault the EMA is used, which is not updated for QAT causing constant metrics being logged).

Another issue coming up: with this new validation, I can no longer run with multiple GPUs. 