### PR TITLE
Fix for QAT on new IC flow

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -180,7 +180,7 @@ def evaluate(
     header = f"Test: {log_suffix}"
 
     num_processed_samples = 0
-    with torch.inference_mode():
+    with torch.no_grad():
         for image, target in metric_logger.log_every(data_loader, print_freq, header):
             image = image.to(device, non_blocking=True)
             target = target.to(device, non_blocking=True)


### PR DESCRIPTION
Replaces inference_mode by no_grad. It prevents setting observer attributes in inference mode, which can't be changed during training afterwards.

Testing plan:
Completed a QAT run on ResNet50 model: https://wandb.ai/neuralmagic/alexandre_debug/workspace?workspace=user-neuralmagic
