### PR TITLE
Audit the onnx pathways to make them robust against >2Gb models

### DIFF
--- a/src/sparseml/exporters/onnx_to_deepsparse.py
+++ b/src/sparseml/exporters/onnx_to_deepsparse.py
@@ -21,6 +21,7 @@ import onnx
 
 from sparseml.exporters import transforms as sparseml_transforms
 from sparseml.exporters.base_exporter import BaseExporter
+from sparsezoo import save_onnx
 
 
 class ONNXToDeepsparse(BaseExporter):
@@ -109,7 +110,7 @@ class ONNXToDeepsparse(BaseExporter):
 
     def export(self, pre_transforms_model: onnx.ModelProto, file_path: str):
         if self.export_input_model or os.getenv("SAVE_PREQAT_ONNX", False):
-            onnx.save(pre_transforms_model, file_path.replace(".onnx", ".preqat.onnx"))
+            save_onnx(pre_transforms_model, file_path.replace(".onnx", ".preqat.onnx"))
 
         post_transforms_model: onnx.ModelProto = self.apply(pre_transforms_model)
-        onnx.save(post_transforms_model, file_path)
+        save_onnx(post_transforms_model, file_path)

--- a/src/sparseml/exporters/transforms/onnx_transform.py
+++ b/src/sparseml/exporters/transforms/onnx_transform.py
@@ -20,7 +20,8 @@ from onnx import ModelProto, NodeProto, TensorProto
 
 from sparseml.exporters.transforms import BaseTransform
 from sparseml.exporters.transforms.utils import MatchResult
-from sparseml.onnx.utils import ONNXGraph, check_load_model, validate_onnx_file
+from sparseml.onnx.utils import ONNXGraph
+from sparsezoo.utils import load_model, validate_onnx
 
 
 __all__ = ["OnnxTransform"]
@@ -80,8 +81,8 @@ class OnnxTransform(BaseTransform):
                 f"Invalid model type: {type(model)}. "
                 "Must be a string (path to the .onnx file) or ONNX ModelProto"
             )
-        model = check_load_model(model)
-        validate_onnx_file(model)
+        model = load_model(model)
+        validate_onnx(model)
         self._nodes_to_delete.clear()
         self._nodes_to_add.clear()
         self._num_matches = 0
@@ -102,5 +103,5 @@ class OnnxTransform(BaseTransform):
         graph = ONNXGraph(model)
         graph.delete_unused_initializers()
         graph.sort_nodes_topologically()
-        validate_onnx_file(model)
+        validate_onnx(model)
         return model

