### PR TITLE
Fix for legacy quantization modifier w/ DDP

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/legacy_modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/legacy_modifier_quantization.py
@@ -504,6 +504,8 @@ class QuantizationModifier(ScheduledModifier):
         if self._submodules is not None:
             found_submodules = []
             for name, submodule in module.named_modules():
+                if name.startswith('module.'):
+                    name = name[7:]
                 if name in self._submodules:
                     self._modules_to_quantize.append(_ModuleToQuantize(name, submodule))
                     found_submodules.append(name)

--- a/src/sparseml/pytorch/sparsification/quantization/legacy_modifier_quantization.py
+++ b/src/sparseml/pytorch/sparsification/quantization/legacy_modifier_quantization.py
@@ -504,7 +504,7 @@ class QuantizationModifier(ScheduledModifier):
         if self._submodules is not None:
             found_submodules = []
             for name, submodule in module.named_modules():
-                if name.startswith('module.'):
+                if name.startswith("module."):
                     name = name[7:]
                 if name in self._submodules:
                     self._modules_to_quantize.append(_ModuleToQuantize(name, submodule))


### PR DESCRIPTION
Remove "module." added by DDP when identifying the submodules for quantization.

Testing plan:
Reproduced the quantization piece of this model:
https://sparsezoo.neuralmagic.com/models/cv%2Fclassification%2Fresnet_v1-50%2Fpytorch%2Fsparseml%2Fimagenet%2Fpruned95_quant-none


Before the fix the quantization was failing