### PR TITLE
[torch 2.0] Set `torch.compile` to raise a warning

### DIFF
--- a/src/sparseml/pytorch/__init__.py
+++ b/src/sparseml/pytorch/__init__.py
@@ -29,7 +29,7 @@ try:
 
     if _PARSED_TORCH_VERSION.major >= 2:
 
-        def raise_torch_compile_error(*args):
+        def raise_torch_compile_error(*args, **kwargs):
             raise RuntimeError(
                 "torch.compile is not supported by sparseml for torch 2.0.x"
             )

--- a/src/sparseml/pytorch/__init__.py
+++ b/src/sparseml/pytorch/__init__.py
@@ -29,11 +29,13 @@ try:
 
     if _PARSED_TORCH_VERSION.major >= 2:
 
-        def raise_torch_compile_warning():
-            warnings.warn("torch.compile is not supported by sparseml for torch 2.0.x")
-            return torch.compile
+        torch_compile_func = torch.compile
 
-        torch.compile = raise_torch_compile_warning()
+        def raise_torch_compile_warning(*args, **kwargs):
+            warnings.warn("torch.compile is not supported by sparseml for torch 2.0.x")
+            return torch_compile_func(*args, **kwargs)
+
+        torch.compile = raise_torch_compile_warning
 
     _BYPASS = bool(int(os.environ.get("NM_BYPASS_TORCH_VERSION", "0")))
     if _PARSED_TORCH_VERSION.major == 1 and _PARSED_TORCH_VERSION.minor in [10, 11]:

--- a/src/sparseml/pytorch/__init__.py
+++ b/src/sparseml/pytorch/__init__.py
@@ -26,6 +26,17 @@ try:
     import torch
 
     _PARSED_TORCH_VERSION = version.parse(torch.__version__)
+
+    if _PARSED_TORCH_VERSION.major >= 2:
+
+        def raise_torch_compile_error():
+            raise RuntimeError(
+                "torch.compile is not supported by sparseml for \
+            torch 2.0.x"
+            )
+
+        torch.compile = raise_torch_compile_error
+
     _BYPASS = bool(int(os.environ.get("NM_BYPASS_TORCH_VERSION", "0")))
     if _PARSED_TORCH_VERSION.major == 1 and _PARSED_TORCH_VERSION.minor in [10, 11]:
         if not _BYPASS:

--- a/src/sparseml/pytorch/__init__.py
+++ b/src/sparseml/pytorch/__init__.py
@@ -29,12 +29,11 @@ try:
 
     if _PARSED_TORCH_VERSION.major >= 2:
 
-        def raise_torch_compile_error(*args, **kwargs):
-            raise RuntimeError(
-                "torch.compile is not supported by sparseml for torch 2.0.x"
-            )
+        def raise_torch_compile_warning():
+            warnings.warn("torch.compile is not supported by sparseml for torch 2.0.x")
+            return torch.compile
 
-        torch.compile = raise_torch_compile_error
+        torch.compile = raise_torch_compile_warning()
 
     _BYPASS = bool(int(os.environ.get("NM_BYPASS_TORCH_VERSION", "0")))
     if _PARSED_TORCH_VERSION.major == 1 and _PARSED_TORCH_VERSION.minor in [10, 11]:

--- a/src/sparseml/pytorch/__init__.py
+++ b/src/sparseml/pytorch/__init__.py
@@ -29,10 +29,9 @@ try:
 
     if _PARSED_TORCH_VERSION.major >= 2:
 
-        def raise_torch_compile_error():
+        def raise_torch_compile_error(*args):
             raise RuntimeError(
-                "torch.compile is not supported by sparseml for \
-            torch 2.0.x"
+                "torch.compile is not supported by sparseml for torch 2.0.x"
             )
 
         torch.compile = raise_torch_compile_error


### PR DESCRIPTION
### Summary:
- If the detected version of the torch installation is 2.0.x, set `torch.compile` to show a warning 
### Test Plan:
- Tested locally by running the following code:

```
import sparseml.pytorch.models.classification.resnet as resnet
import torch 

model = resnet.resnet18()
compiled_model = torch.compile(model, fullgraph=True)
print("Compiled Model", type(compiled_model))
print(compiled_model)
```

This returns  a warning before running `torch.compile` on the given model, when run on the command line with sparseml installed:

