### PR TITLE
Fix for quantization modifier w/ DDP

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -361,10 +361,13 @@ def _match_submodule_name_or_type(
     #   2. match the submodule prefix (longest first)
     submodule_match = ""
     for name_or_type in names_or_types:
+        name_to_compare = submodule_name[:]
+        if name_to_compare.startswith("module."):
+            name_to_compare = name_to_compare[7:]
         if name_or_type == submodule.__class__.__name__:
             # type match, return type name
             return name_or_type
-        if submodule_name.startswith(name_or_type) and (
+        if name_to_compare.startswith(name_or_type) and (
             len(name_or_type) > len(submodule_match)
         ):
             # match to most specific submodule name
@@ -422,7 +425,10 @@ def _validate_set_module_schemes(
         for type_or_name in types_or_names:
             matched = False
             for submodule_name, submodule in model.named_modules():
-                if submodule_name.startswith(type_or_name) or (
+                name_to_match = submodule_name[:]
+                if name_to_match.startswith("module."):
+                    name_to_match = name_to_match[7:]
+                if name_to_match.startswith(type_or_name) or (
                     submodule.__class__.__name__ == type_or_name
                 ):
                     matched = True

--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -425,10 +425,10 @@ def _validate_set_module_schemes(
         for type_or_name in types_or_names:
             matched = False
             for submodule_name, submodule in model.named_modules():
-                name_to_match = submodule_name[:]
-                if name_to_match.startswith("module."):
-                    name_to_match = name_to_match[7:]
-                if name_to_match.startswith(type_or_name) or (
+                name_to_compare = submodule_name[:]
+                if name_to_compare.startswith("module."):
+                    name_to_compare = name_to_compare[7:]
+                if name_to_compare.startswith(type_or_name) or (
                     submodule.__class__.__name__ == type_or_name
                 ):
                     matched = True


### PR DESCRIPTION
Removes "module." from submodule names inserted by DDP.

**Test plan:**
Re-quantized the pruned 80% RN50 model with the following quantization modifier:
```
  - !QuantizationModifier
    start_epoch: eval(quant_start_epoch)
    disable_quantization_observer_epoch: eval(quant_disable_observer_epoch)
    freeze_bn_stats_epoch: eval(quant_freeze_bn_epoch)
    ignore: ['Softmax', 'classifier']
```
Before this PR the quantization modifier failed to match the "classifier" module name because under DDP this module was renamed as module.classifier
