### PR TITLE
Modify YoloV8 arch for quantization

### DIFF
--- a/src/sparseml/yolov8/modules.py
+++ b/src/sparseml/yolov8/modules.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch.nn as nn
+
+from ultralytics.nn import modules as ulm
+
+
+class Conv(nn.Module):
+    """
+    Slightly modified version of ultralytics Conv with SiLU instantiated
+    for each instance. This is to help with SiLU naming in SparseML recipe
+    """
+
+    def __init__(self, layer: ulm.Conv):
+        super().__init__()
+        self.conv = layer.conv
+        self.bn = layer.bn
+        is_silu = isinstance(layer.act, nn.SiLU)
+        self.act = nn.SiLU() if is_silu else layer.act
+
+    def forward(self, x):
+        return self.act(self.bn(self.conv(x)))
+
+    def forward_fuse(self, x):
+        return self.act(self.conv(x))
+
+
+class AddInput(nn.Module):
+    """
+    Equivalent to Identity for quantization support
+    """
+
+    def forward(self, x):
+        return x
+
+
+class Bottleneck(nn.Module):
+    """
+    Modified version of ultralyltics Bottleneck with inputs of the residual
+    adds being marked for potential quantization
+    """
+
+    def __init__(self, layer: ulm.Bottleneck):
+        super().__init__()
+        self.cv1 = layer.cv1
+        self.cv2 = layer.cv2
+        self.add = layer.add
+        self.add_input_0 = AddInput()
+        self.add_input_1 = AddInput()
+
+    def forward(self, x):
+        return (
+            self.add_input_0(x) + self.add_input_1(self.cv2(self.cv1(x)))
+            if self.add
+            else self.cv2(self.cv1(x))
+        )

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -21,7 +21,7 @@ import warnings
 from copy import copy, deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import onnx
 import torch
@@ -31,6 +31,7 @@ from sparseml.pytorch.optim.manager import ScheduledModifierManager
 from sparseml.pytorch.utils import ModuleExporter
 from sparseml.pytorch.utils.helpers import download_framework_model_by_recipe_type
 from sparseml.pytorch.utils.logger import LoggerManager, PythonLogger, WANDBLogger
+from sparseml.yolov8.modules import Bottleneck, Conv
 from sparseml.yolov8.utils.export_samples import export_sample_inputs_outputs
 from sparseml.yolov8.validators import (
     SparseClassificationValidator,
@@ -200,11 +201,22 @@ class SparseTrainer(BaseTrainer):
         LOGGER.info("Loaded previous weights from sparseml checkpoint")
         return ckpt
 
+    def _modify_arch_for_quantization(self):
+        layer_map = {"Bottleneck": Bottleneck, "Conv": Conv}
+        for name, layer in self.model.named_modules():
+            cls_name = layer.__class__.__name__
+            if cls_name in layer_map:
+                submodule_path = name.split(".")
+                parent_module = _get_submodule(self.model, submodule_path[:-1])
+                setattr(parent_module, submodule_path[-1], layer_map[cls_name](layer))
+
     def _build_managers(self, ckpt: Optional[dict]):
         if self.args.recipe is not None:
             self.manager = ScheduledModifierManager.from_yaml(
                 self.args.recipe, recipe_variables=self.args.recipe_args
             )
+            if self.manager.quantization_modifiers:
+                self._modify_arch_for_quantization()
 
         if ckpt is None:
             return
@@ -218,6 +230,8 @@ class SparseTrainer(BaseTrainer):
                 f"at epoch {ckpt['epoch']}"
             )
             self.checkpoint_manager = ScheduledModifierManager.from_yaml(ckpt["recipe"])
+            if self.checkpoint_manager.quantization_modifiers:
+                self._modify_arch_for_quantization()
             self.checkpoint_manager.apply_structure(self.model, epoch=float("inf"))
 
         else:
@@ -228,6 +242,8 @@ class SparseTrainer(BaseTrainer):
                 "Applying structure from un-finished recipe in checkpoint "
                 f"at epoch {ckpt['epoch']}"
             )
+            if self.manager.quantization_modifiers:
+                self._modify_arch_for_quantization()
             self.manager.apply_structure(self.model, epoch=ckpt["epoch"])
 
     def resume_training(self, ckpt):
@@ -730,3 +746,9 @@ def generate_ddp_file(trainer):
     ) as file:
         file.write(content)
     return file.name
+
+
+def _get_submodule(module: torch.nn.Module, path: List[str]) -> torch.nn.Module:
+    if not path:
+        return module
+    return _get_submodule(getattr(module, path[0]), path[1:])


### PR DESCRIPTION
To allow for more control in quantizing residual adds in Yolov8, this PR marks their inputs with custom identity modules that can be manipulate from the recipe. It does so by overwrite ultralytics's Bottleneck with SparseML's version.

It also overwrite ultralytics's Conv with separately instantiated SiLU to help to resolve naming issue in the recipe.

Qualification: manually verify quantization graph before training loop.