```
/home/dsikka/sparseml/src/sparseml/pytorch/__init__.py:33: UserWarning: torch.compile is not supported by sparseml for torch 2.0.x
  warnings.warn("torch.compile is not supported by sparseml for torch 2.0.x")
Compiled Model <class 'torch._dynamo.eval_frame.OptimizedModule'>
OptimizedModule(
  (_orig_mod): ResNet(
    (input): _Input(
      (conv): Conv2d(3, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)
      (bn): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
      (act): ReLU(inplace=True)
      (pool): MaxPool2d(kernel_size=3, stride=2, padding=1, dilation=1, ceil_mode=False)
    )
    (sections): Sequential(
      (0): Sequential(
        (0): _BasicBlock(
          (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (act1): ReLU(inplace=True)
          (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (add_input_conv): AddInput()
          (add_input_identity): AddInput()
          (add_relu): FloatFunctional(
            (activation_post_process): Identity()
          )
        )
        (1): _BasicBlock(
          (conv1): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (act1): ReLU(inplace=True)
          (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (add_input_conv): AddInput()
          (add_input_identity): AddInput()
          (add_relu): FloatFunctional(
            (activation_post_process): Identity()
          )
        )
      )
      (1): Sequential(
        (0): _BasicBlock(
          (conv1): Conv2d(64, 128, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)
          (bn1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (act1): ReLU(inplace=True)
          (conv2): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn2): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (identity): _IdentityModifier(
            (conv): Conv2d(64, 128, kernel_size=(1, 1), stride=(2, 2), bias=False)
            (bn): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          )
          (add_input_conv): AddInput()
          (add_input_identity): AddInput()
          (add_relu): FloatFunctional(
            (activation_post_process): Identity()
          )
        )
        (1): _BasicBlock(
          (conv1): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (act1): ReLU(inplace=True)
          (conv2): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn2): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (add_input_conv): AddInput()
          (add_input_identity): AddInput()
          (add_relu): FloatFunctional(
            (activation_post_process): Identity()
          )
        )
      )
      (2): Sequential(
        (0): _BasicBlock(
          (conv1): Conv2d(128, 256, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)
          (bn1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (act1): ReLU(inplace=True)
          (conv2): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn2): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (identity): _IdentityModifier(
            (conv): Conv2d(128, 256, kernel_size=(1, 1), stride=(2, 2), bias=False)
            (bn): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          )
          (add_input_conv): AddInput()
          (add_input_identity): AddInput()
          (add_relu): FloatFunctional(
            (activation_post_process): Identity()
          )
        )
        (1): _BasicBlock(
          (conv1): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (act1): ReLU(inplace=True)
          (conv2): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn2): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (add_input_conv): AddInput()
          (add_input_identity): AddInput()
          (add_relu): FloatFunctional(
            (activation_post_process): Identity()
          )
        )
      )
      (3): Sequential(
        (0): _BasicBlock(
          (conv1): Conv2d(256, 512, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)
          (bn1): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (act1): ReLU(inplace=True)
          (conv2): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn2): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (identity): _IdentityModifier(
            (conv): Conv2d(256, 512, kernel_size=(1, 1), stride=(2, 2), bias=False)
            (bn): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          )
          (add_input_conv): AddInput()
          (add_input_identity): AddInput()
          (add_relu): FloatFunctional(
            (activation_post_process): Identity()
          )
        )
        (1): _BasicBlock(
          (conv1): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn1): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (act1): ReLU(inplace=True)
          (conv2): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)
          (bn2): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
          (add_input_conv): AddInput()
          (add_input_identity): AddInput()
          (add_relu): FloatFunctional(
            (activation_post_process): Identity()
          )
        )
      )
    )
    (classifier): _Classifier(
      (avgpool): AdaptiveAvgPool2d(output_size=1)
      (fc): Linear(in_features=512, out_features=1000, bias=True)
      (softmax): Softmax(dim=1)
    )
  )
)
```

Also tested with the decorater:

```
import sparseml.pytorch.models.classification.resnet as resnet
import torch 

model = resnet.resnet18()
@torch.compile(fullgraph=True)
def foo(x):
    return model(x)

print(foo(torch.randn(1, 3, 224, 224)))
```

Which shows the same warning, before showing the output.
