### PR TITLE
Convert input for quantized YOLOv8

### DIFF
--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -28,6 +28,7 @@ import torch
 
 from sparseml.optim.helpers import load_recipe_yaml_str
 from sparseml.pytorch.optim.manager import ScheduledModifierManager
+from sparseml.pytorch.sparsification.quantization import skip_onnx_input_quantize
 from sparseml.pytorch.utils import ModuleExporter
 from sparseml.pytorch.utils.helpers import download_framework_model_by_recipe_type
 from sparseml.pytorch.utils.logger import LoggerManager, PythonLogger, WANDBLogger
@@ -711,7 +712,13 @@ class SparseYOLO(YOLO):
             else ["output0"],
         )
 
-        onnx.checker.check_model(os.path.join(save_dir, name))
+        complete_path = os.path.join(save_dir, name)
+        try:
+            skip_onnx_input_quantize(complete_path, complete_path)
+        except:
+            pass
+
+        onnx.checker.check_model(complete_path)
         deployment_folder = exporter.create_deployment_folder(onnx_model_name=name)
         if args["export_samples"]:
             trainer_config = get_cfg(cfg=DEFAULT_SPARSEML_CONFIG_PATH)


### PR DESCRIPTION
Added call to function that skips the quantization of the input if the model is quantized. After that it expects the input to be quantized.

Testing plan:
Exported YOLOv8s dense quantized. Verified that the input is quantized and the QuantizationLinear node is removed. Tested for accuracy and latency on deepsparse.