### PR TITLE
[Fix] Fix the KV Cache insertion logic for quantized OPT

### DIFF
--- a/src/sparseml/exporters/transforms/kv_cache/cache_keys_and_values.py
+++ b/src/sparseml/exporters/transforms/kv_cache/cache_keys_and_values.py
@@ -307,10 +307,13 @@ def create_cache(
 
     cache_parent = graph.get_node_single_parent(node, index=cache_input_idx)
 
-    if isinstance(cache_parent, NodeProto) and cache_parent.op_type in ALLOWED_NODES_FOLLOWING_CONCAT:
+    if (
+        isinstance(cache_parent, NodeProto)
+        and cache_parent.op_type in ALLOWED_NODES_FOLLOWING_CONCAT
+    ):
         while cache_parent.op_type in ALLOWED_NODES_FOLLOWING_CONCAT:
             pre_cache_input_id = cache_parent.input[0]
-            cache_parent = graph.get_node_single_parent(cache_parent, index= 0)
+            cache_parent = graph.get_node_single_parent(cache_parent, index=0)
 
     else:
         pre_cache_input_id = node.input[cache_input_idx]
@@ -362,18 +365,7 @@ def create_cache(
         name=f"concat.{cache_input_name_concat}",
     )
 
-    for _node in model.graph.node:
-        for input_idx, input_id in enumerate(node.input):
-            if input_id == pre_cache_input_id and _node.name != concat_node.name:
-                _node.input[input_idx] = cache_output_name_concat
-
     graph.add_node(concat_node)
-
-    if node.op_type == "MatMulInteger":
-        node_parent = graph.get_node_single_parent(node, index=cache_input_idx)
-        node_grandparent = graph.get_node_single_parent(node_parent, index=0)
-        if node_parent.op_type == "QuantizeLinear" and node_grandparent.op_type == "Transpose":
-            pass
 
     return concat_node, cache_input_info, cache_output_info
 

--- a/src/sparseml/exporters/transforms/kv_cache/cache_keys_and_values.py
+++ b/src/sparseml/exporters/transforms/kv_cache/cache_keys_and_values.py
@@ -365,6 +365,11 @@ def create_cache(
         name=f"concat.{cache_input_name_concat}",
     )
 
+    for node in model.graph.node:
+        for input_idx, input_id in enumerate(node.input):
+            if input_id == pre_cache_input_id and node.name != concat_node.name:
+                node.input[input_idx] = cache_output_name_concat
+
     graph.add_node(concat_node)
 
     return concat_node, cache_input_info, cache_output_info

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -15,7 +15,7 @@
 """
 Helper functions to edit ONNX Graphs.
 """
-
+import copy
 from collections import defaultdict
 from typing import Iterable, List, Optional, Union
 
@@ -241,6 +241,22 @@ class ONNXGraph(object):
                 and (init.name not in output_names)
             ]
         )  # delete inits that have no edge
+
+    def swap_nodes(self, child: NodeProto, parent: NodeProto):
+        """
+        Given a child and parent node, swap the position of the child node
+        with the parent node. It is assumed that the child node has only one
+        parent node and the parent node has only one child node.
+
+        :param child: One of the nodes to swap
+        :param parent: Second node to swap
+        """
+
+        # swap inputs
+        child.input[0], parent.input[0] = parent.input[0], child.input[0]
+        # swap outputs
+        child.output[0], parent.output[0] = parent.output[0], child.output[0]
+
 
     def find_orphaned_nodes(self, node: NodeProto) -> List[NodeProto]:
         """

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -324,6 +324,11 @@ class ONNXGraph(object):
             seen_ids.update(node.output)
 
         # update model node list with topo sorted list
+        print(
+            set(i.name for i in self._model.graph.node).difference(
+                set(i.name for i in updated_node_list)
+            )
+        )
         assert len(updated_node_list) == len(self._model.graph.node)
         self._model.graph.ClearField("node")
         self._model.graph.node.extend(updated_node_list)

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -324,11 +324,6 @@ class ONNXGraph(object):
             seen_ids.update(node.output)
 
         # update model node list with topo sorted list
-        print(
-            set(i.name for i in self._model.graph.node).difference(
-                set(i.name for i in updated_node_list)
-            )
-        )
         assert len(updated_node_list) == len(self._model.graph.node)
         self._model.graph.ClearField("node")
         self._model.graph.node.extend(updated_node_list)

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -15,7 +15,7 @@
 """
 Helper functions to edit ONNX Graphs.
 """
-import copy
+
 from collections import defaultdict
 from typing import Iterable, List, Optional, Union
 
@@ -241,22 +241,6 @@ class ONNXGraph(object):
                 and (init.name not in output_names)
             ]
         )  # delete inits that have no edge
-
-    def swap_nodes(self, child: NodeProto, parent: NodeProto):
-        """
-        Given a child and parent node, swap the position of the child node
-        with the parent node. It is assumed that the child node has only one
-        parent node and the parent node has only one child node.
-
-        :param child: One of the nodes to swap
-        :param parent: Second node to swap
-        """
-
-        # swap inputs
-        child.input[0], parent.input[0] = parent.input[0], child.input[0]
-        # swap outputs
-        child.output[0], parent.output[0] = parent.output[0], child.output[0]
-
 
     def find_orphaned_nodes(self, node: NodeProto) -> List[NodeProto]:
         """


