### PR TITLE
Adding `--datasets-dir` to yolov8 entrypoints

### DIFF
--- a/src/sparseml/yolov8/default.yaml
+++ b/src/sparseml/yolov8/default.yaml
@@ -2,6 +2,7 @@
 
 recipe: null
 recipe_args: null
+datasets_dir: null
 
 task: "detect" # choices=['detect', 'segment', 'classify', 'init'] # init is a special case. Specify task to run.
 mode: "train" # choices=['train', 'val', 'predict'] # mode to run task in.

--- a/src/sparseml/yolov8/export.py
+++ b/src/sparseml/yolov8/export.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import click
 from sparseml.yolov8.trainers import SparseYOLO
+from ultralytics.yolo.utils import USER_CONFIG_DIR, get_settings, yaml_save
 
 
 # Options generated from
@@ -66,7 +69,20 @@ from sparseml.yolov8.trainers import SparseYOLO
     "this flag is set to True,mthe torch model with "
     "the one-shot recipe applied will be exported.",
 )
+@click.option(
+    "--datasets-dir",
+    type=str,
+    default=None,
+    help="Path to override default datasets dir.",
+)
 def main(**kwargs):
+    if kwargs["datasets_dir"] is not None:
+        settings = get_settings()
+        settings["datasets_dir"] = os.path.abspath(
+            os.path.expanduser(kwargs["datasets_dir"])
+        )
+        yaml_save(USER_CONFIG_DIR / "settings.yaml", settings)
+
     model = SparseYOLO(kwargs["model"])
     model.export(**kwargs)
 

--- a/src/sparseml/yolov8/train.py
+++ b/src/sparseml/yolov8/train.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import click
 from sparseml.yolov8.trainers import SparseYOLO
+from ultralytics.yolo.utils import USER_CONFIG_DIR, get_settings, yaml_save
 
 
 # Options generated from
@@ -205,7 +208,20 @@ from sparseml.yolov8.trainers import SparseYOLO
 @click.option(
     "--copy-paste", type=float, default=0.0, help="segment copy-paste (probability)"
 )
+@click.option(
+    "--datasets-dir",
+    type=str,
+    default=None,
+    help="Path to override default datasets dir.",
+)
 def main(**kwargs):
+    if kwargs["datasets_dir"] is not None:
+        settings = get_settings()
+        settings["datasets_dir"] = os.path.abspath(
+            os.path.expanduser(kwargs["datasets_dir"])
+        )
+        yaml_save(USER_CONFIG_DIR / "settings.yaml", settings)
+
     model = SparseYOLO(kwargs["model"])
     model.train(**kwargs)
 

--- a/src/sparseml/yolov8/train.py
+++ b/src/sparseml/yolov8/train.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import logging
+import os
 
 import click
 from sparseml.yolov8.trainers import SparseYOLO

--- a/src/sparseml/yolov8/val.py
+++ b/src/sparseml/yolov8/val.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import click
 from sparseml.yolov8.trainers import SparseYOLO
+from ultralytics.yolo.utils import USER_CONFIG_DIR, get_settings, yaml_save
 
 
 @click.command(
@@ -68,7 +71,20 @@ from sparseml.yolov8.trainers import SparseYOLO
     "--dnn", default=False, is_flag=True, help="use OpenCV DNN for ONNX inference"
 )
 @click.option("--plots", default=False, is_flag=True, help="show plots during training")
+@click.option(
+    "--datasets-dir",
+    type=str,
+    default=None,
+    help="Path to override default datasets dir.",
+)
 def main(**kwargs):
+    if kwargs["datasets_dir"] is not None:
+        settings = get_settings()
+        settings["datasets_dir"] = os.path.abspath(
+            os.path.expanduser(kwargs["datasets_dir"])
+        )
+        yaml_save(USER_CONFIG_DIR / "settings.yaml", settings)
+
     model = SparseYOLO(kwargs["model"])
     model.val(**kwargs)
 


### PR DESCRIPTION
Adds optional `--datasets-dir` flag to train/export/val. If this is specified it overwrites the datsets_dir stored in `~/.config/Ultralytics/settings.yaml`.

# Testing

Ran `sparseml.ultralytics.train --datasets-dir ~/datasets ...` and confirmed the new datasets directory was in home, and the settings file had changed.