--- a/src/sparseml/onnx/optim/analyzer_model.py
+++ b/src/sparseml/onnx/optim/analyzer_model.py
@@ -27,7 +27,6 @@ from sparseml.onnx.optim.sensitivity_pruning import pruning_loss_sens_approx
 from sparseml.onnx.utils import (
     NodeShape,
     calculate_flops,
-    check_load_model,
     extract_node_id,
     extract_node_shapes,
     get_kernel_shape,
@@ -38,6 +37,7 @@ from sparseml.onnx.utils import (
     is_prunable_node,
 )
 from sparseml.utils import clean_path, create_parent_dirs
+from sparsezoo.utils import load_model
 
 
 __all__ = ["NodeAnalyzer", "ModelAnalyzer"]
@@ -358,7 +358,7 @@ class ModelAnalyzer(object):
             raise ValueError("model or nodes must be None, both cannot be passed")
 
         if model is not None:
-            model = check_load_model(model)
+            model = load_model(model)
             node_shapes = extract_node_shapes(model)
             self._nodes = [
                 NodeAnalyzer(

--- a/src/sparseml/onnx/optim/quantization/calibration.py
+++ b/src/sparseml/onnx/optim/quantization/calibration.py
@@ -25,6 +25,7 @@ import numpy as np
 import onnx
 
 from sparseml.onnx.utils import ORTModelRunner, fold_conv_bns, get_node_output_nodes
+from sparsezoo.utils import save_onnx, validate_onnx
 
 
 __all__ = ["CalibrationSession"]
@@ -68,7 +69,7 @@ class CalibrationSession:
                 suffix=".onnx", delete=True
             )
             self._augmented_model_path = self._augmented_model_tmp_file.name
-        onnx.save(self._model_augmented, self._augmented_model_path)
+        save_onnx(self._model_augmented, self._augmented_model_path)
 
         self._sessions = {}  # batch_size -> session
         self._quantization_thresholds = {}  # Dict[node.name, Tuple(min_val, max_val)]
@@ -101,13 +102,11 @@ class CalibrationSession:
             if model_optimized is None:
                 # no optimization performed, skip the rest of this block
                 raise Exception()
-            onnx.checker.check_model(
-                model_optimized
-            )  # should raise exception if broken
+            validate_onnx(model_optimized)  # should raise exception if broken
             optimized_model_path = tempfile.NamedTemporaryFile(
                 suffix=".onnx", delete=False
             )
-            onnx.save(model_optimized, optimized_model_path.name)
+            save_onnx(model_optimized, optimized_model_path.name)
             self._model = model_optimized
             print("Optimization successful")
             return optimized_model_path.name

--- a/src/sparseml/onnx/optim/quantization/quantize_model_post_training.py
+++ b/src/sparseml/onnx/optim/quantization/quantize_model_post_training.py
@@ -24,6 +24,7 @@ from tqdm.auto import tqdm
 from sparseml.onnx.optim.quantization.calibration import CalibrationSession
 from sparseml.onnx.optim.quantization.quantize import QuantizationMode, quantize
 from sparseml.onnx.utils import DataLoader, quantize_resnet_identity_add_inputs
+from sparsezoo.utils import save_onnx
 
 
 __all__ = ["quantize_model_post_training"]
@@ -105,4 +106,4 @@ def quantize_model_post_training(
     if output_model_path is None:
         return calibrated_quantized_model
     else:
-        onnx.save(calibrated_quantized_model, output_model_path)
+        save_onnx(calibrated_quantized_model, output_model_path)

--- a/src/sparseml/onnx/optim/sensitivity_pruning.py
+++ b/src/sparseml/onnx/optim/sensitivity_pruning.py
@@ -30,7 +30,6 @@ from sparseml.onnx.utils import (
     DeepSparseAnalyzeModelRunner,
     DeepSparseModelRunner,
     ORTModelRunner,
-    check_load_model,
     extract_node_id,
     get_node_params,
     get_prunable_nodes,
@@ -46,6 +45,7 @@ from sparseml.optim import (
     default_pruning_sparsities_perf,
 )
 from sparseml.utils import flatten_iterable
+from sparsezoo.utils import load_model
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -142,7 +142,7 @@ def pruning_loss_sens_magnitude_iter(
     :return: the analysis results for the model with an additional layer at each
         iteration along with a float representing the iteration progress
     """
-    model = check_load_model(model)
+    model = load_model(model)
     prunable = get_prunable_nodes(model)
     analysis = PruningLossSensitivityAnalysis()
     num_layers = len(prunable)
@@ -251,7 +251,7 @@ def pruning_loss_sens_one_shot_iter(
     :return: the sensitivity results for every node that is prunable,
         yields update at each layer along with iteration progress
     """
-    model = check_load_model(model)
+    model = load_model(model)
     prunable_nodes = get_prunable_nodes(model)
     analysis = PruningLossSensitivityAnalysis()
     num_updates = len(prunable_nodes) * len(sparsity_levels) + 1

--- a/src/sparseml/onnx/utils/data.py
+++ b/src/sparseml/onnx/utils/data.py
@@ -25,13 +25,13 @@ import numpy
 from onnx import ModelProto
 
 from sparseml.onnx.utils.helpers import (
-    check_load_model,
     extract_shape,
     get_numpy_dtype,
     model_inputs,
     model_outputs,
 )
 from sparseml.utils import NumpyArrayBatcher, load_labeled_data
+from sparsezoo.utils import load_model
 
 
 __all__ = ["DataLoader"]
@@ -171,7 +171,7 @@ class DataLoader(object):
             and outputs, typically the batch dimension
         :return: the created DataLoader instance with the random data
         """
-        model = check_load_model(model)
+        model = load_model(model)
         inputs = model_inputs(model)
         outputs = model_outputs(model)
         data_shapes = OrderedDict(

--- a/src/sparseml/onnx/utils/model.py
+++ b/src/sparseml/onnx/utils/model.py
@@ -34,13 +34,13 @@ from sparseml.onnx.base import require_onnxruntime
 from sparseml.onnx.utils.data import DataLoader
 from sparseml.onnx.utils.graph_editor import override_model_batch_size
 from sparseml.onnx.utils.helpers import (
-    check_load_model,
     extract_node_id,
     get_node_by_id,
     get_prunable_node_from_foldable,
     is_foldable_node,
 )
 from sparsezoo import File, Model
+from sparsezoo.utils import load_model
 
 
 try:
@@ -464,7 +464,7 @@ class ORTModelRunner(ModelRunner):
         import onnxruntime  # import protected by @require_onnxruntime()
 
         super().__init__(loss)
-        self._model = check_load_model(model)
+        self._model = load_model(model)
 
         if batch_size is not None:
             override_model_batch_size(self._model, batch_size)
@@ -712,7 +712,7 @@ def correct_nm_analyze_model_node_ids(nm_result: Dict, model: Union[str, ModelPr
     :param model: the onnx model proto or path to the onnx file that the
         nm_result was for
     """
-    model = check_load_model(model)
+    model = load_model(model)
 
     for layer in nm_result["layer_info"]:
         node_id = (

--- a/src/sparseml/openpifpaf/export.py
+++ b/src/sparseml/openpifpaf/export.py
@@ -19,12 +19,12 @@ import logging
 import os
 from typing import Optional
 
-import onnx
 import torch
 
 import openpifpaf
 from sparseml.pytorch.optim.manager import ScheduledModifierManager
 from sparseml.pytorch.utils import ModuleExporter
+from sparsezoo.utils import validate_onnx
 
 
 LOG = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ def export(
         input_names=["input_batch"],
         output_names=[meta.name for meta in datamodule.head_metas],
     )
-    onnx.checker.check_model(os.path.join(save_dir, name))
+    validate_onnx(os.path.join(save_dir, name))
     exporter.create_deployment_folder()
 
 

--- a/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
@@ -39,6 +39,7 @@ from sparseml.onnx.utils import (
     swap_node_output,
     update_model_param,
 )
+from sparsezoo.utils import save_onnx
 
 
 __all__ = [
@@ -1593,7 +1594,7 @@ def quantize_torch_qat_export(
     graph.delete_unused_initializers()
 
     if output_file_path:
-        onnx.save(model, output_file_path)
+        save_onnx(model, output_file_path)
 
     return model
 
@@ -1718,7 +1719,7 @@ def skip_onnx_input_quantize(
         raise RuntimeError(optim_error_message)
 
     if output_file_path:
-        onnx.save(model, output_file_path)
+        save_onnx(model, output_file_path)
 
 
 def _propagate_mobilebert_embedding_quantization(model: ModelProto):

--- a/src/sparseml/pytorch/torch_to_onnx_exporter.py
+++ b/src/sparseml/pytorch/torch_to_onnx_exporter.py
@@ -30,6 +30,7 @@ from sparseml.pytorch import _PARSED_TORCH_VERSION
 from sparseml.pytorch.opset import TORCH_DEFAULT_ONNX_OPSET
 from sparseml.pytorch.utils.helpers import tensors_module_forward, tensors_to_device
 from sparseml.pytorch.utils.model import is_parallel_model
+from sparsezoo.utils import save_onnx
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -101,7 +102,7 @@ class TorchToONNX(BaseExporter):
 
     def export(self, pre_transforms_model: torch.nn.Module, file_path: str):
         post_transforms_model: onnx.ModelProto = self.apply(pre_transforms_model)
-        onnx.save(post_transforms_model, file_path)
+        save_onnx(post_transforms_model, file_path)
 
 
 class _TorchOnnxExport(BaseTransform):

--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -48,6 +48,7 @@ from sparseml.pytorch.utils.model import (
     trace_model,
 )
 from sparseml.utils import clean_path, create_parent_dirs
+from sparsezoo.utils import save_onnx, validate_onnx
 
 
 __all__ = [
@@ -570,7 +571,7 @@ def export_onnx(
 
         # clean up graph from any injected / wrapped operations
         _delete_trivial_onnx_adds(onnx_model)
-    onnx.save(onnx_model, file_path)
+    save_onnx(onnx_model, file_path)
 
     if convert_qat and is_quant_module:
         # overwrite exported model with fully quantized version
@@ -819,4 +820,4 @@ def _unwrap_batchnorms(model: onnx.ModelProto):
         for idx in range(len(node.output)):
             node.output[idx] = node.output[idx].replace(".bn_wrapper_replace_me", "")
 
-    onnx.checker.check_model(model)
+    validate_onnx(model)

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -728,8 +728,7 @@ class SparseYOLO(YOLO):
         except Exception:
             pass
 
-        onnx.checker.check_model(complete_path)
-
+        validate_onnx(complete_path)
         deployment_folder = exporter.create_deployment_folder(onnx_model_name=name)
         if args["export_samples"]:
             trainer_config = get_cfg(cfg=DEFAULT_SPARSEML_CONFIG_PATH)

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -23,7 +23,6 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Optional
 
-import onnx
 import torch
 
 from sparseml.optim.helpers import load_recipe_yaml_str
@@ -44,6 +43,7 @@ from sparseml.yolov8.validators import (
     SparseSegmentationValidator,
 )
 from sparsezoo import Model
+from sparsezoo.utils import validate_onnx
 from ultralytics import __version__
 from ultralytics.nn.tasks import SegmentationModel, attempt_load_one_weight
 from ultralytics.yolo.cfg import get_cfg
@@ -721,7 +721,7 @@ class SparseYOLO(YOLO):
             else ["output0"],
         )
 
-        onnx.checker.check_model(os.path.join(save_dir, name))
+        validate_onnx(os.path.join(save_dir, name))
         deployment_folder = exporter.create_deployment_folder(onnx_model_name=name)
         if args["export_samples"]:
             trainer_config = get_cfg(cfg=DEFAULT_SPARSEML_CONFIG_PATH)

--- a/tests/sparseml/exporters/transforms/test_constants_to_initializers.py
+++ b/tests/sparseml/exporters/transforms/test_constants_to_initializers.py
@@ -19,6 +19,7 @@ from onnx import ModelProto
 from sparseml.exporters.transforms.constants_to_initializers import (
     ConstantsToInitializers,
 )
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -57,12 +58,12 @@ def onnx_model():
     )
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
 def test_vanilla(onnx_model: ModelProto):
     onnx_model = ConstantsToInitializers().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [n.name for n in onnx_model.graph.node] == ["add"]
     assert [i.name for i in onnx_model.graph.initializer] == ["const"]

--- a/tests/sparseml/exporters/transforms/test_conv_to_convinteger_add_cast_mul.py
+++ b/tests/sparseml/exporters/transforms/test_conv_to_convinteger_add_cast_mul.py
@@ -14,6 +14,7 @@
 import onnx
 
 from sparseml.exporters.transforms import ConvToConvIntegerAddCastMul
+from sparsezoo.utils import validate_onnx
 from tests.sparseml.exporters.transforms.test_onnx_transform import (
     _create_model as _create_model_no_conv,
 )
@@ -95,7 +96,7 @@ def _create_test_model():
     )
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
@@ -103,7 +104,7 @@ def test_convert_quantizable_conv_integer():
     model = _create_test_model()
     transform = ConvToConvIntegerAddCastMul()
     model = transform(model)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     assert [node.name for node in model.graph.node] == [
         "quantize_linear_node_0",
         "conv_node_quant",
@@ -125,5 +126,5 @@ def test_convert_quantizable_conv_integer_no_conv():
     nodes_in = [node.name for node in model_in.graph.node]
     transform = ConvToConvIntegerAddCastMul()
     model_out = transform(model_in)
-    onnx.checker.check_model(model_out)
+    validate_onnx(model_out)
     assert [node.name for node in model_out.graph.node] == nodes_in

--- a/tests/sparseml/exporters/transforms/test_conv_to_qlinearconv.py
+++ b/tests/sparseml/exporters/transforms/test_conv_to_qlinearconv.py
@@ -17,6 +17,7 @@ import pytest
 from onnx import helper
 
 from sparseml.exporters.transforms.conv_to_qlinearconv import ConvToQLinearConv
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -74,7 +75,7 @@ def onnx_model() -> onnx.ModelProto:
         initializer=[x_scale, y_scale, zero_point, weight_init],
     )
     model = helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     assert [i.name for i in model.graph.initializer] == [
         "x_scale",
         "y_scale",
@@ -93,7 +94,7 @@ def onnx_model() -> onnx.ModelProto:
 
 def test_vanilla(onnx_model: onnx.ModelProto):
     onnx_model = ConvToQLinearConv().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [i.name for i in onnx_model.graph.initializer] == [
         "x_scale",
         "y_scale",
@@ -111,10 +112,10 @@ def test_with_bias(onnx_model: onnx.ModelProto):
     gemm = [n for n in onnx_model.graph.node if n.op_type == "Conv"][0]
     gemm.input.append("bias")
     onnx_model.graph.initializer.append(bias)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
 
     onnx_model = ConvToQLinearConv().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [i.name for i in onnx_model.graph.initializer] == [
         "x_scale",
         "y_scale",

--- a/tests/sparseml/exporters/transforms/test_delete_repeated_qdq.py
+++ b/tests/sparseml/exporters/transforms/test_delete_repeated_qdq.py
@@ -17,6 +17,7 @@ import pytest
 from onnx import ModelProto
 
 from sparseml.exporters.transforms.delete_repeated_qdq import DeleteRepeatedQdq
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -55,12 +56,12 @@ def onnx_model():
         initializer=[scale],
     )
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
 def test_vanilla(onnx_model: ModelProto):
     onnx_model = DeleteRepeatedQdq().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [n.name for n in onnx_model.graph.node] == ["quant2", "dequant2"]
     assert [i.name for i in onnx_model.graph.initializer] == ["scale"]

--- a/tests/sparseml/exporters/transforms/test_delete_trivial_onnx_adds.py
+++ b/tests/sparseml/exporters/transforms/test_delete_trivial_onnx_adds.py
@@ -16,6 +16,7 @@ import onnx
 import pytest
 
 from sparseml.exporters.transforms import DeleteTrivialOnnxAdds
+from sparsezoo.utils import validate_onnx
 
 
 def _create_test_model(initializer_set_to_nonzero=False):
@@ -84,8 +85,8 @@ def _test_initializer_nonzero(model):
 )
 def test_delete_trivial_onnx_adds(initializer_set_to_nonzero, test_function):
     model = _create_test_model(initializer_set_to_nonzero=initializer_set_to_nonzero)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     transform = DeleteTrivialOnnxAdds()
     model = transform(model)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     test_function(model)

--- a/tests/sparseml/exporters/transforms/test_flatten_qparams.py
+++ b/tests/sparseml/exporters/transforms/test_flatten_qparams.py
@@ -18,6 +18,7 @@ import pytest
 from onnx import ModelProto, numpy_helper
 
 from sparseml.exporters.transforms.flatten_qparams import FlattenQParams
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -57,7 +58,7 @@ def onnx_model():
         initializer=[zp, scale],
     )
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
 
     return model
 
@@ -77,7 +78,7 @@ def test_vanilla(onnx_model: ModelProto):
 
     onnx_model = FlattenQParams().apply(onnx_model)
 
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert len(onnx_model.graph.initializer) == 2
     assert [init.name for init in onnx_model.graph.initializer] == [
         "zero_point",

--- a/tests/sparseml/exporters/transforms/test_fold_conv_div_bn.py
+++ b/tests/sparseml/exporters/transforms/test_fold_conv_div_bn.py
@@ -17,6 +17,7 @@ import pytest
 from onnx import ModelProto
 
 from sparseml.exporters.transforms.fold_conv_div_bn import FoldConvDivBn
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -64,13 +65,13 @@ def onnx_model():
     )
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
 def test_vanilla(onnx_model: ModelProto):
     onnx_model = FoldConvDivBn().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [n.name for n in onnx_model.graph.node] == ["conv"]
     assert [i.name for i in onnx_model.graph.initializer] == ["weight", "conv.bias"]
     assert onnx_model.graph.node[0].op_type == "Conv"
@@ -83,9 +84,9 @@ def test_overwrites_existing_bias(onnx_model: ModelProto):
         )
     )
     onnx_model.graph.node[0].input.append("test_bias")
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
 
     onnx_model = FoldConvDivBn().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [n.name for n in onnx_model.graph.node] == ["conv"]
     assert [i.name for i in onnx_model.graph.initializer] == ["weight", "conv.bias"]

--- a/tests/sparseml/exporters/transforms/test_fold_identity_initializer.py
+++ b/tests/sparseml/exporters/transforms/test_fold_identity_initializer.py
@@ -15,6 +15,7 @@
 import onnx
 
 from sparseml.exporters.transforms import FoldIdentityInitializers
+from sparsezoo.utils import validate_onnx
 
 
 def _create_test_model():
@@ -64,8 +65,8 @@ def _test_result(model):
 
 def test_fold_identity_initializers():
     model = _create_test_model()
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     transform = FoldIdentityInitializers()
     model = transform(model)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     _test_result(model)

--- a/tests/sparseml/exporters/transforms/test_initializers_to_uint8.py
+++ b/tests/sparseml/exporters/transforms/test_initializers_to_uint8.py
@@ -18,6 +18,7 @@ import pytest
 from onnx import ModelProto, numpy_helper
 
 from sparseml.exporters.transforms.initializers_to_uint8 import InitializersToUint8
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -50,13 +51,13 @@ def onnx_model():
     )
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
 def test_vanilla(onnx_model: ModelProto):
     onnx_model = InitializersToUint8().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [n.name for n in onnx_model.graph.node] == ["add"]
     assert [i.name for i in onnx_model.graph.initializer] == ["init1"]
     a = numpy_helper.to_array(onnx_model.graph.initializer[0])

--- a/tests/sparseml/exporters/transforms/test_matmul_add_to_matmulinteger_add_cast_mul.py
+++ b/tests/sparseml/exporters/transforms/test_matmul_add_to_matmulinteger_add_cast_mul.py
@@ -19,6 +19,7 @@ from onnx import helper
 from sparseml.exporters.transforms.matmul_add_to_matmulinteger_add_cast_mul import (
     MatMulAddToMatMulIntegerAddCastMul,
 )
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -77,7 +78,7 @@ def onnx_model() -> onnx.ModelProto:
         initializer=[x_scale, y_scale, zero_point, weight, bias],
     )
     model = helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     assert [i.name for i in model.graph.initializer] == [
         "x_scale",
         "y_scale",
@@ -98,7 +99,7 @@ def onnx_model() -> onnx.ModelProto:
 
 def test_vanilla(onnx_model: onnx.ModelProto):
     onnx_model = MatMulAddToMatMulIntegerAddCastMul().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [i.name for i in onnx_model.graph.initializer] == [
         "zero_point",
         "matmul.weight_quantized",
@@ -122,9 +123,9 @@ def test_vanilla(onnx_model: onnx.ModelProto):
 def test_without_transpose(onnx_model: onnx.ModelProto):
     onnx_model.graph.node[-2].input[1] = "weight_dequant_output"
     onnx_model.graph.node.pop(-3)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     onnx_model = MatMulAddToMatMulIntegerAddCastMul().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [i.name for i in onnx_model.graph.initializer] == [
         "zero_point",
         "matmul.weight_quantized",
@@ -149,10 +150,10 @@ def test_no_bias_changes_nothing(onnx_model: onnx.ModelProto):
     # remove "bias" initializer and "add" node
     assert onnx_model.graph.initializer.pop().name == "bias"
     assert onnx_model.graph.node.pop().name == "add"
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
 
     onnx_model = MatMulAddToMatMulIntegerAddCastMul().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     # NOTE: nothing changes
     assert [i.name for i in onnx_model.graph.initializer] == [
         "x_scale",

--- a/tests/sparseml/exporters/transforms/test_matmul_to_qlinearmatmul.py
+++ b/tests/sparseml/exporters/transforms/test_matmul_to_qlinearmatmul.py
@@ -16,6 +16,7 @@ import onnx
 import pytest
 
 from sparseml.exporters.transforms.matmul_to_qlinearmatmul import MatMulToQLinearMatMul
+from sparsezoo.utils import validate_onnx
 from tests.sparseml.exporters.transforms.test_onnx_transform import (
     _create_model as _create_model_no_matmul,
 )
@@ -145,7 +146,7 @@ def _create_test_model(with_transpose=False, with_reshape=False):
         graph = _add_reshape_and_transpose_node(graph)
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
@@ -281,7 +282,7 @@ def test_convert_quantizable_matmul(with_transpose, with_reshape, testing_functi
     transform = MatMulToQLinearMatMul()
     model = transform(model)
     testing_function(model)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
 
 
 def test_convert_quantizable_matmul_without_matmul():
@@ -289,5 +290,5 @@ def test_convert_quantizable_matmul_without_matmul():
     nodes_in = [node.name for node in model_in.graph.node]
     transform = MatMulToQLinearMatMul()
     model_out = transform(model_in)
-    onnx.checker.check_model(model_out)
+    validate_onnx(model_out)
     assert [node.name for node in model_out.graph.node] == nodes_in

--- a/tests/sparseml/exporters/transforms/test_onnx_transform.py
+++ b/tests/sparseml/exporters/transforms/test_onnx_transform.py
@@ -14,11 +14,11 @@
 
 import os
 
-import onnx
 import pytest
 from onnx import AttributeProto, TensorProto, helper
 
 from sparseml.exporters.transforms import OnnxTransform
+from sparsezoo.utils import save_onnx
 
 
 def _create_model():
@@ -62,5 +62,5 @@ def test_onnx_transform_from_path(tmp_path):
     model = _create_model()
     transform = _TestOnnxTransform()
     path = os.path.join(str(tmp_path), "model.onnx")
-    onnx.save(model, path)
+    save_onnx(model, path)
     assert transform(path)

--- a/tests/sparseml/exporters/transforms/test_propagate_embedding_quantization.py
+++ b/tests/sparseml/exporters/transforms/test_propagate_embedding_quantization.py
@@ -19,6 +19,7 @@ from onnx import ModelProto
 from sparseml.exporters.transforms.propagate_embedding_quantization import (
     PropagateEmbeddingQuantization,
 )
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -76,13 +77,13 @@ def onnx_model():
     )
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
 def test_vanilla(onnx_model: ModelProto):
     onnx_model = PropagateEmbeddingQuantization().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
 
     assert [n.name for n in onnx_model.graph.node] == [
         "gather",

--- a/tests/sparseml/exporters/transforms/test_quantize_qat_embedding.py
+++ b/tests/sparseml/exporters/transforms/test_quantize_qat_embedding.py
@@ -16,6 +16,7 @@ import onnx
 import pytest
 
 from sparseml.exporters.transforms import QuantizeQATEmbedding
+from sparsezoo.utils import validate_onnx
 
 
 def _create_test_model(with_qdq=False):
@@ -79,7 +80,7 @@ def _create_test_model(with_qdq=False):
         graph = _add_qdq_nodes(graph)
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
@@ -143,4 +144,4 @@ def test_quantize_qat_embedding(with_qdq, testing_function):
     transform = QuantizeQATEmbedding()
     model = transform(model)
     testing_function(model)
-    onnx.checker.check_model(model)
+    validate_onnx(model)

--- a/tests/sparseml/exporters/transforms/test_quantize_residuals.py
+++ b/tests/sparseml/exporters/transforms/test_quantize_residuals.py
@@ -17,6 +17,7 @@ import pytest
 from onnx import ModelProto
 
 from sparseml.exporters.transforms.quantize_residuals import QuantizeResiduals
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -55,13 +56,13 @@ def onnx_model():
     )
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
 def test_relu_input(onnx_model: ModelProto):
     onnx_model = QuantizeResiduals().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [(n.name, n.op_type) for n in onnx_model.graph.node] == [
         ("relu", "Relu"),
         ("quant", "QuantizeLinear"),
@@ -79,10 +80,10 @@ def test_relu_input(onnx_model: ModelProto):
 def test_add_input(onnx_model: ModelProto):
     onnx_model.graph.node[0].op_type = "Add"
     onnx_model.graph.node[0].input.append("input")
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
 
     onnx_model = QuantizeResiduals().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
 
     assert [(n.name, n.op_type) for n in onnx_model.graph.node] == [
         ("relu", "Add"),

--- a/tests/sparseml/exporters/transforms/test_remove_duplicate_qconv_weights.py
+++ b/tests/sparseml/exporters/transforms/test_remove_duplicate_qconv_weights.py
@@ -19,6 +19,7 @@ from onnx import ModelProto, numpy_helper
 from sparseml.exporters.transforms.remove_duplicate_qconv_weights import (
     RemoveDuplicateQConvWeights,
 )
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -103,13 +104,13 @@ def onnx_model():
     )
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
 def test_vanilla(onnx_model: ModelProto):
     onnx_model = RemoveDuplicateQConvWeights().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [n.name for n in onnx_model.graph.node] == [
         "conv1",
         "conv2",

--- a/tests/sparseml/exporters/transforms/test_remove_duplicate_quantize_ops.py
+++ b/tests/sparseml/exporters/transforms/test_remove_duplicate_quantize_ops.py
@@ -19,6 +19,7 @@ from onnx import ModelProto
 from sparseml.exporters.transforms.remove_duplicate_quantize_ops import (
     RemoveDuplicateQuantizeOps,
 )
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -54,11 +55,11 @@ def onnx_model():
     )
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
 def test_vanilla(onnx_model: ModelProto):
     onnx_model = RemoveDuplicateQuantizeOps().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [n.name for n in onnx_model.graph.node] == ["quant1"]

--- a/tests/sparseml/exporters/transforms/test_skip_input_quantize.py
+++ b/tests/sparseml/exporters/transforms/test_skip_input_quantize.py
@@ -18,6 +18,7 @@ import pytest
 from onnx import numpy_helper
 
 from sparseml.exporters.transforms.skip_input_quantize import SkipInputQuantize
+from sparsezoo.utils import validate_onnx
 
 
 def onnx_model(input_fp32=False, add_quantize_node=False):
@@ -74,7 +75,7 @@ def onnx_model(input_fp32=False, add_quantize_node=False):
     )
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
@@ -109,5 +110,5 @@ def test_skip_input_quantize(input_fp32, add_quantize_node, testing_func):
     model = onnx_model(input_fp32, add_quantize_node)
     transform = SkipInputQuantize()
     model = transform.apply(model)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     testing_func(model)

--- a/tests/sparseml/exporters/transforms/test_unwrap_batchnorms.py
+++ b/tests/sparseml/exporters/transforms/test_unwrap_batchnorms.py
@@ -18,6 +18,7 @@ import pytest
 from onnx import ModelProto, numpy_helper
 
 from sparseml.exporters.transforms.unwrap_batchnorms import UnwrapBatchNorms
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture
@@ -53,7 +54,7 @@ def onnx_model():
     )
 
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
     return model
 
 
@@ -66,7 +67,7 @@ def test_vanilla(onnx_model: ModelProto):
     assert onnx_model.graph.node[0].output == ["output"]
 
     onnx_model = UnwrapBatchNorms().apply(onnx_model)
-    onnx.checker.check_model(onnx_model)
+    validate_onnx(onnx_model)
     assert [n.name for n in onnx_model.graph.node] == ["add"]
     assert [i.name for i in onnx_model.graph.initializer] == ["init1"]
     assert onnx_model.graph.node[0].input == ["input", "init1"]

--- a/tests/sparseml/onnx/optim/quantization/helpers.py
+++ b/tests/sparseml/onnx/optim/quantization/helpers.py
@@ -22,6 +22,8 @@ import numpy as np
 import onnx
 from onnx import ModelProto, TensorProto, numpy_helper
 
+from sparsezoo.utils import save_onnx
+
 
 __all__ = [
     "make_tmp_onnx_file",
@@ -39,7 +41,7 @@ def _random_float_tensor(name, *shape):
 
 def make_tmp_onnx_file(model: ModelProto) -> str:
     path = tempfile.NamedTemporaryFile(suffix=".onnx", delete=False).name
-    onnx.save(model, path)
+    save_onnx(model, path)
     return path
 
 

--- a/tests/sparseml/onnx/optim/quantization/test_quantize_model_post_training.py
+++ b/tests/sparseml/onnx/optim/quantization/test_quantize_model_post_training.py
@@ -29,6 +29,7 @@ from sparseml.onnx.utils import (
 )
 from sparseml.pytorch.datasets import ImagenetteDataset, ImagenetteSize
 from sparsezoo import Model
+from sparsezoo.utils import save_onnx
 
 
 def _test_model_is_quantized(
@@ -79,7 +80,7 @@ def _test_resnet_identity_quant(model_path, has_resnet_block, save_optimized):
     # check that running the optimization has no affect even if its already been run
     assert not quantize_resnet_identity_add_inputs(quant_model)
     if save_optimized:
-        onnx.save(quant_model, model_path)
+        save_onnx(quant_model, model_path)
 
 
 @pytest.mark.skipif(

--- a/tests/sparseml/onnx/utils/test_graph_editor.py
+++ b/tests/sparseml/onnx/utils/test_graph_editor.py
@@ -15,7 +15,6 @@
 from typing import List
 
 import numpy
-import onnx
 import pytest
 from onnx import load_model
 
@@ -25,6 +24,7 @@ from sparseml.onnx.utils import (
     prune_model_one_shot,
     prune_unstructured,
 )
+from sparsezoo.utils import validate_onnx
 from tests.sparseml.onnx.helpers import OnnxRepoModelFixture
 
 
@@ -117,7 +117,7 @@ def test_sort_nodes_topologically(
 ):
     model_path = onnx_repo_models.model_path
     model = load_model(model_path)
-    onnx.checker.check_model(model)  # assert that starting model is valid
+    validate_onnx(model)  # assert that starting model is valid
 
     # create invalid model by changing node ordering
     nodes = list(model.graph.node)
@@ -127,7 +127,7 @@ def test_sort_nodes_topologically(
             numpy.random.shuffle(nodes)
             model.graph.ClearField("node")
             model.graph.node.extend(nodes)
-            onnx.checker.check_model(model)
+            validate_onnx(model)
         except Exception:
             # checker failed due to node topo ordering
             checker_failed = True
@@ -137,4 +137,4 @@ def test_sort_nodes_topologically(
     graph = ONNXGraph(model)
     graph.sort_nodes_topologically()
     # check that sorted model is valid
-    onnx.checker.check_model(model)
+    validate_onnx(model)

--- a/tests/sparseml/onnx/utils/test_helpers.py
+++ b/tests/sparseml/onnx/utils/test_helpers.py
@@ -24,7 +24,6 @@ from sparseml.onnx.utils import (
     NodeParam,
     SparsityMeasurement,
     calculate_flops,
-    check_load_model,
     conv_node_params,
     extract_node_id,
     extract_node_shapes,
@@ -152,13 +151,6 @@ def get_prunable_onnx_model():
 @pytest.fixture
 def prunable_onnx_model():
     return get_prunable_onnx_model()
-
-
-def test_check_load_model(onnx_repo_models):  # noqa: F811
-    model_path = onnx_repo_models.model_path
-    loaded_model = load_model(model_path)
-    assert loaded_model == check_load_model(model_path)
-    assert loaded_model == check_load_model(loaded_model)
 
 
 @pytest.mark.parametrize(

--- a/tests/sparseml/pytorch/image_classification/test_export.py
+++ b/tests/sparseml/pytorch/image_classification/test_export.py
@@ -23,6 +23,7 @@ from click.testing import CliRunner
 from sparseml.pytorch.image_classification.export import main
 from sparseml.pytorch.models import resnet18
 from sparsezoo.analyze import ModelAnalysis
+from sparsezoo.utils import validate_onnx
 
 
 @pytest.fixture()
@@ -83,7 +84,7 @@ def test_export_one_shot(resnet_checkpoint, recipe_path, temp_dir):
 
     # exported file is valid onnx
     model = onnx.load(expected_onnx_path)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
 
     # check onnx model is sparse
     model_analysis = ModelAnalysis.from_onnx(onnx_file_path=expected_onnx_path)

--- a/tests/sparseml/pytorch/test_torch_to_onnx_exporter.py
+++ b/tests/sparseml/pytorch/test_torch_to_onnx_exporter.py
@@ -26,6 +26,7 @@ from sparseml.pytorch.models.registry import ModelRegistry
 from sparseml.pytorch.sparsification.quantization import QuantizationModifier
 from sparseml.pytorch.torch_to_onnx_exporter import TorchToONNX
 from sparseml.pytorch.utils import ModuleExporter
+from sparsezoo.utils import validate_onnx
 from tests.sparseml.pytorch.helpers import ConvNet, LinearNet, MLPNet
 
 
@@ -228,8 +229,8 @@ def _assert_onnx_models_are_equal(
     sample_batch: torch.Tensor,
     expect_op_types=None,
 ):
-    onnx.checker.check_model(old_model_path)
-    onnx.checker.check_model(new_model_path)
+    validate_onnx(old_model_path)
+    validate_onnx(new_model_path)
 
     old_model = onnx.load(old_model_path)
     new_model = onnx.load(new_model_path)

--- a/tests/sparseml/pytorch/utils/test_exporter.py
+++ b/tests/sparseml/pytorch/utils/test_exporter.py
@@ -26,6 +26,7 @@ from sparseml.pytorch.utils.exporter import (
     _flatten_qparams,
     _fold_identity_initializers,
 )
+from sparsezoo.utils import validate_onnx
 from tests.sparseml.pytorch.helpers import MLPNet
 
 
@@ -72,7 +73,7 @@ def test_fold_identity_initializers():
         initializer=[init1],
     )
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
 
     assert len(model.graph.node) == 2
     assert len(model.graph.initializer) == 1
@@ -84,7 +85,7 @@ def test_fold_identity_initializers():
     assert [node.name for node in model.graph.node] == ["add"]
     assert model.graph.node[0].input == ["init1", "input"]
 
-    onnx.checker.check_model(model)
+    validate_onnx(model)
 
 
 def test_flatten_params():
@@ -113,7 +114,7 @@ def test_flatten_params():
         initializer=[zp, scale],
     )
     model = onnx.helper.make_model(graph)
-    onnx.checker.check_model(model)
+    validate_onnx(model)
 
     assert len(model.graph.initializer) == 2
     assert [init.name for init in model.graph.initializer] == ["zero_point", "scale"]
@@ -135,4 +136,4 @@ def test_flatten_params():
     assert scale.shape == ()
     assert scale.dtype == numpy.float32
 
-    onnx.checker.check_model(model)
+    validate_onnx(model)


### PR DESCRIPTION
Uses the helper functions from sparsezoo to work reliably with the larger models (bigger than protobuf size, where the large data information is stored in the additional accompanying file).

Replaced all the instances where onnx model is saved with the sparsezoo helper function.
Replaced all the instances where onnx model is checked with the sparsezoo helper function.

GHA fail because we are not using the updated sparsezoo repository. 
After pip installing this branch: [neuralmagic/sparsezoo#308](https://github.com/neuralmagic/sparsezoo/pull/308) locally, I got all green tests for `pytorch` and `onnx` test targets.