### PR TITLE
Update: missed instances of python3.6 -> 3.7

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Developing SparseML
 
-SparseML is developed and tested using Python 3.6-3.9.
+SparseML is developed and tested using Python 3.7-3.9.
 To develop SparseML, you will also need the development dependencies and to follow the styling guidelines.
 
 Here's some details to get started.

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Installation
 
-This repository is tested on Python 3.6-3.9, and Linux/Debian systems.
+This repository is tested on Python 3.7-3.9, and Linux/Debian systems.
 It is recommended to install in a [virtual environment](https://docs.python.org/3/library/venv.html) to keep your system in order.
 Currently supported ML Frameworks are the following: `torch>=1.1.0,<=1.8.0`, `tensorflow>=1.8.0,<=2.0.0`, `tensorflow.keras >= 2.2.0`.
 


### PR DESCRIPTION
This PR updates old references of python3.6 -> python3.7