### PR TITLE
Skip onnx.check_model if model is too large

### DIFF
--- a/src/sparseml/onnx/utils/helpers.py
+++ b/src/sparseml/onnx/utils/helpers.py
@@ -87,14 +87,14 @@ def validate_onnx_file(path: str):
     """
     try:
         onnx_model = check_load_model(path)
-        
+
         if onnx_model.ByteSize() < onnx.checker.MAXIMUM_PROTOBUF:
             onnx.checker.check_model(onnx_model)
         else:
             _LOGGER.warning(
                 "onnx check_model skipped as model exceeds maximum protobuf size of 2GB"
             )
-        
+
         if not onnx_model.opset_import:
             raise ValueError("could not parse opset_import")
     except Exception as err:

--- a/src/sparseml/onnx/utils/helpers.py
+++ b/src/sparseml/onnx/utils/helpers.py
@@ -87,7 +87,14 @@ def validate_onnx_file(path: str):
     """
     try:
         onnx_model = check_load_model(path)
-        onnx.checker.check_model(onnx_model)
+        
+        if onnx_model.ByteSize() < onnx.checker.MAXIMUM_PROTOBUF:
+            onnx.checker.check_model(onnx_model)
+        else:
+            _LOGGER.warning(
+                "onnx check_model skipped as model exceeds maximum protobuf size of 2GB"
+            )
+        
         if not onnx_model.opset_import:
             raise ValueError("could not parse opset_import")
     except Exception as err:


### PR DESCRIPTION
Gets ONNX export around the issue of checking models that are too large for `check_model()`. There are still probably issues with saving ONNX models that are too large