### PR TITLE
YOLOv8 ONNX export fix

### DIFF
--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -48,6 +48,7 @@ from sparsezoo import Model
 from sparsezoo.utils import validate_onnx
 from ultralytics import __version__
 from ultralytics.nn.tasks import SegmentationModel, attempt_load_one_weight
+from ultralytics.nn.modules import Detect, Segment
 from ultralytics.yolo.cfg import get_cfg
 from ultralytics.yolo.data.dataloaders.v5loader import create_dataloader
 from ultralytics.yolo.engine.model import YOLO
@@ -712,6 +713,10 @@ class SparseYOLO(YOLO):
 
         name = args.get("name", f"{type(self.model).__name__}.onnx")
         save_dir = args["save_dir"]
+
+        for _, m in self.model.named_modules():
+            if isinstance(m, (Detect, Segment)):
+                m.export = True
 
         exporter = ModuleExporter(self.model, save_dir)
         if save_one_shot_torch:

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -47,8 +47,8 @@ from sparseml.yolov8.validators import (
 from sparsezoo import Model
 from sparsezoo.utils import validate_onnx
 from ultralytics import __version__
-from ultralytics.nn.tasks import SegmentationModel, attempt_load_one_weight
 from ultralytics.nn.modules import Detect, Segment
+from ultralytics.nn.tasks import SegmentationModel, attempt_load_one_weight
 from ultralytics.yolo.cfg import get_cfg
 from ultralytics.yolo.data.dataloaders.v5loader import create_dataloader
 from ultralytics.yolo.engine.model import YOLO

--- a/src/sparseml/yolov8/utils/export_samples.py
+++ b/src/sparseml/yolov8/utils/export_samples.py
@@ -144,8 +144,7 @@ def _export_torch_outputs(
 
     # Run model to get torch outputs
     model_out = model(image)
-    # preds, intermediate_outputs = model_out
-    preds, _ = model_out
+    preds = model_out
 
     # Move to cpu for exporting
     preds = preds.detach().to("cpu")
@@ -164,8 +163,7 @@ def _export_ort_outputs(
     # Run model to get onnxruntime outputs
     ort_inputs = {session.get_inputs()[0].name: image}
     ort_outs = session.run(None, ort_inputs)
-    # preds, interm_out1, interm_out2, interm_out3 = model_out
-    preds, *_ = ort_outs
+    preds = ort_outs
 
     sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}.npz")
     numpy.savez(sample_output_filename, preds)


### PR DESCRIPTION
Before this PR the ONNX for YOLOv8 would include 3 intermediate outputs. This creates performance issues for the engine. This PR fixes this behavior such that the ONNX will only have the final detection output.

The fix is based on this line of code from the original export script from ultralytics: https://github.com/ultralytics/ultralytics/blob/64f247d6923e28108792cbeea16343606d8cd844/ultralytics/yolo/engine/exporter.py#L180

In short, the Segment and Detection heads have an internal parameter "export" that is set to False by default. When this parameter is False, the heads will output the intermediate values, when it's set to True they output only the final results. The fix simply switches this parameter to True in the export flow.