### PR TITLE
Fix loading Yolov8 sparsezoo models

### DIFF
--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -534,6 +534,7 @@ class SparseYOLO(YOLO):
             model = download_framework_model_by_recipe_type(
                 Model(model_str), model_suffix="pt"
             )
+            model_str = str(model)
             self.is_sparseml_checkpoint = True
 
         if model_str.endswith(".pt"):
@@ -800,6 +801,7 @@ class SparseYOLO(YOLO):
         overrides["rect"] = True  # rect batches as default
         overrides.update(kwargs)
         overrides["mode"] = "val"
+        overrides["data"] = data or overrides["data"]
         args = get_cfg(cfg=DEFAULT_CFG, overrides=overrides)
         args.data = data or args.data
         args.task = self.task

--- a/src/sparseml/yolov8/val.py
+++ b/src/sparseml/yolov8/val.py
@@ -77,7 +77,6 @@ from sparseml.yolov8.utils import data_from_dataset_path
     help="Path to override default datasets path.",
 )
 @click.option("--batch", default=16, type=int, help="number of images per batch")
-
 def main(**kwargs):
     if kwargs["dataset_path"] is not None:
         kwargs["data"] = data_from_dataset_path(kwargs["data"], kwargs["dataset_path"])

--- a/src/sparseml/yolov8/val.py
+++ b/src/sparseml/yolov8/val.py
@@ -76,6 +76,8 @@ from sparseml.yolov8.utils import data_from_dataset_path
     default=None,
     help="Path to override default datasets path.",
 )
+@click.option("--batch", default=16, type=int, help="number of images per batch")
+
 def main(**kwargs):
     if kwargs["dataset_path"] is not None:
         kwargs["data"] = data_from_dataset_path(kwargs["data"], kwargs["dataset_path"])


### PR DESCRIPTION
Loading pretrained yolov8 models from sparsezoo stubs fails for sparseML checkpoints. This PR fixes this issue.

Testing Plan:
Running yolov8 training commands with models from sparsezoo.