### PR TITLE
[Bug-fix] Skip saving recipe for runs without one

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -716,7 +716,7 @@ def main(args):
                 )
             else:
                 checkpoint["epoch"] = -1 if epoch == max_epochs - 1 else epoch
-                if str(manager) is not None:
+                if manager is not None:
                     checkpoint["recipe"] = str(manager)
 
             file_names = ["checkpoint.pth"]


### PR DESCRIPTION
Quick fix to avoid saving a recipe as 'None' if a recipe isn't used. This avoids a checkpoint loading error when using the dense checkpoint as a starting point for another run

**Test plan**
`sparseml.image_classification.train --arch-key densenet121 --dataset-path /network/datasets/imagenette2-160 --pretrained True --epochs 1 --output-dir densenet`

followed by

`sparseml.image_classification.train --arch-key densenet121 --checkpoint-path densenet/checkpoint.pth --dataset-path /network/datasets/imagenette2-160 --pretrained True --epochs 1`