### PR TITLE
Fix onnx export for quantized MPT models

### DIFF
--- a/src/sparseml/transformers/utils/model.py
+++ b/src/sparseml/transformers/utils/model.py
@@ -407,7 +407,7 @@ class SparseAutoModel:
             f"after SparseML recipes have been applied {model_name_or_path}"
         )
 
-        return {}, True
+        return None, True
 
     @staticmethod
     def _check_tf(model_name_or_path: str):


### PR DESCRIPTION
Empty dict raises an exception when exporting quantized MPT models because when `state_dict = {}`, the HF loading pipeline will try to initialize the model by calling `_init_weights` for each module. However, for MPT models, this function is not defined and will therefore raise an exception.

@bfineran  on a side note, I am not really sure what this function is supposed to do. According to the code it will return either `None` (for pruned model) or `{}` (for quantized model), but never the actual loaded `state_dict` as mentioned in the docstring. We might want to rethink whether we need to refactor the function and its usage, or at least to update the docstring because at the moment they don't match.