### PR TITLE
[ONNX] override_model_input_shape helper function

### DIFF
--- a/src/sparseml/onnx/utils/helpers.py
+++ b/src/sparseml/onnx/utils/helpers.py
@@ -74,6 +74,7 @@ __all__ = [
     "get_tensor_shape",
     "get_tensor_dim_shape",
     "set_tensor_dim_shape",
+    "override_model_input_shape",
 ]
 
 
@@ -1233,3 +1234,25 @@ def set_tensor_dim_shape(tensor: onnx.TensorProto, dim: int, value: int):
     :param value: new shape for the given dimension
     """
     tensor.type.tensor_type.shape.dim[dim].dim_value = value
+
+
+def override_model_input_shape(model: Union[str, onnx.ModelProto], shape: List[int]):
+    """
+    Set the shape of the first input of the given model to the given shape.
+    If given a file, the file will be overwritten
+
+    :param model: ONNX model or model path to overrwrite
+    :param shape: shape as list of integers to override with. must match
+        existing dimensions
+    """
+    if isinstance(model, str):
+        model_path = model
+        model = onnx.load(model)
+    else:
+        model_path = None
+
+    for dim, dim_size in enumerate(shape):
+        set_tensor_dim_shape(model.graph.input[0], dim, dim_size)
+
+    if model_path:
+        onnx.save(model, model_path)


### PR DESCRIPTION
simple helper function to override an ONNX graph's input shape to a target shape

added to set a hardcoded starting shape for yolov5 graph exports with dynamic shape. (dynamic shape export is required to change image size, however deepsparse engine requires a static input shape and static input shapes provide good information for model analysis and shape inference)

**test_plan:**
manual, see yolov5 pr for extensive testing