### PR TITLE
[YOLOv8] Fixing the sparsezoo pathway

### DIFF
--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -589,12 +589,12 @@ class SparseYOLO(YOLO):
 
             if "yaml" in self.ckpt:
                 self.model = self.ModelClass(dict(self.ckpt["yaml"]))
+            elif "model_yaml" in self.ckpt:
+                self.model = self.ModelClass(dict(self.ckpt["model_yaml"]))
             else:
                 self.model = self.ModelClass(dict(self.ckpt["model"].yaml))
             if "recipe" in self.ckpt:
-                manager = ScheduledModifierManager.from_yaml(
-                    self.ckpt["model"]["recipe"]
-                )
+                manager = ScheduledModifierManager.from_yaml(self.ckpt["recipe"])
                 epoch = self.ckpt.get("epoch", -1)
                 if epoch < 0:
                     epoch = float("inf")

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -586,9 +586,14 @@ class SparseYOLO(YOLO):
                 self.PredictorClass,
             ) = self._assign_ops_from_task(self.task)
 
-            self.model = self.ModelClass(dict(self.ckpt["model_yaml"]))
+            if "yaml" in self.ckpt:
+                self.model = self.ModelClass(dict(self.ckpt["yaml"]))
+            else:
+                self.model = self.ModelClass(dict(self.ckpt["model"].yaml))
             if "recipe" in self.ckpt:
-                manager = ScheduledModifierManager.from_yaml(self.ckpt["recipe"])
+                manager = ScheduledModifierManager.from_yaml(
+                    self.ckpt["model"]["recipe"]
+                )
                 epoch = self.ckpt.get("epoch", -1)
                 if epoch < 0:
                     epoch = float("inf")

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -530,7 +530,8 @@ class SparseYOLO(YOLO):
                 Model(model_str), model_suffix="pt"
             )
             self.is_sparseml_checkpoint = True
-        elif model_str.endswith(".pt"):
+
+        if model_str.endswith(".pt"):
             if os.path.exists(model_str):
                 ckpt = torch.load(model_str)
                 self.is_sparseml_checkpoint = (

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -527,7 +527,7 @@ class SparseYOLO(YOLO):
 
         if model_str.startswith("zoo:"):
             model = download_framework_model_by_recipe_type(
-                Model(model_str), model_suffix=".pt"
+                Model(model_str), model_suffix="pt"
             )
             self.is_sparseml_checkpoint = True
         elif model_str.endswith(".pt"):


### PR DESCRIPTION
Fix for: https://app.asana.com/0/1203126676641557/1204359816230311/f

## Testing

### Testing with "base" sparseml model
```bash
sparseml.ultralytics.val --model zoo:cv/detection/yolov8-s/pytorch/ultralytics/coco/base-none --data coco.yaml
```
Outputs:
```bash
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.009
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.013
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.010
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.002
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.008
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.016
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.012
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.017
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.018
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.009
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.018
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.025
```
### Testing with "vanilla" ultralytics model
```bash
sparseml.ultralytics.val --model yolov8n.pt --data coco128.yaml
```
Outputs:
```bash
Ultralytics YOLOv8.0.30 🚀 Python-3.8.10 torch-1.12.1+cu116 CUDA:0 (NVIDIA RTX A4000, 16117MiB)
val: Scanning /home/ubuntu/damian/deepsparse/datasets/coco128/labels/train2017.cache... 126 images, 2 backgrounds, 0 corrupt: 100%|██████████| 128/128 [00:00<?, ?it/s]
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100%|██████████| 8/8 [00:01<00:00,  6.26it/s]
                   all        128        929       0.64      0.537      0.605      0.446
Speed: 0.1ms pre-process, 2.1ms inference, 0.0ms loss, 0.7ms post-process per image
```
### Testing with dummy sparseml checkpoint model
```
sparseml.ultralytics.val --model runs/detect/train281/weights/last.pt --data coco128.yaml
```
Outputs:
```bash
Ultralytics YOLOv8.0.30 🚀 Python-3.8.10 torch-1.12.1+cu116 CUDA:0 (NVIDIA RTX A4000, 16117MiB)
val: Scanning /home/ubuntu/damian/deepsparse/datasets/coco128/labels/train2017.cache... 126 images, 2 backgrounds, 0 corrupt: 100%|██████████| 128/128 [00:00<?, ?it/s]
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100%|██████████| 8/8 [00:01<00:00,  6.93it/s]
                   all        128        929          0          0          0          0
Speed: 0.1ms pre-process, 4.1ms inference, 0.0ms loss, 0.0ms post-process per image
```