### PR TITLE
Convert OPT MatMuls with quantized inputs to MatMulInteger

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
@@ -665,9 +665,11 @@ def _convert_quantizable_matmuls_with_nonquantized_outputs(model: ModelProto):
         # Check if is followed by Add node (bias)
         bias_add_node = graph.get_node_single_child(matmul_node)
         if bias_add_node is not None and bias_add_node.op_type == "Add":
-            bias_initializer = get_init_by_name(model, bias_add_node.input[1]) or get_init_by_name(model, bias_add_node.input[0])
+            bias_initializer = get_init_by_name(
+                model, bias_add_node.input[1]
+            ) or get_init_by_name(model, bias_add_node.input[0])
             if bias_initializer is not None:
-                #check if bias is finite
+                # check if bias is finite
                 bias_initializer = numpy_helper.to_array(bias_initializer)
                 if numpy.all(numpy.isfinite(bias_initializer)):
                     # Create initializer for quantized bias
@@ -676,7 +678,10 @@ def _convert_quantizable_matmuls_with_nonquantized_outputs(model: ModelProto):
 
                     bias_zero_point = 0
                     quantized_bias = _quantize_array(
-                        bias_initializer, output_scale, bias_zero_point, dtype=numpy.int32
+                        bias_initializer,
+                        output_scale,
+                        bias_zero_point,
+                        dtype=numpy.int32,
                     )
                     quantized_bias_initializer = numpy_helper.from_array(
                         quantized_bias,
@@ -697,7 +702,9 @@ def _convert_quantizable_matmuls_with_nonquantized_outputs(model: ModelProto):
         # Casting MatMulInteger INT32 output to FP32
 
         cast_node_name = f"{matmul_node.name}_cast"
-        cast_node_input = quantized_add_node.output if has_bias else matmul_int_op_node.output
+        cast_node_input = (
+            quantized_add_node.output if has_bias else matmul_int_op_node.output
+        )
         cast_node = onnx.helper.make_node(
             "Cast",
             cast_node_input,

--- a/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
@@ -841,8 +841,11 @@ def _convert_quantizable_matmul_with_quantized_outputs(model: ModelProto):
 
     if matmul_nodes:
         _LOGGER.info(
-            f"Converted {conversion_count} quantizable MatMul ops " "to QLinearMatMul"
+            f"Converted {conversion_count} quantizable MatMul with quantized outputs "
+            "to QLinearMatMul"
         )
+
+    return conversion_count
 
 
 def _convert_quantizable_matmul(model: ModelProto):

--- a/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize_qat_export.py
@@ -629,7 +629,6 @@ def _convert_quantizable_matmuls_with_nonquantized_outputs(model: ModelProto):
         ):
             continue
 
-        current_output = matmul_node
         _LOGGER.debug(f"Matched quantizable MatMul: {matmul_node.name}")
 
         # Create MatMulInteger node
@@ -670,7 +669,8 @@ def _convert_quantizable_matmuls_with_nonquantized_outputs(model: ModelProto):
 
     if matmul_nodes:
         _LOGGER.info(
-            f"Converted {conversion_count} quantizable MatMul (A8A8 inputs, FP output) ops to MatMulInteger"
+            f"Converted {conversion_count} quantizable MatMul "
+            "(A8A8 inputs, FP output) ops to MatMulInteger"
         )
         graph = ONNXGraph(model)
         graph.delete_unused_initializers()


### PR DESCRIPTION
This change enables converting the torch.bmm with two quantized inputs and non-quantized output to MatMulInteger. This procedure is mutually exclusive with the existing one for QATMatMul-based quantized matmuls.

The attached graph shows two MatMulInteger that are the results of this conversion on OPT-125m.
 
![after](https://github.com/neuralmagic/sparseml/assets/2721633/9abae0ff-5a40-4969-a451-adc6f4383196)

Note that the quantization of these MatMuls on OPT requires [this PR](https://github.com/neuralmagic/transformers/pull/78).