### PR TITLE
Add arguments to set RGB mean std for IC

### DIFF
--- a/src/sparseml/pytorch/torchvision/train.py
+++ b/src/sparseml/pytorch/torchvision/train.py
@@ -267,6 +267,8 @@ def load_data(traindir, valdir, args):
             traindir,
             presets.ClassificationPresetTrain(
                 crop_size=train_crop_size,
+                mean=args.rgb_mean,
+                std=args.rgb_std,
                 interpolation=interpolation,
                 auto_augment_policy=auto_augment_policy,
                 random_erase_prob=random_erase_prob,
@@ -289,6 +291,8 @@ def load_data(traindir, valdir, args):
     else:
         preprocessing = presets.ClassificationPresetEval(
             crop_size=val_crop_size,
+            mean=args.rgb_mean,
+            std=args.rgb_std,
             resize_size=val_resize_size,
             interpolation=interpolation,
         )
@@ -1210,6 +1214,26 @@ def _deprecate_old_arguments(f):
         "The architecture key for teacher image classification model; "
         "example: `resnet50`, `mobilenet`. "
         "Note: Will be read from the checkpoint if not specified"
+    ),
+)
+@click.option(
+    "--rgb-mean",
+    nargs=3,
+    default=(0.485, 0.456, 0.406),
+    type=float,
+    help=(
+        "RGB mean values used to shift input RGB values; "
+        "Note: Will use ImageNet values if not specified."
+    ),
+)
+@click.option(
+    "--rgb-std",
+    default=(0.229, 0.224, 0.225),
+    nargs=3,
+    type=float,
+    help=(
+        "RGB standard-deviation values used to normalize input RGB values; "
+        "Note: Will use ImageNet values if not specified."
     ),
 )
 @click.pass_context


### PR DESCRIPTION
The existing IC flow normalizes the input images using the RGB mean and std values from ImageNet (as is common in many IC flows).
This PR adds arguments that allow the user to override the default values for RGB mean and std. The PR is driven by EficientNetV2-L, which uses different values for the RGB mean and std, but it is a desirable feature in general.

**Testing plan:**
1. Evaluated EfficientNetV2-L overriding RGB mean and std and verified accuracy
```
sparseml.image_classification.train \
    --checkpoint-path zoo:cv/classification/efficientnet_v2-l/pytorch/sparseml/imagenet/base-none \
    --test-only \
    --arch-key efficientnet_v2_l \
    --dataset-path ~/datasets/imagenet_calib \
    --rgb-mean 0.5 0.5 0.5 \
    --rgb-std 0.5 0.5 0.5 \
    --val-crop-size 480 \
    --val-resize-size 480 \
    --interpolation bicubic \
    --batch-size 32
```

2. Evaluated EfficietNetV2-S without overriding RGB mean and std and verified accuracy
```
sparseml.image_classification.train \
    --checkpoint-path zoo:cv/classification/efficientnet_v2-s/pytorch/sparseml/imagenet/base-none \
    --test-only \
    --arch-key efficientnet_v2_s \
    --dataset-path ~/datasets/imagenet_calib \
    --val-crop-size 384 \
    --val-resize-size 384 \
    --batch-size 32
```