### PR TITLE
Upgrade numpy to 1.21.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ _deps = [
     "ipywidgets>=7.0.0",
     "pyyaml>=5.0.0",
     "progressbar2>=3.0.0",
-    "numpy>=1.0.0,<=1.21.6",
+    "numpy>=1.0.0",
     "matplotlib>=3.0.0",
     "merge-args>=0.1.0",
     "onnx>=1.5.0,<1.15.0",


### PR DESCRIPTION
Updates support to latest numpy
Needed to support deepsparse numpy version upgrade from https://github.com/neuralmagic/deepsparse/pull/1094

The deepsparse change was made to support a ragged sequence being created in question answering pipeline during `spans_extra_info` computation; landing this diff along with   https://github.com/neuralmagic/sparsezoo/pull/332 also fixes a few google colab errors we were seeing before.