### PR TITLE
[BugFix] Hide `sparseml.benchmark`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,6 @@ def _setup_entry_points() -> Dict:
     entry_points = {
         "console_scripts": [
             # sparsification
-            "sparseml.benchmark=sparseml.benchmark.info:_main",
             "sparseml.framework=sparseml.framework.info:_main",
             "sparseml.sparsification=sparseml.sparsification.info:_main",
         ]

--- a/src/sparseml/benchmark/info.py
+++ b/src/sparseml/benchmark/info.py
@@ -91,7 +91,6 @@ sparseml.benchmark --framework onnx --model ~/downloads/model.onnx \
 import argparse
 import logging
 import os
-import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterable, Iterator, Optional
 
@@ -105,7 +104,7 @@ from sparseml.benchmark.serialization import (
     BenchmarkResult,
 )
 from sparseml.framework.info import FrameworkInferenceProviderInfo, FrameworkInfo
-from sparseml.utils import clean_path, create_parent_dirs
+from sparseml.utils import clean_path, create_parent_dirs, deprecation_warning
 from sparseml.utils.helpers import convert_to_bool
 
 
@@ -545,10 +544,8 @@ def _parse_args():
 
 
 def _main():
-    warnings.warn(
-        f"{__file__} is scheduled for deprecation in a future version",
-        DeprecationWarning,
-        2,
+    deprecation_warning(
+        message=f"{__file__} is scheduled for deprecation in a future version",
     )
     args = _parse_args()
     save_benchmark_results(

--- a/src/sparseml/benchmark/info.py
+++ b/src/sparseml/benchmark/info.py
@@ -91,6 +91,7 @@ sparseml.benchmark --framework onnx --model ~/downloads/model.onnx \
 import argparse
 import logging
 import os
+import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterable, Iterator, Optional
 
@@ -544,6 +545,11 @@ def _parse_args():
 
 
 def _main():
+    warnings.warn(
+        f"{__file__} is scheduled for deprecation in a future version",
+        DeprecationWarning,
+        2,
+    )
     args = _parse_args()
     save_benchmark_results(
         model=args.model,


### PR DESCRIPTION
This PR is a first step towards deprecating `sparseml.benchmark` utility which is fairly old and will be deprecated/refactored or removed in a future version

For now, this removes the public pathway `sparseml.benchmark`
Additionally raises a deprecation warning if the script is invoked directly

The actual utility wasn't removed as of yet, cause the helpers in this namespace might be required by `sparsify`