### PR TITLE
[BugFix] Crash when num labels in dataset is < 5

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -82,7 +82,7 @@ def train_one_epoch(
     )
     metric_logger.add_meter("loss", utils.SmoothedValue(window_size=accum_steps))
     metric_logger.add_meter("acc1", utils.SmoothedValue(window_size=accum_steps))
-    if not num_classes or num_classes > 4:
+    if not num_classes or num_classes >= 5:
         metric_logger.add_meter("acc5", utils.SmoothedValue(window_size=accum_steps))
 
     steps_accumulated = 0
@@ -143,7 +143,7 @@ def train_one_epoch(
                 # Reset ema buffer to keep copying weights during warmup period
                 model_ema.n_averaged.fill_(0)
 
-        if not num_classes or num_classes > 4:
+        if not num_classes or num_classes >= 5:
             acc1, num_correct_1, acc5, num_correct_5 = utils.accuracy(
                 output, target, topk=(1, 5)
             )
@@ -156,7 +156,7 @@ def train_one_epoch(
             acc1.item(), n=batch_size, total=num_correct_1
         )
 
-        if not num_classes or num_classes > 4:
+        if not num_classes or num_classes >= 5:
             metric_logger.meters["acc5"].update(
                 acc5.item(), n=batch_size, total=num_correct_5
             )
@@ -216,7 +216,7 @@ def evaluate(
                 acc1.item(), n=batch_size, total=num_correct_1
             )
 
-            if not num_classes or num_classes >= 4:
+            if not num_classes or num_classes >= 5:
                 metric_logger.meters["acc5"].update(
                     acc5.item(), n=batch_size, total=num_correct_5
                 )
@@ -241,7 +241,7 @@ def evaluate(
     metric_logger.synchronize_between_processes()
 
     log_message = header + f"Acc@1 {metric_logger.acc1.global_avg:.3f}"
-    if not num_classes or num_classes >= 4:
+    if not num_classes or num_classes >= 5:
         log_message += f"Acc@5 {metric_logger.acc5.global_avg:.3f}"
 
     _LOGGER.info(log_message)


### PR DESCRIPTION
This PR fixes a bug in our IC integration, where the script would fail with the following output when num labels in the dataset were found to be less than 5.

```bash
Traceback (most recent call last):

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/bin/sparseml.image_classification.train", line 8, in <module>

    sys.exit(cli())

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/lib/python3.8/site-packages/sparseml/pytorch/torchvision/train.py", line 868, in new_func

    return f(*args, **kwargs)

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/lib/python3.8/site-packages/click/core.py", line 1128, in __call__

    return self.main(*args, **kwargs)

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/lib/python3.8/site-packages/click/core.py", line 1053, in main

    rv = self.invoke(ctx)

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/lib/python3.8/site-packages/click/core.py", line 1395, in invoke

    return ctx.invoke(self.callback, **ctx.params)

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/lib/python3.8/site-packages/click/core.py", line 754, in invoke

    return __callback(*args, **kwargs)

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func

    return f(get_current_context(), *args, **kwargs)

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/lib/python3.8/site-packages/sparseml/pytorch/torchvision/train.py", line 1187, in cli

    main(SimpleNamespace(**kwargs))

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/lib/python3.8/site-packages/sparseml/pytorch/torchvision/train.py", line 650, in main

    train_metrics = train_one_epoch(

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/lib/python3.8/site-packages/sparseml/pytorch/torchvision/train.py", line 143, in train_one_epoch

    acc1, num_correct_1, acc5, num_correct_5 = utils.accuracy(

  File "/home/ubuntu/rshaw/python-venvs/sparseml-env/lib/python3.8/site-packages/sparseml/pytorch/torchvision/utils.py", line 209, in accuracy

    _, pred = output.topk(maxk, 1, True, True)

RuntimeError: selected index k out of range
```
This happened because we assume in the script that num_labels are always > 5

Current PR addresses the above problem by:
- propagating num_classes to appropriate function
- only log top 5 accuracy when num labels is > 5 (this entails wrapping with an if statement wherever top5 accuracy was being access)


Test: Successful completion of train epoch 0 manually with the following
Command:
```bash
sparseml.image_classification.train \
    --recipe "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none?recipe_type=transfer-classification" \
    --checkpoint-path "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_quant-none" \
    --arch-key resnet50 \
    --dataset-path /home/rahul/datasets/imagenette-small
```
Where `imagenette-small` is a self created dataset with 2 classes only

Output:
```bash
2023-04-03 09:12:43 __main__     INFO     namespace(amp=False, arch_key='resnet50', augmix_severity=3, auto_augment=None, batch_size=32, bias_weight_decay=None, cache_dataset=False, checkpoint_path='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_quant-none', clip_grad_norm=None, cutmix_alpha=0.0, dataset_path='/home/rahul/datasets/imagenette-small', device=None, dist_url='env://', distill_teacher=None, distributed=False, epochs=10, eval_steps=None, gradient_accum_steps=1, interpolation='bilinear', label_smoothing=0.0, logging_steps=100, lr=0.1, lr_gamma=0.1, lr_min=0.0, lr_scheduler='steplr', lr_step_size=30, lr_warmup_decay=0.01, lr_warmup_epochs=0, lr_warmup_method='constant', mixup_alpha=0.0, model_ema=False, model_ema_decay=0.99998, model_ema_steps=32, momentum=0.9, norm_weight_decay=None, opt='sgd', output_dir='.', pretrained='True', pretrained_dataset=None, pretrained_teacher_dataset=None, print_freq=None, ra_magnitude=9, ra_reps=3, ra_sampler=False, random_erase=0.0, recipe='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none?recipe_type=transfer-classification', recipe_args=None, resume=None, save_best_after=1, start_epoch=0, sync_bn=False, teacher_arch_key=None, test_only=False, train_crop_size=224, transformer_embedding_decay=None, use_deterministic_algorithms=False, val_crop_size=224, val_resize_size=256, weight_decay=0.0001, workers=16, world_size=1)
2023-04-03 09:12:43 __main__     INFO     namespace(amp=False, arch_key='resnet50', augmix_severity=3, auto_augment=None, batch_size=32, bias_weight_decay=None, cache_dataset=False, checkpoint_path='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95_quant-none', clip_grad_norm=None, cutmix_alpha=0.0, dataset_path='/home/rahul/datasets/imagenette-small', device=None, dist_url='env://', distill_teacher=None, distributed=False, epochs=10, eval_steps=None, gradient_accum_steps=1, interpolation='bilinear', label_smoothing=0.0, logging_steps=100, lr=0.1, lr_gamma=0.1, lr_min=0.0, lr_scheduler='steplr', lr_step_size=30, lr_warmup_decay=0.01, lr_warmup_epochs=0, lr_warmup_method='constant', mixup_alpha=0.0, model_ema=False, model_ema_decay=0.99998, model_ema_steps=32, momentum=0.9, norm_weight_decay=None, opt='sgd', output_dir='.', pretrained='True', pretrained_dataset=None, pretrained_teacher_dataset=None, print_freq=None, ra_magnitude=9, ra_reps=3, ra_sampler=False, random_erase=0.0, recipe='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none?recipe_type=transfer-classification', recipe_args=None, resume=None, save_best_after=1, start_epoch=0, sync_bn=False, teacher_arch_key=None, test_only=False, train_crop_size=224, transformer_embedding_decay=None, use_deterministic_algorithms=False, val_crop_size=224, val_resize_size=256, weight_decay=0.0001, workers=16, world_size=1)
2023-04-03 09:12:43 __main__     INFO     Loading data
2023-04-03 09:12:43 __main__     INFO     Loading data
2023-04-03 09:12:43 __main__     INFO     Loading training data
2023-04-03 09:12:43 __main__     INFO     Loading training data
2023-04-03 09:12:43 __main__     INFO     Took 0.007406473159790039
2023-04-03 09:12:43 __main__     INFO     Took 0.007406473159790039
2023-04-03 09:12:43 __main__     INFO     Loading validation data
2023-04-03 09:12:43 __main__     INFO     Loading validation data
2023-04-03 09:12:43 __main__     INFO     Creating data loaders
2023-04-03 09:12:43 __main__     INFO     Creating data loaders
2023-04-03 09:12:43 __main__     INFO     Creating model
2023-04-03 09:12:43 __main__     INFO     Creating model
2023-04-03 09:12:43 sparseml.pytorch.utils.logger INFO     Logging all SparseML modifier-level logs to sparse_logs/03-04-2023_09.12.43.log
INFO:sparseml.pytorch.utils.logger:Logging all SparseML modifier-level logs to sparse_logs/03-04-2023_09.12.43.log
/home/rahul/projects/sparseml/src/sparseml/pytorch/torchvision/train.py:566: UserWarning: Optimizer state dict not loaded from checkpoint. Unless run is resumed with the --resume arg, the optimizer will start from a fresh state
  warnings.warn(
/home/rahul/projects/sparseml/src/sparseml/pytorch/torchvision/train.py:615: UserWarning: Unable to import wandb for logging
  warnings.warn("Unable to import wandb for logging")
2023-04-03 09:12:49 __main__     INFO     Start training
2023-04-03 09:12:49 __main__     INFO     Start training
INFO:__main__:Start training
2023-04-03 09:12:49 __main__     INFO     Expected dataset to have move than 5 classes but found 2 only top1 metrics will be reported during eval
2023-04-03 09:12:49 __main__     INFO     Expected dataset to have move than 5 classes but found 2 only top1 metrics will be reported during eval
INFO:__main__:Expected dataset to have move than 5 classes but found 2 only top1 metrics will be reported during eval
2023-04-03 09:12:51 __main__     INFO     Epoch: [0]  [ 0/82]  eta: 0:02:45  lr: 0.0005  imgs_per_sec: 21.60780920924898  loss: 0.6741 (0.6741)  acc1: 65.6250 (65.6250)  time: 2.0162  data: 0.5352  max mem: 8766
2023-04-03 09:12:51 __main__     INFO     Epoch: [0]  [ 0/82]  eta: 0:02:45  lr: 0.0005  imgs_per_sec: 21.60780920924898  loss: 0.6741 (0.6741)  acc1: 65.6250 (65.6250)  time: 2.0162  data: 0.5352  max mem: 8766
INFO:__main__:Epoch: [0]  [ 0/82]  eta: 0:02:45  lr: 0.0005  imgs_per_sec: 21.60780920924898  loss: 0.6741 (0.6741)  acc1: 65.6250 (65.6250)  time: 2.0162  data: 0.5352  max mem: 8766
2023-04-03 09:13:07 __main__     INFO     Epoch: [0] Total time: 0:00:18
2023-04-03 09:13:07 __main__     INFO     Epoch: [0] Total time: 0:00:18
INFO:__main__:Epoch: [0] Total time: 0:00:18
2023-04-03 09:13:08 __main__     INFO     Test:   [0/4]  eta: 0:00:01  loss: 0.0470 (0.0470)  acc1: 96.8750 (96.8750)  time: 0.4978  data: 0.4163  max mem: 8766
2023-04-03 09:13:08 __main__     INFO     Test:   [0/4]  eta: 0:00:01  loss: 0.0470 (0.0470)  acc1: 96.8750 (96.8750)  time: 0.4978  data: 0.4163  max mem: 8766
INFO:__main__:Test:   [0/4]  eta: 0:00:01  loss: 0.0470 (0.0470)  acc1: 96.8750 (96.8750)  time: 0.4978  data: 0.4163  max mem: 8766
2023-04-03 09:13:08 __main__     INFO     Test:  Total time: 0:00:00
2023-04-03 09:13:08 __main__     INFO     Test:  Total time: 0:00:00
INFO:__main__:Test:  Total time: 0:00:00
2023-04-03 09:13:08 __main__     INFO     Test: Acc@1 99.000
2023-04-03 09:13:08 __main__     INFO     Test: Acc@1 99.000
INFO:__main__:Test: Acc@1 99.000
2023-04-03 09:13:09 __main__     INFO     Epoch: [1]  [ 0/82]  eta: 0:01:00  lr: 0.00048800884649231267  imgs_per_sec: 102.99247072545619  loss: 0.1002 (0.1002)  acc1: 96.8750 (96.8750)  time: 0.7392  data: 0.4285  max mem: 8766
2023-04-03 09:13:09 __main__     INFO     Epoch: [1]  [ 0/82]  eta: 0:01:00  lr: 0.00048800884649231267
```

