### PR TITLE
[Sparsify.alpha][Image Classification] use registry dataset is possible when local path to dataset is not available

### DIFF
--- a/src/sparseml/pytorch/datasets/registry.py
+++ b/src/sparseml/pytorch/datasets/registry.py
@@ -32,6 +32,14 @@ class DatasetRegistry(object):
     _CONSTRUCTORS = {}
     _ATTRIBUTES = {}
 
+    @classmethod
+    @property
+    def registered_datasets(cls) -> List[str]:
+        """
+        :return: valid dataset names registered to this registry
+        """
+        return list(cls._CONSTRUCTORS.keys())
+
     @staticmethod
     def create(key: str, *args, **kwargs) -> Dataset:
         """


### PR DESCRIPTION
enables example registry datasets to be downloaded automatically if a local imagefolder of the same name is not found

**testing:**
verified the following previously failing sparsify command now automatically downloads the example dataset and runs
```
sparsify.run sparse-transfer --use-case image-classification --data imagenette
```