### PR TITLE
[Bug-fix] YOLOv5 integration test output pathing

### DIFF
--- a/tests/integrations/yolov5/test_yolov5.py
+++ b/tests/integrations/yolov5/test_yolov5.py
@@ -221,6 +221,6 @@ def _get_onnx_file_path(weights, one_shot):
             if weights.parent.stem == "weights"
             else weights.parent / "DeepSparse_Deployment"
         )
-        onnx_file_name = weights.name
+        onnx_file_name = str(Path(weights.name).with_suffix(".onnx"))
 
     return str(save_dir / onnx_file_name)


### PR DESCRIPTION
There is currently a failing post-commit yolov5 integration test caused by an incorrect pathing assumption in the integration test. This PR fixes it by updating the final output path to refer to an `.onnx` file rather than a `.pt` file

**Test plan**
Tested locally with `make testinteg TARGETS=yolov5 SPARSEML_TEST_CADENCE=commit`