### PR DESCRIPTION
## Feature Description

Fixes the KV Cache logic for quantized text generation models.

In a nutshell, the `QuantizeLinear` nodes that were created in the process of quantization were messing up our pattern-matching rules for finding `Key Matmul `and `Value Matmul`. Additionally the `QuantizeLinear` nodes are by default inserted into a graph in such a way, that they break the topology of the graph with the  kv cache support.

This fix:
- updates the pattern matching for finding `Key Matmul` and `Value MatMul` to be robust against the presence of `QuantizeLinear` nodes
- moves the `QuantizeLinear` nodes to their appropriate place in the onnx graph.

<img width="953" alt="image" src="https://github.com/neuralmagic/sparseml/assets/97082108/7c7f3244-00b9-4526-a8f5-26f28a2c667d">
<img width="953" alt="image" src="https://github.com/neuralmagic/sparseml/assets/97082108/d2f60fda-16b1-4fe2-9d1c-e7623a0ff0b8">
<img width="981" alt="image" src="https://github.com/neuralmagic/sparseml/assets/97082108/8e38e964-d9ea-4d40-bc32-66ad80f3853a">
<img width="981" alt="image" src="https://github.com/neuralmagic/sparseml/assets/97082108/b5f7e7e4-295e-4400-8fed-344deab1f160">
<img width="981" alt="image" src="https://github.com/neuralmagic/sparseml/assets/97082108/4503d3a9-d7d3-456a-8c89-d29a0b0521a9">
<img width="981" alt="image" src="https://github.com/neuralmagic/sparseml/assets/97082108/5caed687-8b3f-488a-becc-9d039f96aa30">

## Manual Testing
Note: For manual testing it is required to use this branch: https://github.com/neuralmagic/deepsparse/pull/1123. It provides the appropriate support for quantized kv cache.

### OPT
Tested with the model provided by @natuan `nlg-text_generation/c4-opt_1.3b-pruned50_quant/sparsegpt@opt-1.3b@c4@opt1.3b.W8A8linear.A8A8O16matmul@SP0.5@SQ1@PTQ1@ID15513`

1. Injecting the kv cache:
```bash
python kv_cache_injector.py --input-file /home/ubuntu/damian/ml-experiments/nlg-text_generation/c4-opt_1.3b-pruned50_quant/sparsegpt@opt-1.3b@c4@opt1.3b.W8A8linear.A8A8O16matmul@SP0.5@SQ1@PTQ1@ID15513/deployment/model.onnx --output-file /home/ubuntu/damian/ml-experiments/nlg-text_generation/c4-opt_1.3b-pruned50_quant/sparsegpt@opt-1.3b@c4@opt1.3b.W8A8linear.A8A8O16matmul@SP0.5@SQ1@PTQ1@ID15513/deployment/model_kvcache.onnx
```

