### PR TITLE
[Transformers] Allow for model-less dataset creation

### DIFF
--- a/src/sparseml/transformers/export.py
+++ b/src/sparseml/transformers/export.py
@@ -178,7 +178,7 @@ def load_task_dataset(
 
         data_training_args = DataTrainingArguments(**data_args)
         return get_tokenized_token_classification_dataset(
-            data_args=data_training_args, tokenizer=tokenizer, model=model
+            data_args=data_training_args, tokenizer=tokenizer, model=model or config
         )
 
     if (

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -705,7 +705,7 @@ def _get_tokenized_and_preprocessed_raw_datasets(
     ) = _get_label_info(data_args, raw_datasets)
 
     train_dataset = predict_dataset = eval_dataset = None
-    config = config if model else config
+    config = model.config if model else config
     if not main_process_func:
         main_process_func = lambda desc: nullcontext(desc)  # noqa: E731
 

--- a/src/sparseml/transformers/text_classification.py
+++ b/src/sparseml/transformers/text_classification.py
@@ -687,7 +687,7 @@ def _get_label_info(data_args, raw_datasets):
 def _get_tokenized_and_preprocessed_raw_datasets(
     config,
     data_args: DataTrainingArguments,
-    model: Module,
+    model: Optional[Module],
     raw_datasets,
     tokenizer: transformers.PreTrainedTokenizerBase,
     teacher_tokenizer=None,
@@ -705,6 +705,7 @@ def _get_tokenized_and_preprocessed_raw_datasets(
     ) = _get_label_info(data_args, raw_datasets)
 
     train_dataset = predict_dataset = eval_dataset = None
+    config = config if model else config
     if not main_process_func:
         main_process_func = lambda desc: nullcontext(desc)  # noqa: E731
 
@@ -757,11 +758,11 @@ def _get_tokenized_and_preprocessed_raw_datasets(
     )
 
     if label_to_id is not None:
-        model.config.label2id = label_to_id
-        model.config.id2label = {id: label for label, id in config.label2id.items()}
+        config.label2id = label_to_id
+        config.id2label = {id: label for label, id in config.label2id.items()}
     elif data_args.task_name is not None and not is_regression:
-        model.config.label2id = {l: i for i, l in enumerate(label_list)}
-        model.config.id2label = {id: label for label, id in config.label2id.items()}
+        config.label2id = {l: i for i, l in enumerate(label_list)}
+        config.id2label = {id: label for label, id in config.label2id.items()}
 
     max_seq_length = data_args.max_seq_length
     if max_seq_length > tokenizer.model_max_length:

--- a/src/sparseml/transformers/token_classification.py
+++ b/src/sparseml/transformers/token_classification.py
@@ -728,7 +728,7 @@ def _get_tokenized_dataset(
     data_args: DataTrainingArguments,
     label_list: List,
     labels_are_int: bool,
-    model: Module,
+    model: Module,  # model config object can be passed in as well
     num_labels: int,
     raw_datasets: Union[Dataset, DatasetDict, IterableDatasetDict, IterableDataset],
     tokenizer: transformers.PreTrainedTokenizerBase,
@@ -741,29 +741,30 @@ def _get_tokenized_dataset(
     do_predict: bool = False,
 ) -> Dict[str, Any]:
     train_dataset = predict_dataset = eval_dataset = None
+    config = model.config if isinstance(model, Module) else model
     # Model has labels -> use them.
-    if model.config.label2id != PretrainedConfig(num_labels=num_labels).label2id:
-        if list(sorted(model.config.label2id.keys())) == list(sorted(label_list)):
+    if config.label2id != PretrainedConfig(num_labels=num_labels).label2id:
+        if list(sorted(config.label2id.keys())) == list(sorted(label_list)):
             # Reorganize `label_list` to match the ordering of the model.
             if labels_are_int:
                 label_to_id = {
-                    i: int(model.config.label2id[l]) for i, l in enumerate(label_list)
+                    i: int(config.label2id[l]) for i, l in enumerate(label_list)
                 }
-                label_list = [model.config.id2label[i] for i in range(num_labels)]
+                label_list = [config.id2label[i] for i in range(num_labels)]
             else:
-                label_list = [model.config.id2label[i] for i in range(num_labels)]
+                label_list = [config.id2label[i] for i in range(num_labels)]
                 label_to_id = {l: i for i, l in enumerate(label_list)}
         else:
             _LOGGER.warning(
                 "Your model seems to have been trained with labels, but they don't "
                 "match the dataset: ",
-                f"model labels: {list(sorted(model.config.label2id.keys()))}, dataset "
+                f"model labels: {list(sorted(config.label2id.keys()))}, dataset "
                 f"labels: {list(sorted(label_list))}."
                 "\nIgnoring the model labels as a result.",
             )
     # Set the correspondences label/ID inside the model config
-    model.config.label2id = {l: i for i, l in enumerate(label_list)}
-    model.config.id2label = {i: l for i, l in enumerate(label_list)}
+    config.label2id = {l: i for i, l in enumerate(label_list)}
+    config.id2label = {i: l for i, l in enumerate(label_list)}
     # Map that sends B-Xxx label to its I-Xxx counterpart
     b_to_i_label = []
     for idx, label in enumerate(label_list):


### PR DESCRIPTION
Currently, a pytorch model is required to create a text-classification or token-classification dataset. This PR removes the requirement and allows instead a config to be used directly.

Test plan
Local testing with DeepSparse deployment folder