### PR TITLE
Add variable bit width support to ONNXToDeepsparse

### DIFF
--- a/src/sparseml/exporters/onnx_to_deepsparse.py
+++ b/src/sparseml/exporters/onnx_to_deepsparse.py
@@ -56,7 +56,7 @@ class ONNXToDeepsparse(BaseExporter):
         optimized model.
     :param quant_bit_width: The bit width to use for weight quantization. Note that
         quantized weights will be stored as uint8 regardless. This only affects the
-        zero-point shift applied.
+        zero-point shift and clipping applied.
     """
 
     def __init__(

--- a/src/sparseml/exporters/onnx_to_deepsparse.py
+++ b/src/sparseml/exporters/onnx_to_deepsparse.py
@@ -54,6 +54,9 @@ class ONNXToDeepsparse(BaseExporter):
     :param inplace: If true, does conversion of model in place. Default is true
     :param export_input_model: If true, saves the input onnx model alongside the
         optimized model.
+    :param quant_bit_width: The bit width to use for weight quantization. Note that
+        quantized weights will be stored as uint8 regardless. This only affects the
+        zero-point shift applied.
     """
 
     def __init__(
@@ -62,6 +65,7 @@ class ONNXToDeepsparse(BaseExporter):
         skip_input_quantize: bool = False,
         inplace: bool = True,
         export_input_model: bool = False,
+        quant_bit_width: int = 8,
     ):
         self.inplace = inplace
         self.export_input_model = export_input_model
@@ -69,7 +73,7 @@ class ONNXToDeepsparse(BaseExporter):
         transforms = [
             sparseml_transforms.ConstantsToInitializers(),
             sparseml_transforms.FoldIdentityInitializers(),
-            sparseml_transforms.InitializersToUint8(),
+            sparseml_transforms.InitializersToUint8(bit_width=quant_bit_width),
             sparseml_transforms.FlattenQParams(),
             sparseml_transforms.FoldConvDivBn(),
             sparseml_transforms.DeleteRepeatedQdq(),

--- a/src/sparseml/exporters/onnx_to_deepsparse.py
+++ b/src/sparseml/exporters/onnx_to_deepsparse.py
@@ -77,17 +77,23 @@ class ONNXToDeepsparse(BaseExporter):
             sparseml_transforms.FlattenQParams(),
             sparseml_transforms.FoldConvDivBn(),
             sparseml_transforms.DeleteRepeatedQdq(),
-            sparseml_transforms.QuantizeQATEmbedding(),
+            sparseml_transforms.QuantizeQATEmbedding(bit_width=quant_bit_width),
             sparseml_transforms.PropagateEmbeddingQuantization(),
             sparseml_transforms.MatMulToQLinearMatMul(),
-            sparseml_transforms.MatMulAddToMatMulIntegerAddCastMul(),
+            sparseml_transforms.MatMulAddToMatMulIntegerAddCastMul(
+                bit_width=quant_bit_width
+            ),
             sparseml_transforms.MatMulToMatMulIntegerCastMul(),
             sparseml_transforms.FoldReLUQuants(),
-            sparseml_transforms.ConvToQLinearConv()
+            sparseml_transforms.ConvToQLinearConv(bit_width=quant_bit_width)
             if use_qlinear_conv
-            else sparseml_transforms.ConvToConvIntegerAddCastMul(),
-            sparseml_transforms.GemmToQLinearMatMul(),
-            sparseml_transforms.GemmToMatMulIntegerAddCastMul(),
+            else sparseml_transforms.ConvToConvIntegerAddCastMul(
+                bit_width=quant_bit_width
+            ),
+            sparseml_transforms.GemmToQLinearMatMul(bit_width=quant_bit_width),
+            sparseml_transforms.GemmToMatMulIntegerAddCastMul(
+                bit_width=quant_bit_width
+            ),
             sparseml_transforms.QuantizeResiduals(),
             sparseml_transforms.RemoveDuplicateQConvWeights(),
             sparseml_transforms.RemoveDuplicateQuantizeOps(),

--- a/src/sparseml/exporters/transforms/conv_to_convinteger_add_cast_mul.py
+++ b/src/sparseml/exporters/transforms/conv_to_convinteger_add_cast_mul.py
@@ -62,7 +62,18 @@ class ConvToConvIntegerAddCastMul(OnnxTransform):
     |     |
     | Mul (Rescale from bias scale)
     ```
+
+    :param bit_width: the bit width to use for the quantization
     """
+
+    def __init__(self, bit_width: int = 8) -> None:
+        super().__init__()
+        self.bit_width = bit_width
+        if bit_width <= 0 or bit_width > 8:
+            raise ValueError(
+                "only [1, 8] bit quantization currently supported. Received "
+                f"{bit_width}"
+            )
 
     def transform(self, model: ModelProto) -> ModelProto:
         graph = ONNXGraph(model)
@@ -108,6 +119,7 @@ class ConvToConvIntegerAddCastMul(OnnxTransform):
             bias_add_name="{}_bias_add".format(match.node.name),
             target_output=match.node.output[0],
             transpose_weight=False,
+            bit_width=self.bit_width,
         )
 
         # Clean up

--- a/src/sparseml/exporters/transforms/gemm_to_matmulinteger_add_cast_mul.py
+++ b/src/sparseml/exporters/transforms/gemm_to_matmulinteger_add_cast_mul.py
@@ -60,7 +60,18 @@ class GemmToMatMulIntegerAddCastMul(OnnxTransform):
     |     |
     | Mul (Rescale from bias scale)
     ```
+
+    :param bit_width: the bit width to use for the quantization
     """
+
+    def __init__(self, bit_width: int = 8) -> None:
+        super().__init__()
+        self.bit_width = bit_width
+        if bit_width <= 0 or bit_width > 8:
+            raise ValueError(
+                "only [1, 8] bit quantization currently supported. Received "
+                f"{bit_width}"
+            )
 
     def transform(self, model: ModelProto) -> ModelProto:
         graph = ONNXGraph(model)
@@ -130,6 +141,7 @@ class GemmToMatMulIntegerAddCastMul(OnnxTransform):
             bias_add_name=f"{gemm.name}_bias_add",
             target_output=gemm.output[0],
             transpose_weight=transpose_weight,
+            bit_width=self.bit_width,
         )
 
         # Cleanup

--- a/src/sparseml/exporters/transforms/gemm_to_qlinearmatmul.py
+++ b/src/sparseml/exporters/transforms/gemm_to_qlinearmatmul.py
@@ -63,7 +63,18 @@ class GemmToQLinearMatMul(OnnxTransform):
         | |
         Add
     ```
+
+    :param bit_width: the bit width to use for the quantization
     """
+
+    def __init__(self, bit_width: int = 8) -> None:
+        super().__init__()
+        self.bit_width = bit_width
+        if bit_width <= 0 or bit_width > 8:
+            raise ValueError(
+                "only [1, 8] bit quantization currently supported. Received "
+                f"{bit_width}"
+            )
 
     def transform(self, model: ModelProto) -> ModelProto:
         graph = ONNXGraph(model)
@@ -126,6 +137,7 @@ class GemmToQLinearMatMul(OnnxTransform):
             weight_quantize_params.scale,
             weight_quantize_params.zero_point,
             weight_quantize_params.zero_point.dtype,
+            self.bit_width,
         )
         quantized_weight = quantized_weight.transpose()  # Gemm has implicit transpose
         quantized_weight_name = "{}.weight_quantized".format(gemm_node.name)