```bash
2023-07-18 09:58:01 sparseml.exporters.transforms.kv_cache.configs INFO     Loaded config file /home/ubuntu/damian/ml-experiments/nlg-text_generation/c4-opt_1.3b-pruned50_quant/sparsegpt@opt-1.3b@c4@opt1.3b.W8A8linear.A8A8O16matmul@SP0.5@SQ1@PTQ1@ID15513/deployment/config.json for model: opt
2023-07-18 09:58:01 sparseml.exporters.transforms.kv_cache.configs INFO     Properly configured arguments for KV Cache Transformation
Attempting to validate an in-memory ONNX model that has been loaded without external data. This is currently not supported by the ONNX checker. The validation will be skipped.
2023-07-18 09:58:03 sparseml.exporters.transforms.onnx_transform INFO     [CacheKeysAndValues] Transformed 48 matches
Attempting to validate an in-memory ONNX model that has been loaded without external data. This is currently not supported by the ONNX checker. The validation will be skipped.
Attempting to validate an in-memory ONNX model that has been loaded without external data. This is currently not supported by the ONNX checker. The validation will be skipped.
2023-07-18 09:58:04 sparseml.exporters.transforms.onnx_transform INFO     [PositionsAdjustmentOPT] Transformed 3 matches
Attempting to validate an in-memory ONNX model that has been loaded without external data. This is currently not supported by the ONNX checker. The validation will be skipped.
Modified model saved to: /home/ubuntu/damian/ml-experiments/nlg-text_generation/c4-opt_1.3b-pruned50_quant/sparsegpt@opt-1.3b@c4@opt1.3b.W8A8linear.A8A8O16matmul@SP0.5@SQ1@PTQ1@ID15513/deployment/model_kvcache.onnx
```
3. Renaming `deployment/model_kvcache.onnx` to `deployment/model.onnx` and running it in the pipeline.

```bash
opt = Pipeline.create(task="opt", model_path="/home/ubuntu/damian/ml-experiments/nlg-text_generation/c4-opt_1.3b-pruned50_quant/sparsegpt@opt-1.3b@c4@opt1.3b.W8A8linear.A 8A8O16matmul@SP0.5@SQ1@PTQ1@ID15513/deployment", engine_type=engine_type, use_deepsparse_cache = False, max_generated_tokens=32)

out = opt(sequences="Who is the president of the United States?")
print(out.sequences[0])
```

```bash


Who is the president of the United States?

Who is the president of the United States?

Who is the president of the United States
```

Note: This PR does not alter the behavior of KV cache injection for non-quantized OPT model.

### CodeGen

Tested with the model provided by @shubhra  `codegen_mono-350m-apps_bigpython_bigquery_thepile-base_quantized/training/`

1. Injecting the kv cache:
```bash
python kv_cache_injector.py --input-file /home/ubuntu/damian/codegen_mono-350m-apps_bigpython_bigquery_thepile-base_quantized/training/model.onnx --output-file /home/ubuntu/damian/codegen_mono-350m-apps_bigpython_bigquery_thepile-base_quantized/training/model_kvcache.onnx
```

```bash
2023-07-18 11:22:34 sparseml.exporters.transforms.kv_cache.configs INFO     Loaded config file /home/ubuntu/damian/codegen_mono-350m-apps_bigpython_bigquery_thepile-base_quantized/training/config.json for model: codegen
2023-07-18 11:22:34 sparseml.exporters.transforms.kv_cache.configs INFO     Properly configured arguments for KV Cache Transformation
2023-07-18 11:22:35 sparseml.exporters.transforms.onnx_transform INFO     [CacheKeysAndValues] Transformed 40 matches
2023-07-18 11:22:38 sparseml.exporters.transforms.onnx_transform INFO     [PositionsAdjustmentCodeGen] Transformed 3 matches
Modified model saved to: /home/ubuntu/damian/codegen_mono-350m-apps_bigpython_bigquery_thepile-base_quantized/training/model_kvcache.onnx
```
3. Renaming `training/model_kvcache.onnx` to `training/model.onnx` and running it in the pipeline.

```bash
opt = Pipeline.create(task="codegen", model_path="/home/ubuntu/damian/codegen_mono-350m-apps_bigpython_bigquery_thepile-base_quantized/training", engine_type=engine_type, use_deepsparse_cache = False, max_generated_tokens=32)

out = opt(sequences="def hello_world():")
print(out.sequences[0])
```

```bash

print("Hello World")

hello_world()

# This is a comment

# This is a comment

# This is
```

Note: This PR does not alter the behavior of KV cache injection for non-quantized CodeGen model.

