### PR TITLE
[YOLOV8] `ultralytics` Update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ _dev_deps = [
 
 
 _ultralytics_deps = [
-    "ultralytics==8.0.30",
+    "ultralytics==8.0.124",
     supported_torch_version,
 ]
 

--- a/src/sparseml/yolov8/__init__.py
+++ b/src/sparseml/yolov8/__init__.py
@@ -23,10 +23,9 @@ except ImportError:
 
 
 _analytics.send_event("python__yolov8__init")
-"""
-if "8.0.30" not in ultralytics.__version__:
+
+if "8.0.124" not in ultralytics.__version__:
     raise ValueError(
-        f"ultralytics==8.0.30 is required, found {ultralytics.__version__}. "
+        f"ultralytics==8.0.124 is required, found {ultralytics.__version__}. "
         "To fix run `pip install sparseml[ultralytics]`."
     )
-"""

--- a/src/sparseml/yolov8/__init__.py
+++ b/src/sparseml/yolov8/__init__.py
@@ -23,9 +23,10 @@ except ImportError:
 
 
 _analytics.send_event("python__yolov8__init")
-
+"""
 if "8.0.30" not in ultralytics.__version__:
     raise ValueError(
         f"ultralytics==8.0.30 is required, found {ultralytics.__version__}. "
         "To fix run `pip install sparseml[ultralytics]`."
     )
+"""

--- a/src/sparseml/yolov8/default.yaml
+++ b/src/sparseml/yolov8/default.yaml
@@ -5,7 +5,7 @@ recipe_args: null
 datasets_dir: null
 
 task: "detect" # choices=['detect', 'segment', 'classify', 'init'] # init is a special case. Specify task to run.
-mode: "train" # choices=['train', 'val', 'predict'] # mode to run task in.
+mode: "val" # choices=['train', 'val', 'predict'] # mode to run task in.
 
 # Train settings -------------------------------------------------------------------------------------------------------
 model: "yolov8n.yaml" # i.e. yolov8n.pt, yolov8n.yaml. Path to model file
@@ -62,10 +62,10 @@ show: False # show results if possible
 save_txt: False # save results as .txt file
 save_conf: False # save results with confidence scores
 save_crop: False # save cropped images with results
-hide_labels: False # hide labels
-hide_conf: False # hide confidence scores
+show_labels: True # hide labels
+show_conf: True # hide confidence scores
 vid_stride: 1 # video frame-rate stride
-line_thickness: 3 # bounding box thickness (pixels)
+line_width: 3 # bounding box thickness (pixels)
 visualize: False # visualize results
 augment: False # apply data augmentation to images
 agnostic_nms: False # class-agnostiic NMS

--- a/src/sparseml/yolov8/default.yaml
+++ b/src/sparseml/yolov8/default.yaml
@@ -5,7 +5,7 @@ recipe_args: null
 datasets_dir: null
 
 task: "detect" # choices=['detect', 'segment', 'classify', 'init'] # init is a special case. Specify task to run.
-mode: "val" # choices=['train', 'val', 'predict'] # mode to run task in.
+mode: "train" # choices=['train', 'val', 'predict'] # mode to run task in.
 
 # Train settings -------------------------------------------------------------------------------------------------------
 model: "yolov8n.yaml" # i.e. yolov8n.pt, yolov8n.yaml. Path to model file
@@ -36,7 +36,7 @@ resume: False # resume training from last checkpoint
 amp: True # (bool) Automatic Mixed Precision (AMP) training, choices=[True, False], True runs AMP check
 fraction: 1.0  # (float) dataset fraction to train on (default is 1.0, all images in train set)
 profile: False # (bool) profile ONNX and TensorRT speeds during training for loggers
-# min_memory: False  # minimize memory footprint loss function, choices=[False, True, <roll_out_thr>]
+min_memory: False  # minimize memory footprint loss function, choices=[False, True, <roll_out_thr>]
 
 # Segmentation
 overlap_mask: True # masks should overlap during training

--- a/src/sparseml/yolov8/default.yaml
+++ b/src/sparseml/yolov8/default.yaml
@@ -54,7 +54,7 @@ iou: 0.7 # intersection over union (IoU) threshold for NMS
 max_det: 300 # maximum number of detections per image
 half: False # use half precision (FP16)
 dnn: False # use OpenCV DNN for ONNX inferences
-plots: False # show plots during training
+plots: True # show plots during training
 
 # Prediction settings --------------------------------------------------------------------------------------------------
 source: null # source directory for images or videos

--- a/src/sparseml/yolov8/default.yaml
+++ b/src/sparseml/yolov8/default.yaml
@@ -53,8 +53,8 @@ conf: null # object confidence threshold for detection (default 0.25 predict, 0.
 iou: 0.7 # intersection over union (IoU) threshold for NMS
 max_det: 300 # maximum number of detections per image
 half: False # use half precision (FP16)
-dnn: False # use OpenCV DNN for ONNX inference
-plots: True # show plots during training
+dnn: False # use OpenCV DNN for ONNX inferences
+plots: False # show plots during training
 
 # Prediction settings --------------------------------------------------------------------------------------------------
 source: null # source directory for images or videos

--- a/src/sparseml/yolov8/default.yaml
+++ b/src/sparseml/yolov8/default.yaml
@@ -33,7 +33,10 @@ rect: False # support rectangular training
 cos_lr: False # use cosine learning rate scheduler
 close_mosaic: 10 # disable mosaic augmentation for final 10 epochs
 resume: False # resume training from last checkpoint
-min_memory: False  # minimize memory footprint loss function, choices=[False, True, <roll_out_thr>]
+amp: True # (bool) Automatic Mixed Precision (AMP) training, choices=[True, False], True runs AMP check
+fraction: 1.0  # (float) dataset fraction to train on (default is 1.0, all images in train set)
+profile: False # (bool) profile ONNX and TensorRT speeds during training for loggers
+# min_memory: False  # minimize memory footprint loss function, choices=[False, True, <roll_out_thr>]
 
 # Segmentation
 overlap_mask: True # masks should overlap during training

--- a/src/sparseml/yolov8/train.py
+++ b/src/sparseml/yolov8/train.py
@@ -221,6 +221,9 @@ def main(**kwargs):
         kwargs["data"] = data_from_dataset_path(kwargs["data"], kwargs["dataset_path"])
     del kwargs["dataset_path"]
 
+    # Now we can pass in the task and checks if taks passed or tries to guess
+    # what the task was based on the yaml --> need a check to make sure they work 
+    # together? Or let the user know. Can just not provide an input
     model = SparseYOLO(kwargs["model"])
     model.train(**kwargs)
 

--- a/src/sparseml/yolov8/train.py
+++ b/src/sparseml/yolov8/train.py
@@ -224,7 +224,7 @@ def main(**kwargs):
     # Now we can pass in the task and checks if taks passed or tries to guess
     # what the task was based on the yaml --> need a check to make sure they work 
     # together? Or let the user know. Can just not provide an input
-    model = SparseYOLO(kwargs["model"])
+    model = SparseYOLO(kwargs["model"], kwargs["task"])
     model.train(**kwargs)
 
 

--- a/src/sparseml/yolov8/train.py
+++ b/src/sparseml/yolov8/train.py
@@ -50,13 +50,13 @@ logger = logging.getLogger()
     "--model",
     default="yolov8n.yaml",
     type=str,
-    help="i.e. yolov8n.pt, yolov8n.yaml. Path to model file",
+    help="i.e. yolov8n.pt, yolov8n.yaml, yolov8n-seg.yaml. Path to model file",
 )
 @click.option(
     "--data",
     default="coco128.yaml",
     type=str,
-    help="i.e. coco128.yaml. Path to data file",
+    help="i.e. coco128.yaml, coco128-seg.yaml. Path to data file",
 )
 @click.option("--epochs", default=100, type=int, help="number of epochs to train for")
 @click.option(
@@ -221,9 +221,8 @@ def main(**kwargs):
         kwargs["data"] = data_from_dataset_path(kwargs["data"], kwargs["dataset_path"])
     del kwargs["dataset_path"]
 
-    # Now we can pass in the task and checks if taks passed or tries to guess
-    # what the task was based on the yaml --> need a check to make sure they work 
-    # together? Or let the user know. Can just not provide an input
+    # NOTE: the task, model, and data kwargs will override the values in default.yaml
+    # They should be provided or default values will be used.
     model = SparseYOLO(kwargs["model"], kwargs["task"])
     model.train(**kwargs)
 

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -863,8 +863,8 @@ class SparseYOLO(YOLO):
         overrides["rect"] = True  # rect batches as default
         overrides.update(kwargs)
         overrides["mode"] = "val"
+        overrides["nbs"] = int(overrides["nbs"])
         overrides["data"] = data or overrides["data"]
-        overrides["plots"] = False
         args = get_cfg(cfg=DEFAULT_CFG, overrides=overrides)
         args.data = data or args.data
         args.task = self.task

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -556,7 +556,6 @@ class SparseSegmentationTrainer(SparseTrainer, SegmentationTrainer):
 
 
 class SparseYOLO(YOLO):
-    # TODO: Remove this input type
     def __init__(self, model="yolov8n.yaml", task="detect") -> None:
         model_str = str(model)
 
@@ -741,7 +740,9 @@ class SparseYOLO(YOLO):
             if isinstance(m, (Detect, Segment)):
                 m.export = True
 
-        # What is the the format? Can't find this variable
+        # format attribute seems to not exist within this ultralytics update
+        # This is a workaround. Should be one of
+        # ('saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs')
         self.model.model[-1].format = "saved_model"
         exporter = ModuleExporter(self.model, save_dir)
         if save_one_shot_torch:

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -347,7 +347,7 @@ class SparseTrainer(BaseTrainer):
                 loggers=self.logger_manager,
                 grad_sampler={
                     "data_loader_builder": self._get_data_loader_builder(),
-                    "loss_function": lambda preds, batch: self.model.loss(batch, preds)[
+                    "loss_function": lambda preds, batch: self.model.loss(batch=batch, preds=preds)[
                         0
                     ]
                     / self.train_loader.batch_size,
@@ -593,7 +593,7 @@ class SparseYOLO(YOLO):
         elif self.ValidatorClass == SegmentationValidator:
             self.ValidatorClass = SparseSegmentationValidator
 
-    def _load(self, weights: str):
+    def _load(self, weights: str, task=None):
         if self.is_sparseml_checkpoint:
             """
             NOTE: the model is given to the trainer class with this snippet
@@ -651,7 +651,7 @@ class SparseYOLO(YOLO):
             LOGGER.info("Loaded previous weights from checkpoint")
             assert self.model.yaml == self.ckpt["model_yaml"]
         else:
-            return super()._load(weights)
+            return super()._load(weights, task)
 
     def export(self, **kwargs):
         """

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -863,7 +863,8 @@ class SparseYOLO(YOLO):
         overrides["rect"] = True  # rect batches as default
         overrides.update(kwargs)
         overrides["mode"] = "val"
-        overrides["nbs"] = int(overrides["nbs"])
+        if overrides.get("nbs"):
+            overrides["nbs"] = int(overrides["nbs"])
         overrides["data"] = data or overrides["data"]
         args = get_cfg(cfg=DEFAULT_CFG, overrides=overrides)
         args.data = data or args.data

--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -283,6 +283,7 @@ class SparseTrainer(BaseTrainer):
 
     def _setup_train(self, world_size):
         rank = int(os.getenv("RANK", -1))
+
         super()._setup_train(world_size)
         # NOTE: self.resume_training() was called in ^
 
@@ -346,7 +347,7 @@ class SparseTrainer(BaseTrainer):
                 loggers=self.logger_manager,
                 grad_sampler={
                     "data_loader_builder": self._get_data_loader_builder(),
-                    "loss_function": lambda preds, batch: self.model.loss(preds, batch)[
+                    "loss_function": lambda preds, batch: self.model.loss(batch, preds)[
                         0
                     ]
                     / self.train_loader.batch_size,
@@ -593,7 +594,6 @@ class SparseYOLO(YOLO):
             self.ValidatorClass = SparseSegmentationValidator
 
     def _load(self, weights: str):
-        print("IN _LOAD")
         if self.is_sparseml_checkpoint:
             """
             NOTE: the model is given to the trainer class with this snippet

--- a/src/sparseml/yolov8/utils/export_samples.py
+++ b/src/sparseml/yolov8/utils/export_samples.py
@@ -145,22 +145,18 @@ def _export_torch_outputs(
     # Run model to get torch outputs
     model_out = model(image)
     preds = model_out
+    sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}.npz")
+    seg_prediction = None
 
     # Move to cpu for exporting
     # Segmentation currently supports two outputs
     if isinstance(preds, tuple):
-        pred_0 = preds[0].detach().to("cpu")
-        pred_1 = preds[1].detach().to("cpu")
-
-        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}-0.npz")
-        numpy.savez(sample_output_filename, pred_0)
-
-        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}-1.npz")
-        numpy.savez(sample_output_filename, pred_1)
+        preds_out = preds[0].detach().to("cpu")
+        seg_prediction = preds[1].detach().to("cpu")
     else:
-        preds = preds.detach().to("cpu")
-        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}.npz")
-        numpy.savez(sample_output_filename, preds)
+        preds_out = preds.detach().to("cpu")
+
+    numpy.savez(sample_output_filename, preds_out, seg_prediction=seg_prediction)
 
 
 def _export_ort_outputs(
@@ -177,15 +173,13 @@ def _export_ort_outputs(
     preds = numpy.squeeze(preds, axis=0)
 
     if len(preds) > 1:
-        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}-0.npz")
-        numpy.savez(sample_output_filename, preds[0])
-
-        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}-1.npz")
-        numpy.savez(sample_output_filename, preds[1])
-
+        preds_out = preds[0]
+        seg_prediction = preds[1]
     else:
-        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}.npz")
-        numpy.savez(sample_output_filename, preds)
+        preds_out = preds
+
+    sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}.npz")
+    numpy.savez(sample_output_filename, preds_out, seg_prediction=seg_prediction)
 
 
 def _export_inputs(image: torch.Tensor, sample_in_dir: str, file_idx: str):

--- a/src/sparseml/yolov8/utils/export_samples.py
+++ b/src/sparseml/yolov8/utils/export_samples.py
@@ -169,14 +169,16 @@ def _export_ort_outputs(
     # Run model to get onnxruntime outputs
     ort_inputs = {session.get_inputs()[0].name: image}
     ort_outs = session.run(None, ort_inputs)
-    preds = numpy.squeeze(ort_outs, axis=0)
-    preds = numpy.squeeze(preds, axis=0)
+    preds = ort_outs
+    seg_prediction = None
 
     if len(preds) > 1:
         preds_out = preds[0]
         seg_prediction = preds[1]
     else:
-        preds_out = preds
+        preds_out = preds[0]
+
+    preds_out = numpy.squeeze(preds_out, axis=0)
 
     sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}.npz")
     numpy.savez(sample_output_filename, preds_out, seg_prediction=seg_prediction)

--- a/src/sparseml/yolov8/utils/export_samples.py
+++ b/src/sparseml/yolov8/utils/export_samples.py
@@ -147,10 +147,20 @@ def _export_torch_outputs(
     preds = model_out
 
     # Move to cpu for exporting
-    preds = preds.detach().to("cpu")
+    # Segmentation currently supports two outputs
+    if isinstance(preds, tuple):
+        pred_0 = preds[0].detach().to("cpu")
+        pred_1 = preds[1].detach().to("cpu")
 
-    sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}.npz")
-    numpy.savez(sample_output_filename, preds)
+        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}-0.npz")
+        numpy.savez(sample_output_filename, pred_0)
+
+        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}-1.npz")
+        numpy.savez(sample_output_filename, pred_1)
+    else:
+        preds = preds.detach().to("cpu")
+        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}.npz")
+        numpy.savez(sample_output_filename, preds)
 
 
 def _export_ort_outputs(
@@ -166,8 +176,16 @@ def _export_ort_outputs(
     preds = numpy.squeeze(ort_outs, axis=0)
     preds = numpy.squeeze(preds, axis=0)
 
-    sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}.npz")
-    numpy.savez(sample_output_filename, preds)
+    if len(preds) > 1:
+        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}-0.npz")
+        numpy.savez(sample_output_filename, preds[0])
+
+        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}-1.npz")
+        numpy.savez(sample_output_filename, preds[1])
+
+    else:
+        sample_output_filename = os.path.join(sample_out_dir, f"out-{file_idx}.npz")
+        numpy.savez(sample_output_filename, preds)
 
 
 def _export_inputs(image: torch.Tensor, sample_in_dir: str, file_idx: str):

--- a/src/sparseml/yolov8/val.py
+++ b/src/sparseml/yolov8/val.py
@@ -42,6 +42,9 @@ from sparseml.yolov8.utils import data_from_dataset_path
     help="i.e. coco128.yaml. Path to data file",
 )
 @click.option(
+    "--save-json", default=False, is_flag=True, help="save results to JSON file"
+)
+@click.option(
     "--save-hybrid",
     default=False,
     is_flag=True,
@@ -66,6 +69,7 @@ from sparseml.yolov8.utils import data_from_dataset_path
 @click.option(
     "--dnn", default=False, is_flag=True, help="use OpenCV DNN for ONNX inference"
 )
+@click.option("--plots", default=False, is_flag=True, help="show plots during training")
 @click.option(
     "--dataset-path",
     type=str,

--- a/src/sparseml/yolov8/val.py
+++ b/src/sparseml/yolov8/val.py
@@ -42,9 +42,6 @@ from sparseml.yolov8.utils import data_from_dataset_path
     help="i.e. coco128.yaml. Path to data file",
 )
 @click.option(
-    "--save-json", default=False, is_flag=True, help="save results to JSON file"
-)
-@click.option(
     "--save-hybrid",
     default=False,
     is_flag=True,
@@ -69,7 +66,6 @@ from sparseml.yolov8.utils import data_from_dataset_path
 @click.option(
     "--dnn", default=False, is_flag=True, help="use OpenCV DNN for ONNX inference"
 )
-@click.option("--plots", default=False, is_flag=True, help="show plots during training")
 @click.option(
     "--dataset-path",
     type=str,

--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -138,8 +138,7 @@ class SparseValidator(BaseValidator):
                 if not hasattr(self, "loss"):
                     self.loss = trainer.model.loss(batch=batch, preds=x)[1]
                 else:
-                    self.loss += trainer.model.loss(
-                        batch=batch, preds=x)[1]
+                    self.loss += trainer.model.loss(batch=batch, preds=x)[1]
 
             # pre-process predictions
             with dt[3]:
@@ -173,7 +172,7 @@ class SparseValidator(BaseValidator):
                 self.loss.cpu() / len(self.dataloader), prefix="val"
             ),
         }
-        print("Training?", self.training)
+
         if self.training:
             return {
                 k: round(float(v), 5) for k, v in stats.items()

--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -134,14 +134,12 @@ class SparseValidator(BaseValidator):
 
             # loss
             with dt[2]:
+                x = preds if self.training else preds[1]
                 if not hasattr(self, "loss"):
-                    self.loss = model.loss(batch, preds if self.training else preds[1])[
-                        1
-                    ]
+                    self.loss = trainer.model.loss(batch=batch, preds=x)[1]
                 else:
-                    self.loss += model.loss(
-                        batch, preds if self.training else preds[1]
-                    )[1]
+                    self.loss += trainer.model.loss(
+                        batch=batch, preds=x)[1]
 
             # pre-process predictions
             with dt[3]:
@@ -175,11 +173,13 @@ class SparseValidator(BaseValidator):
                 self.loss.cpu() / len(self.dataloader), prefix="val"
             ),
         }
+        print("Training?", self.training)
         if self.training:
             return {
                 k: round(float(v), 5) for k, v in stats.items()
             }  # return results as 5 decimal place floats
         else:
+            """
             LOGGER.info(
                 (
                     "Speed: %.1fms pre-process, %.1fms inference, %.1fms loss, %.1fms "
@@ -187,6 +187,7 @@ class SparseValidator(BaseValidator):
                 ),
                 *self.speed,
             )
+            """
             LOGGER.info(f"Validation loss: {stats['val/Loss']}")
             if self.args.save_json and self.jdict:
                 with open(str(self.save_dir / "predictions.json"), "w") as f:

--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -134,11 +134,11 @@ class SparseValidator(BaseValidator):
             # loss
             with dt[2]:
                 if not hasattr(self, "loss"):
-                    self.loss = trainer.criterion(
+                    self.loss = model.loss(
                         preds if self.training else preds[1], batch
                     )[1]
                 else:
-                    self.loss += trainer.criterion(
+                    self.loss += model.loss(
                         preds if self.training else preds[1], batch
                     )[1]
 

--- a/src/sparseml/yolov8/validators.py
+++ b/src/sparseml/yolov8/validators.py
@@ -184,6 +184,7 @@ class SparseValidator(BaseValidator):
                 "postprocess per image" % tuple(self.speed.values())
             )
             LOGGER.info(f"Validation loss: {results['val/Loss']}")
+            LOGGER.info(f"Metrics: {results}")
             if self.args.save_json and self.jdict:
                 with open(str(self.save_dir / "predictions.json"), "w") as f:
                     LOGGER.info(f"Saving {f.name}...")


### PR DESCRIPTION
### Summary
- Update sparseml to use `ultralytics` == 8.0.124. 
- Also update some of the workflows which did not work currently (such as exporting segmentation models with samples)


### Testing
- Training, Validation, and Export workflows were tested for a dense network and while applying a recipe during training
- Recipe applied during training:

```
version: 1.1.0

training_modifiers:
  - !EpochRangeModifier
    start_epoch: 0
    end_epoch: 15

pruning_modifiers:
  - !GMPruningModifier
    init_sparsity: 0.05
    final_sparsity: 0.10
    start_epoch: 5.0
    end_epoch: 10.0
    update_frequency: 1.0
    params: ["model.0.conv.weight", "model.1.conv.weight"]

quantization_modifiers:
  - !QuantizationModifier
    start_epoch: 11.0
    freeze_bn_stats_epoch: 12.0
    disable_quantization_observer_epoch: 13.0
    ignore: ["Upsample", "Concat", "SiLU"]
```

#### Testing Example Commands:

GPU + Recipe

```
Train: sparseml.ultralytics.train --recipe ~/sparseml/recipe.yaml (
Export: sparseml.ultralytics.export_onnx --model runs/detect/train/weights/last.pt --export-samples 20
Val: sparseml.ultralytics.val --model runs/detect/train/weights/[best.pt](http://best.pt/)

```
GPU + Dense

```
Train: sparseml.ultralytics.train  --epochs 50
Export: sparseml.ultralytics.export_onnx --model runs/detect/train/weights/last.pt --export-samples 20
Val: parseml.ultralytics.val --model runs/detect/train/weights/best.pt

```
GPU + Recipe - Segmentation
```
Train: sparseml.ultralytics.train --recipe ~/sparseml/recipe.yaml --task segment --model yolov8n-seg.yaml --data coco128-seg.yaml
Export: sparseml.ultralytics.export_onnx --model runs/segment/train/weights/last.pt --export-samples 20
Val: sparseml.ultralytics.val --task segment --data coco128-seg.yaml --model runs/segment/train/weights/last.pt
```

GPU + Dense - Segmentation
```
Train: sparseml.ultralytics.train --epochs 50 --task segment --model yolov8n-seg.yaml --data coco128-seg.yaml
Export: sparseml.ultralytics.export_onnx --model runs/segment/train/weights/last.pt --export-samples 20
Val: sparseml.ultralytics.val --task segment --data coco128-seg.yaml --model runs/segment/train/weights/last.pt
```

- Trained + exported models were visually examined using netron to make sure the recipes were applied properly during training
- Validation loss was compared for quantized models before and after applying the changes to make sure they were similar

Ran validation on the following model: 
```
sparseml.ultralytics.val \
  --model zoo:cv/detection/yolov8-s/pytorch/ultralytics/coco/pruned65_quant-none \
  --data coco.yaml
```

The mAP@0.50 and mAP@0.5:0.95 match the values listed on sparsezoo and the predictions plots also make sense