### PR TITLE
[1.5.2] restrict pandas to <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ _deps = [
     "matplotlib>=3.0.0",
     "merge-args>=0.1.0",
     "onnx>=1.5.0,<=1.12.0",
-    "pandas>=0.25.0",
+    "pandas>=0.25.0,<2.0",
     "packaging>=20.0",
     "psutil>=5.0.0",
     "pydantic>=1.5.0",

--- a/src/sparseml/version.py
+++ b/src/sparseml/version.py
@@ -19,7 +19,7 @@ Functionality for storing and setting the version info for SparseML
 from datetime import date
 
 
-version_base = "1.5.1"
+version_base = "1.5.2"
 is_release = False  # change to True to set the generated version as a release version
 
 


### PR DESCRIPTION
this fixes a bug in the latest NM 1.5 supported transformers datasets that is incompatible with pandas 2.0. Specifically, a removed kwarg is passed to pandas on `datasets.load_dataset`.

Future releases will support later datasets versions.