### PR TITLE
Fix YOLOv8 validation when custom dataset yaml is provided

### DIFF
--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -88,8 +88,8 @@ class SparseValidator(BaseValidator):
                 raise FileNotFoundError(
                     emojis(f"Dataset '{self.args.data}' not found ❌")
                 )
-            if isinstance(self.data['path'], str):
-                self.data['path'] = Path(self.data['path'])
+            if isinstance(self.data["path"], str):
+                self.data["path"] = Path(self.data["path"])
 
             if self.device.type == "cpu":
                 self.args.workers = (

--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -14,6 +14,7 @@
 
 import json
 from argparse import Namespace
+from pathlib import Path
 
 import torch
 from tqdm import tqdm
@@ -87,6 +88,8 @@ class SparseValidator(BaseValidator):
                 raise FileNotFoundError(
                     emojis(f"Dataset '{self.args.data}' not found ❌")
                 )
+            if isinstance(self.data['path'], str):
+                self.data['path'] = Path(self.data['path'])
 
             if self.device.type == "cpu":
                 self.args.workers = (


### PR DESCRIPTION
The pycocotools pathway for model validation expects a "Path" object for the data['path'] entry. When the user provides a complete path to a yaml file (or when --dataset-path is provided) this entry remains a string, which leads to an error when doing the pycocotools evaluation.

This is a failure on ultralytics side, but we can fix in the integration since we override the validator class.

Testing plan: The fix allowed me to use "dataset-path" as below:
sparseml.ultralytics.val \
  --model zoo:cv/detection/yolov8-n/pytorch/ultralytics/coco/base-none \
  --data coco.yaml \
  --dataset-path /home/alexandre/datasets/coco
 
 (dataset-path is implemented by 1. copying ultralytics' coco.yaml to the local path, 2. overwriting the dataset path in the yaml file, 3. replacing the data argument with the complete path to edited yaml file.)