### PR TITLE
[Bug-fix] Set explicit stream handler for modifier logger

### DIFF
--- a/src/sparseml/pytorch/utils/logger.py
+++ b/src/sparseml/pytorch/utils/logger.py
@@ -355,7 +355,8 @@ class PythonLogger(LambdaLogger):
         :return: logger
         """
         logger = logging.getLogger(__name__)
-        # File handler set up, for logging modifier debug statements
+
+        # File handler setup, for logging modifier debug statements
         base_log_path = (
             os.environ.get("NM_TEST_LOG_DIR")
             if os.environ.get("NM_TEST_MODE")


### PR DESCRIPTION
The modifier debug file logging flow is currently broken. Debug logs aren't getting propagated to the modifier file handler, as the modifier logger logging level is usually set at a level above debug. 

This PR fixes that by adding a stream handler to the default modifier logger and setting the modifier logging level to debug, leaving the level filtering to the handlers.

It also includes minor cleanup to make the code easier to read

Test plan
Existing unit tests in addition to running with the command below

```
sparseml.image_classification.train \
    --recipe zoo:cv/classification/efficientnet-b0/pytorch/sparseml/imagenet/base_quant-none \
    --checkpoint-path zoo:cv/classification/efficientnet-b0/pytorch/sparseml/imagenet/base-none \
    --arch-key efficientnetb0 \
    --dataset-path /network/datasets/imagenet_calib \
    --batch-size 32 \
    --train-crop-size 224 \
    --val-crop-size 224 \
    --val-resize-size 256 \
    --weight-decay 0.00001 \
    --interpolation bicubic \
    --random-erase 0.1 \
    --label-smoothing 0.1 \
    --opt rmsprop \
    --model-ema \
    --norm-weight-decay 0.0 \
    --teacher-arch-key efficientnetb0 \
    --distill-teacher zoo:cv/classification/efficientnet-b0/pytorch/sparseml/imagenet/base-none \
    --pretrained-teacher-dataset imagenet
```