### PR TITLE
Update RN50 for QAT

### DIFF
--- a/src/sparseml/pytorch/models/classification/resnet.py
+++ b/src/sparseml/pytorch/models/classification/resnet.py
@@ -140,26 +140,9 @@ class _IdentityModifier(Module):
         return in_channels != out_channels or stride > 1
 
 
-class _AddReLU(Module):
-    """
-    Wrapper for the FloatFunctional class that enables QATWrapper used to
-    quantize the first input to the Add operation
-    """
-
-    def __init__(self, num_channels):
-        super().__init__()
-        if FloatFunctional:
-            self.functional = FloatFunctional()
-            self.wrap_qat = True
-            self.qat_wrapper_kwargs = {"num_inputs": 1, "num_outputs": 1}
-        else:
-            self.functional = ReLU(num_channels=num_channels, inplace=True)
-
-    def forward(self, x, y):
-        if isinstance(self.functional, FloatFunctional):
-            return self.functional.add_relu(x, y)
-        else:
-            return self.functional(x + y)
+class _AddInput(Module):
+    def forward(self, x):
+        return x
 
 
 class _BasicBlock(Module):
@@ -185,7 +168,8 @@ class _BasicBlock(Module):
             else None
         )
 
-        # self.add_relu = _AddReLU(out_channels)
+        self.no_op_conv = _AddInput()
+        self.no_op_identity = _AddInput()
         if FloatFunctional:
             self.add_relu = FloatFunctional()
         else:
@@ -200,10 +184,10 @@ class _BasicBlock(Module):
 
         out = self.conv2(out)
         out = self.bn2(out)
+        out = self.no_op_conv(out)
 
         identity_val = self.identity(inp) if self.identity is not None else inp
-        # out = self.add_relu(identity_val, out)
-        # return out
+        identity_val = self.no_op_identity(identity_val)
 
         if isinstance(self.add_relu, FloatFunctional):
             return self.add_relu.add_relu(identity_val, out)
@@ -250,7 +234,8 @@ class _BottleneckBlock(Module):
             else None
         )
 
-        # self.add_relu = _AddReLU(out_channels)
+        self.no_op_conv = _AddInput()
+        self.no_op_identity = _AddInput()
         if FloatFunctional:
             self.add_relu = FloatFunctional()
         else:
@@ -269,11 +254,10 @@ class _BottleneckBlock(Module):
 
         out = self.conv3(out)
         out = self.bn3(out)
+        out = self.no_op_conv(out)
 
         identity_val = self.identity(inp) if self.identity is not None else inp
-
-        # out = self.add_relu(identity_val, out)
-        # return out
+        identity_val = self.no_op_identity(identity_val)
 
         if isinstance(self.add_relu, FloatFunctional):
             return self.add_relu.add_relu(identity_val, out)
@@ -315,6 +299,9 @@ class _BasicBlockV2(Module):
             else None
         )
 
+        self.no_op_conv = _AddInput()
+        self.no_op_identity = _AddInput()
+
         self.initialize()
 
     def forward(self, inp: Tensor):
@@ -324,11 +311,13 @@ class _BasicBlockV2(Module):
         out = self.act1(out)
         if self.identity is not None:
             identity = self.identity(out)
+            identity = self.no_op_identity(out)
         out = self.conv1(out)
 
         out = self.bn2(out)
         out = self.act2(out)
         out = self.conv2(out)
+        out = self.no_op_conv(out)
 
         out += identity
 
@@ -377,6 +366,8 @@ class _BottleneckBlockV2(Module):
             if in_channels != out_channels or stride != 1
             else None
         )
+        self.no_op_conv = _AddInput()
+        self.no_op_identity = _AddInput()
 
         self.initialize()
 
@@ -387,6 +378,7 @@ class _BottleneckBlockV2(Module):
         out = self.act1(out)
         if self.identity is not None:
             identity = self.identity(out)
+            identity = self.no_op_identity(identity)
         out = self.conv1(out)
 
         out = self.bn2(out)
@@ -396,6 +388,7 @@ class _BottleneckBlockV2(Module):
         out = self.bn3(out)
         out = self.act3(out)
         out = self.conv3(out)
+        out = self.no_op_conv(out)
 
         out += identity
 

--- a/src/sparseml/pytorch/models/classification/resnet.py
+++ b/src/sparseml/pytorch/models/classification/resnet.py
@@ -140,7 +140,7 @@ class _IdentityModifier(Module):
         return in_channels != out_channels or stride > 1
 
 
