### PR TITLE
Update sparseml to support torch 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ _pytorch_deps = [
 ]
 _pytorch_all_deps = _pytorch_deps + [
     "torchvision>=0.3.0,<=0.15.1",
-    "torchaudio<=0.13",
+    "torchaudio<=2.0.1",
 ]
 _pytorch_vision_deps = _pytorch_deps + [
     "torchvision>=0.3.0,<=0.15.1",

--- a/setup.py
+++ b/setup.py
@@ -68,11 +68,11 @@ _pytorch_deps = [
     "gputils",
 ]
 _pytorch_all_deps = _pytorch_deps + [
-    "torchvision>=0.3.0,<=0.15",
+    "torchvision>=0.3.0,<=0.15.1",
     "torchaudio<=0.13",
 ]
 _pytorch_vision_deps = _pytorch_deps + [
-    "torchvision>=0.3.0,<=0.15",
+    "torchvision>=0.3.0,<=0.15.1",
     "opencv-python<=4.6.0.66",
 ]
 _transformers_deps = _pytorch_deps + [

--- a/setup.py
+++ b/setup.py
@@ -62,17 +62,17 @@ _deepsparse_deps = [
 _deepsparse_ent_deps = [f"deepsparse-ent~={version_nm_deps}"]
 
 _onnxruntime_deps = ["onnxruntime>=1.0.0"]
-supported_torch_version = "torch>=1.7.0,<1.14"
+supported_torch_version = "torch>=1.7.0,<=2.0"
 _pytorch_deps = [
     supported_torch_version,
     "gputils",
 ]
 _pytorch_all_deps = _pytorch_deps + [
-    "torchvision>=0.3.0,<0.15",
+    "torchvision>=0.3.0,<=0.15",
     "torchaudio<=0.13",
 ]
 _pytorch_vision_deps = _pytorch_deps + [
-    "torchvision>=0.3.0,<0.15",
+    "torchvision>=0.3.0,<=0.15",
     "opencv-python<=4.6.0.66",
 ]
 _transformers_deps = _pytorch_deps + [

--- a/src/sparseml/pytorch/base.py
+++ b/src/sparseml/pytorch/base.py
@@ -49,7 +49,7 @@ __all__ = [
 
 
 _TORCH_MIN_VERSION = "1.0.0"
-_TORCH_MAX_VERSION = "1.13.100"  # set bug to 100 to support all future 1.9.X versions
+_TORCH_MAX_VERSION = "2.0.0"  # set bug to 100 to support all future 1.9.X versions
 
 
 def check_torch_install(

--- a/src/sparseml/pytorch/base.py
+++ b/src/sparseml/pytorch/base.py
@@ -49,7 +49,7 @@ __all__ = [
 
 
 _TORCH_MIN_VERSION = "1.0.0"
-_TORCH_MAX_VERSION = "2.0.0"
+_TORCH_MAX_VERSION = "2.0.100"
 
 
 def check_torch_install(

--- a/src/sparseml/pytorch/base.py
+++ b/src/sparseml/pytorch/base.py
@@ -49,7 +49,7 @@ __all__ = [
 
 
 _TORCH_MIN_VERSION = "1.0.0"
-_TORCH_MAX_VERSION = "2.0.0"  # set bug to 100 to support all future 1.9.X versions
+_TORCH_MAX_VERSION = "2.0.0"
 
 
 def check_torch_install(


### PR DESCRIPTION
- Updated max version of `torch` to be 2.0, updated `torchvision` max to be `0.15.1`
- Updated max `torchaudio` to be `2.0.1`
- Tested and passed all `pytorch` tests 
- Tested updated package versions in training using `sparseml.image_classification.train`. Used the `ImageNette` dataset and `ResNet-50` model from SparseZoo

```
# Epoch and Learning-Rate variables
num_epochs: 3.0
init_lr: 0.0005

# quantization variables
quantization_epochs: 1.0

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0.0
    end_epoch: eval(num_epochs)

  - !LearningRateFunctionModifier
    final_lr: 0.0
    init_lr: eval(init_lr)
    lr_func: cosine
    start_epoch: 0.0
    end_epoch: eval(num_epochs)

# Phase 1 Sparse Transfer Learning / Recovery
sparse_transfer_learning_modifiers:
  - !ConstantPruningModifier
    start_epoch: 0.0
    params: __ALL_PRUNABLE__

# Phase 2 Apply quantization
sparse_quantized_transfer_learning_modifiers:
  - !QuantizationModifier
    start_epoch: eval(num_epochs - quantization_epochs)
```

- Trained using the sample recipe above and then exported in onnx using `sparseml.image_classification.export_onnx`
- Confirmed size of the onnx export model to match another model trained/exported using torch 1.13.1 (23 mb) and validated graph using Netron thanks to @KSGulin 