### PR TITLE
Add explicit opencv dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,10 @@ _pytorch_all_deps = _pytorch_deps + [
     "torchvision>=0.3.0,<0.15",
     "torchaudio<=0.13",
 ]
-_pytorch_vision_deps = _pytorch_deps + ["torchvision>=0.3.0,<0.15"]
+_pytorch_vision_deps = _pytorch_deps + [
+    "torchvision>=0.3.0,<0.15",
+    "opencv-python<=4.6.0.66",
+]
 _transformers_deps = _pytorch_deps + [
     f"{'nm-transformers' if is_release else 'nm-transformers-nightly'}"
     f"~={version_nm_deps}",


### PR DESCRIPTION
The current install spaseml[torchvision] command does not include opencv and will result in an error on runtime. This PR adds the requirement with the same version constraints as DeepSparse