--- a/src/sparseml/exporters/transforms/initializers_to_uint8.py
+++ b/src/sparseml/exporters/transforms/initializers_to_uint8.py
@@ -33,6 +33,11 @@ class InitializersToUint8(OnnxTransform):
     def __init__(self, bit_width: int = 8) -> None:
         super().__init__()
         self.bit_width = bit_width
+        if bit_width <= 0 or bit_width > 8:
+            raise ValueError(
+                "only [1, 8] bit quantization currently supported. received "
+                f"QuantizationArgs with num_bits={bit_width}"
+            )
 
     def transform(self, model: ModelProto) -> ModelProto:
         initializers_to_add = []

--- a/src/sparseml/exporters/transforms/initializers_to_uint8.py
+++ b/src/sparseml/exporters/transforms/initializers_to_uint8.py
@@ -35,8 +35,8 @@ class InitializersToUint8(OnnxTransform):
         self.bit_width = bit_width
         if bit_width <= 0 or bit_width > 8:
             raise ValueError(
-                "only [1, 8] bit quantization currently supported. received "
-                f"QuantizationArgs with num_bits={bit_width}"
+                "only [1, 8] bit quantization currently supported. Received "
+                f"{bit_width}"
             )
 
     def transform(self, model: ModelProto) -> ModelProto:

--- a/src/sparseml/exporters/transforms/matmul_add_to_matmulinteger_add_cast_mul.py
+++ b/src/sparseml/exporters/transforms/matmul_add_to_matmulinteger_add_cast_mul.py
@@ -63,7 +63,18 @@ class MatMulAddToMatMulIntegerAddCastMul(OnnxTransform):
     |     |
     | Mul (Rescale from bias scale)
     ```
+
+    :param bit_width: the bit width to use for the quantization
     """
+
+    def __init__(self, bit_width: int = 8) -> None:
+        super().__init__()
+        self.bit_width = bit_width
+        if bit_width <= 0 or bit_width > 8:
+            raise ValueError(
+                "only [1, 8] bit quantization currently supported. Received "
+                f"{bit_width}"
+            )
 
     def transform(self, model: ModelProto) -> ModelProto:
         graph = ONNXGraph(model)
@@ -128,6 +139,7 @@ class MatMulAddToMatMulIntegerAddCastMul(OnnxTransform):
             bias_add_name=add.name if add else None,
             target_output=add.output[0] if add and bias_init else None,
             transpose_weight=opt_transpose is not None,
+            bit_width=self.bit_width,
         )
 
         # Clean up

--- a/src/sparseml/exporters/transforms/quantize_qat_embedding.py
+++ b/src/sparseml/exporters/transforms/quantize_qat_embedding.py
@@ -52,7 +52,18 @@ class QuantizeQATEmbedding(OnnxTransform):
     |        |
     |        Dq
     ```
+
+    :param bit_width: the bit width to use for the quantization
     """
+
+    def __init__(self, bit_width: int = 8) -> None:
+        super().__init__()
+        self.bit_width = bit_width
+        if bit_width <= 0 or bit_width > 8:
+            raise ValueError(
+                "only [1, 8] bit quantization currently supported. Received "
+                f"{bit_width}"
+            )
 
     def transform(self, model: ModelProto) -> ModelProto:
         graph = ONNXGraph(model)
@@ -94,7 +105,9 @@ class QuantizeQATEmbedding(OnnxTransform):
         scale = numpy_helper.to_array(scale_initializer)
         zero_point = numpy_helper.to_array(zero_point_initializer)
 
-        embedding_quant = quantize_array(embedding, scale, zero_point, zero_point.dtype)
+        embedding_quant = quantize_array(
+            embedding, scale, zero_point, zero_point.dtype, self.bit_width
+        )
         embedding_quant_initializer = numpy_helper.from_array(
             embedding_quant, name=f"{embedding_initializer.name}_quant"
         )

--- a/src/sparseml/exporters/transforms/utils/add_quantized_conv_matmul_add_ops.py
+++ b/src/sparseml/exporters/transforms/utils/add_quantized_conv_matmul_add_ops.py
@@ -60,7 +60,7 @@ def add_quantized_conv_matmul_add_ops(
 
     # Quantize weights and add to graph
     quantized_weight_initializer = _quantize_weight_initializer(
-        node, weight_quantize_params, transpose_weight
+        node, weight_quantize_params, transpose_weight, bit_width
     )
     model.graph.initializer.append(quantized_weight_initializer)
 

--- a/src/sparseml/exporters/transforms/utils/helpers.py
+++ b/src/sparseml/exporters/transforms/utils/helpers.py
@@ -132,7 +132,7 @@ def quantize_array(
     dtype: Any = numpy.uint8,
     bit_width: int = 8,
 ) -> numpy.ndarray:
-    if 1 <= bit_width <= 8:
+    if bit_width <= 0 or bit_width > 8:
         raise ValueError(
             "only [1, 8] bit quantization currently supported. Received " f"{bit_width}"
         )

--- a/src/sparseml/exporters/transforms/utils/helpers.py
+++ b/src/sparseml/exporters/transforms/utils/helpers.py
@@ -136,7 +136,7 @@ def quantize_array(
         raise ValueError(
             "only [1, 8] bit quantization currently supported. Received " f"{bit_width}"
         )
-    if isinstance(zero_point, int) and (zero_point <= 0 or zero_point > 2**bit_width):
+    if isinstance(zero_point, int) and (zero_point < 0 or zero_point > 2**bit_width):
         raise ValueError(
             f"For bit_width {bit_width}, zero_point must be in [0, {2**bit_width}). "
             f"Received {zero_point}"

--- a/src/sparseml/exporters/transforms/utils/helpers.py
+++ b/src/sparseml/exporters/transforms/utils/helpers.py
@@ -136,7 +136,7 @@ def quantize_array(
         raise ValueError(
             "only [1, 8] bit quantization currently supported. Received " f"{bit_width}"
         )
-    if isinstance(zero_point, int) and 0 <= zero_point < 2**bit_width:
+    if isinstance(zero_point, int) and (zero_point <= 0 or zero_point > 2**bit_width):
         raise ValueError(
             f"For bit_width {bit_width}, zero_point must be in [0, {2**bit_width}). "
             f"Received {zero_point}"


### PR DESCRIPTION
This PR adds support for variable-bit weight quantization in the ONNXToDeepsparse exporter. This affects two steps:

- Conversion of intiailziers to unit8
- Clipping in quantization of weight arrays

**Test Plan**
Local sparsify runs with int-4 weight quantization