### PR TITLE
[Cherry pick] dependency installation

### DIFF
--- a/.github/workflows/Integrations-post-merge-check.yaml
+++ b/.github/workflows/Integrations-post-merge-check.yaml
@@ -44,10 +44,6 @@ jobs:
       - name: "Upgrade protobuf version"
         run: pip3 install --upgrade protobuf
       - name: "⚙️ Install dependencies"
-        run: pip3 install .[dev,torchvision,deepsparse,onnxruntime]
-      - name: "Install transformers integration"
-        run: sparseml.transformers.question_answering --help
-      - name: "Install yolov5 integration"
-        run: sparseml.yolov5.train --help
+        run: pip3 install .[dev,torchvision,deepsparse,onnxruntime,transformers,yolov5]
       - name: "🔬 Running integrations tests (cadence: commit}})"
         run: make testinteg TARGETS=yolov5,transformers,image_classification


### PR DESCRIPTION
Cherry Pick: `7c2800982df8ba09f62d1637db63db11b42be9b0`

This Cherry pick was originally missed and was causing post merge integration tests to fail on RC