### PR TITLE
Fixing yolov8-seg validation

### DIFF
--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -100,6 +100,7 @@ __all__ = [
     "MEMORY_BOUNDED",
     "memory_aware_threshold",
     "download_framework_model_by_recipe_type",
+    "detach",
 ]
 
 
@@ -1162,3 +1163,14 @@ def download_framework_model_by_recipe_type(
         framework_model = zoo_model.training.default.get_file(model_name)
 
     return framework_model.path
+
+
+def detach(x: Union[torch.Tensor, List, Tuple]):
+    if isinstance(x, torch.Tensor):
+        return x.detach()
+    elif isinstance(x, List):
+        return [detach(e) for e in x]
+    elif isinstance(x, Tuple):
+        return tuple([detach(e) for e in x])
+    else:
+        raise ValueError("Unexpected type to detach")

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -587,7 +587,7 @@ class SparseYOLO(YOLO):
             ) = self._assign_ops_from_task(self.task)
 
             self.model = self.ModelClass(dict(self.ckpt["model_yaml"]))
-            if "recipe" in self.ckpt:
+            if "recipe" in self.ckpt and self.ckpt["recipe"]:
                 manager = ScheduledModifierManager.from_yaml(self.ckpt["recipe"])
                 epoch = self.ckpt.get("epoch", -1)
                 if epoch < 0:

--- a/src/sparseml/yolov8/utils/helpers.py
+++ b/src/sparseml/yolov8/utils/helpers.py
@@ -15,14 +15,16 @@
 import os
 import warnings
 from argparse import Namespace
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple, Union
+
+import torch
 
 from ultralytics.yolo.data.dataloaders.v5loader import create_dataloader
 from ultralytics.yolo.engine.model import DetectionModel
 from ultralytics.yolo.engine.trainer import BaseTrainer
 
 
-__all__ = ["check_coco128_segmentation", "create_grad_sampler"]
+__all__ = ["check_coco128_segmentation", "create_grad_sampler", "detach"]
 
 
 def check_coco128_segmentation(args: Namespace) -> Namespace:
@@ -69,3 +71,14 @@ def create_grad_sampler(
         / train_loader.batch_size,
     )
     return grad_sampler
+
+
+def detach(x: Union[torch.Tensor, List, Tuple]):
+    if isinstance(x, torch.Tensor):
+        return x.detach()
+    elif isinstance(x, List):
+        return [detach(e) for e in x]
+    elif isinstance(x, Tuple):
+        return tuple([detach(e) for e in x])
+    else:
+        raise ValueError("Unexpected type to detach")

--- a/src/sparseml/yolov8/utils/helpers.py
+++ b/src/sparseml/yolov8/utils/helpers.py
@@ -15,16 +15,14 @@
 import os
 import warnings
 from argparse import Namespace
-from typing import Any, Dict, List, Tuple, Union
-
-import torch
+from typing import Any, Dict
 
 from ultralytics.yolo.data.dataloaders.v5loader import create_dataloader
 from ultralytics.yolo.engine.model import DetectionModel
 from ultralytics.yolo.engine.trainer import BaseTrainer
 
 
-__all__ = ["check_coco128_segmentation", "create_grad_sampler", "detach"]
+__all__ = ["check_coco128_segmentation", "create_grad_sampler"]
 
 
 def check_coco128_segmentation(args: Namespace) -> Namespace:
@@ -71,14 +69,3 @@ def create_grad_sampler(
         / train_loader.batch_size,
     )
     return grad_sampler
-
-
-def detach(x: Union[torch.Tensor, List, Tuple]):
-    if isinstance(x, torch.Tensor):
-        return x.detach()
-    elif isinstance(x, List):
-        return [detach(e) for e in x]
-    elif isinstance(x, Tuple):
-        return tuple([detach(e) for e in x])
-    else:
-        raise ValueError("Unexpected type to detach")

--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -17,6 +17,7 @@ import json
 import torch
 from tqdm import tqdm
 
+from sparseml.yolov8.utils import detach
 from ultralytics.nn.autobackend import AutoBackend
 from ultralytics.yolo.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.yolo.engine.validator import BaseValidator
@@ -136,7 +137,7 @@ class SparseValidator(BaseValidator):
 
             # During QAT the resulting preds are grad required, breaking
             # the update metrics function.
-            detached_preds = [p.detach() for p in preds]
+            detached_preds = detach(preds)
             self.update_metrics(detached_preds, batch)
 
             if self.args.plots and batch_i < 3:

--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -17,7 +17,7 @@ import json
 import torch
 from tqdm import tqdm
 
-from sparseml.yolov8.utils import detach
+from sparseml.pytorch.utils import detach
 from ultralytics.nn.autobackend import AutoBackend
 from ultralytics.yolo.data.utils import check_cls_dataset, check_det_dataset
 from ultralytics.yolo.engine.validator import BaseValidator


### PR DESCRIPTION
The PR enables segmentation evaluation for yolov8 models, which currently fails. It implements a function that extends `detach` to PyTorch expected types ie. list or tuples.

Testing:
- Evaluation works for both detection and segmentation models obtained form either SparseML or ultraltyics