### PR TITLE
[Fix] `ModelAnalysis` imports

### DIFF
--- a/tests/sparseml/pytorch/image_classification/test_export.py
+++ b/tests/sparseml/pytorch/image_classification/test_export.py
@@ -22,7 +22,7 @@ import torch
 from click.testing import CliRunner
 from sparseml.pytorch.image_classification.export import main
 from sparseml.pytorch.models import resnet18
-from sparsezoo.analysis import ModelAnalysis
+from sparsezoo.analyze import ModelAnalysis
 
 
 @pytest.fixture()


### PR DESCRIPTION
This PR fixes `ModelAnalysis` imports as it's been  migrated to a new namespace
Fixes: https://github.com/neuralmagic/sparseml/actions/runs/4494873417/jobs/7907921277