### PR TITLE
update-dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -138,12 +138,12 @@ COPY --from=build $VENV $VENV
 COPY --from=build sparseml sparseml
 ENV PATH="${VENV}/bin:$PATH"
 HEALTHCHECK CMD python -c 'import sparseml'
-ENTRYPOINT bash
+CMD bash
 
 FROM base as prod
 ARG VENV
 COPY --from=build $VENV $VENV
 ENV PATH="${VENV}/bin:$PATH"
 HEALTHCHECK CMD python -c 'import sparseml'
-ENTRYPOINT bash
+CMD bash
 


### PR DESCRIPTION
This PR updates the dockerfile to use
`CMD` over `ENTRYPOINT` to allow easier overriding of commands for users

for example
Now the `deepsparse.server` can be run directly with one command

```bash
docker container run -it --gpus all ghcr.io/neuralmagic/sparseml:1.4.4-cu102 \
  sparseml.transformers.export_onnx --help
```