### PR TITLE
Fix loading of YOLOv8 sparse models on CPUs

### DIFF
--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -555,7 +555,7 @@ class SparseYOLO(YOLO):
 
         if model_str.endswith(".pt"):
             if os.path.exists(model_str):
-                ckpt = torch.load(model_str)
+                ckpt = torch.load(model_str, map_location="cpu")
                 self.is_sparseml_checkpoint = (
                     "source" in ckpt and ckpt["source"] == "sparseml"
                 )


### PR DESCRIPTION
Small change to load models initially into CPUs. The model is transferred to GPU if needed later. Without this change the model failed to load on CPU-only systems.

**Test plan:** 
1. I made sure that I could load the model in CPU-only machines and export to onnx, which motivated this fix.
2. In a GPU system I evaluated a dense model (zoo:cv/detection/yolov8-s/pytorch/ultralytics/coco/base-none) and made sure GPUs were used as expected
3. In a GPU system I evaluated a sparse model (zoo:cv/detection/yolov8-s/pytorch/ultralytics/coco/pruned50_quant-none) and made sure GPUs were used as expected
4. In a GPU system I ran a training command for a sparse model (zoo:cv/detection/yolov8-s/pytorch/ultralytics/coco/pruned50_quant-none) and made sure GPUs were used as expected
5. In a GPU system I exported a sparse model to onnx (zoo:cv/detection/yolov8-s/pytorch/ultralytics/coco/pruned50_quant-none)