-class _AddInput(Module):
+class AddInput(Module):
     def forward(self, x):
         return x
 
@@ -168,8 +168,8 @@ class _BasicBlock(Module):
             else None
         )
 
-        self.no_op_conv = _AddInput()
-        self.no_op_identity = _AddInput()
+        self.add_input_conv = AddInput()
+        self.add_input_identity = AddInput()
         if FloatFunctional:
             self.add_relu = FloatFunctional()
         else:
@@ -184,10 +184,10 @@ class _BasicBlock(Module):
 
         out = self.conv2(out)
         out = self.bn2(out)
-        out = self.no_op_conv(out)
+        out = self.add_input_conv(out)
 
         identity_val = self.identity(inp) if self.identity is not None else inp
-        identity_val = self.no_op_identity(identity_val)
+        identity_val = self.add_input_identity(identity_val)
 
         if isinstance(self.add_relu, FloatFunctional):
             return self.add_relu.add_relu(identity_val, out)
@@ -234,8 +234,8 @@ class _BottleneckBlock(Module):
             else None
         )
 
-        self.no_op_conv = _AddInput()
-        self.no_op_identity = _AddInput()
+        self.add_input_conv = AddInput()
+        self.add_input_identity = AddInput()
         if FloatFunctional:
             self.add_relu = FloatFunctional()
         else:
@@ -254,10 +254,10 @@ class _BottleneckBlock(Module):
 
         out = self.conv3(out)
         out = self.bn3(out)
-        out = self.no_op_conv(out)
+        out = self.add_input_conv(out)
 
         identity_val = self.identity(inp) if self.identity is not None else inp
-        identity_val = self.no_op_identity(identity_val)
+        identity_val = self.add_input_identity(identity_val)
 
         if isinstance(self.add_relu, FloatFunctional):
             return self.add_relu.add_relu(identity_val, out)
@@ -299,8 +299,8 @@ class _BasicBlockV2(Module):
             else None
         )
 
-        self.no_op_conv = _AddInput()
-        self.no_op_identity = _AddInput()
+        self.add_input_conv = AddInput()
+        self.add_input_identity = AddInput()
 
         self.initialize()
 
@@ -311,13 +311,13 @@ class _BasicBlockV2(Module):
         out = self.act1(out)
         if self.identity is not None:
             identity = self.identity(out)
-            identity = self.no_op_identity(out)
+            identity = self.add_input_identity(identity)
         out = self.conv1(out)
 
         out = self.bn2(out)
         out = self.act2(out)
         out = self.conv2(out)
-        out = self.no_op_conv(out)
+        out = self.add_input_conv(out)
 
         out += identity
 
@@ -366,8 +366,8 @@ class _BottleneckBlockV2(Module):
             if in_channels != out_channels or stride != 1
             else None
         )
-        self.no_op_conv = _AddInput()
-        self.no_op_identity = _AddInput()
+        self.add_input_conv = AddInput()
+        self.add_input_identity = AddInput()
 
         self.initialize()
 
@@ -378,7 +378,7 @@ class _BottleneckBlockV2(Module):
         out = self.act1(out)
         if self.identity is not None:
             identity = self.identity(out)
-            identity = self.no_op_identity(identity)
+            identity = self.add_input_identity(identity)
         out = self.conv1(out)
 
         out = self.bn2(out)
@@ -388,7 +388,7 @@ class _BottleneckBlockV2(Module):
         out = self.bn3(out)
         out = self.act3(out)
         out = self.conv3(out)
-        out = self.no_op_conv(out)
+        out = self.add_input_conv(out)
 
         out += identity
 


### PR DESCRIPTION
Introduce "no op" modules to the inputs for the residual add operation. These modules allow these inputs to be quantized by the new quantization modifier, addressing a long standing issue w/ RN50 models. Prior to this, the quantization of residual adds was only possible via a construction that created duplicate quantization nodes and hurt accuracy.

Testing plan:
1. Completed a QAT run of RN50 using the schedule of the pruned 95% model (https://sparsezoo.neuralmagic.com/models/cv%2Fclassification%2Fresnet_v1-50%2Fpytorch%2Fsparseml%2Fimagenet%2Fpruned95_quant-none) implemented via a recipe that uses the new quantization modifier:
https://wandb.ai/neuralmagic/alexandre_debug/runs/cwne0smk?workspace=user-neuralmagic

2. Evaluated the existing model from the zoo to verify that the changes do not affect the ability to load legacy models.