### PR TITLE
[Bug] Fix dataset alias support

### DIFF
--- a/src/sparseml/pytorch/datasets/registry.py
+++ b/src/sparseml/pytorch/datasets/registry.py
@@ -33,7 +33,6 @@ class DatasetRegistry(object):
     _ATTRIBUTES = {}
 
     @classmethod
-    @property
     def registered_datasets(cls) -> List[str]:
         """
         :return: valid dataset names registered to this registry

--- a/src/sparseml/pytorch/image_classification/utils/helpers.py
+++ b/src/sparseml/pytorch/image_classification/utils/helpers.py
@@ -278,7 +278,7 @@ def get_dataset_and_dataloader(
             )
         except Exception as registry_exception:
             if dataset_name == "imagefolder" and (
-                dataset_path in DatasetRegistry.registered_datasets
+                dataset_path in DatasetRegistry.registered_datasets()
             ):
                 # user attempting to run imagefolder of pre-supported
                 # dataset, without a local copy,


### PR DESCRIPTION
-> Remove property from classmethod as it's not supported beyond python 3.9-3.11

Test Command:
```bash
sparsify.run sparse-transfer --use-case image_classification --data imagenette --optim-level 0.5
```
With python3.8, before this PR:
ERROR:
 ```bash
Failures:
[1]:
  time      : 2023-07-07_20:52:56
  host      : quad-mle-1
  rank      : 1 (local_rank: 1)
  exitcode  : 1 (pid: 1351007)
  error_file: /tmp/torchelastic_fimqz_6i/none_vfy4yr00/attempt_0/1/error.json
  traceback : Traceback (most recent call last):
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/utils/helpers.py", line 271, in get_dataset_and_dataloader
      dataset = DatasetRegistry.create(
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/datasets/registry.py", line 58, in create
      return DatasetRegistry._CONSTRUCTORS[key](*args, **kwargs)
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/datasets/classification/imagefolder.py", line 110, in __init__
      super().__init__(root, transform=transforms.Compose(trans))
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 309, in __init__
      super().__init__(
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 144, in __init__
      classes, class_to_idx = self.find_classes(self.root)
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 218, in find_classes
      return find_classes(directory)
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 40, in find_classes
      classes = sorted(entry.name for entry in os.scandir(directory) if entry.is_dir())
  FileNotFoundError: [Errno 2] No such file or directory: '/home/rahul/projects/sparsify/imagenette/train'
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
      return f(*args, **kwargs)
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/train.py", line 575, in main
      train_dataset, train_loader, = helpers.get_dataset_and_dataloader(
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/utils/helpers.py", line 281, in get_dataset_and_dataloader
      dataset_path in DatasetRegistry.registered_datasets
  TypeError: argument of type 'method' is not iterable
  
[2]:
  time      : 2023-07-07_20:52:56
  host      : quad-mle-1
  rank      : 2 (local_rank: 2)
  exitcode  : 1 (pid: 1351008)
  error_file: /tmp/torchelastic_fimqz_6i/none_vfy4yr00/attempt_0/2/error.json
  traceback : Traceback (most recent call last):
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/utils/helpers.py", line 271, in get_dataset_and_dataloader
      dataset = DatasetRegistry.create(
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/datasets/registry.py", line 58, in create
      return DatasetRegistry._CONSTRUCTORS[key](*args, **kwargs)
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/datasets/classification/imagefolder.py", line 110, in __init__
      super().__init__(root, transform=transforms.Compose(trans))
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 309, in __init__
      super().__init__(
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 144, in __init__
      classes, class_to_idx = self.find_classes(self.root)
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 218, in find_classes
      return find_classes(directory)
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 40, in find_classes
      classes = sorted(entry.name for entry in os.scandir(directory) if entry.is_dir())
  FileNotFoundError: [Errno 2] No such file or directory: '/home/rahul/projects/sparsify/imagenette/train'
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
      return f(*args, **kwargs)
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/train.py", line 575, in main
      train_dataset, train_loader, = helpers.get_dataset_and_dataloader(
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/utils/helpers.py", line 281, in get_dataset_and_dataloader
      dataset_path in DatasetRegistry.registered_datasets
  TypeError: argument of type 'method' is not iterable
  
[3]:
  time      : 2023-07-07_20:52:56
  host      : quad-mle-1
  rank      : 3 (local_rank: 3)
  exitcode  : 1 (pid: 1351010)
  error_file: /tmp/torchelastic_fimqz_6i/none_vfy4yr00/attempt_0/3/error.json
  traceback : Traceback (most recent call last):
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/utils/helpers.py", line 271, in get_dataset_and_dataloader
      dataset = DatasetRegistry.create(
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/datasets/registry.py", line 58, in create
      return DatasetRegistry._CONSTRUCTORS[key](*args, **kwargs)
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/datasets/classification/imagefolder.py", line 110, in __init__
      super().__init__(root, transform=transforms.Compose(trans))
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 309, in __init__
      super().__init__(
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 144, in __init__
      classes, class_to_idx = self.find_classes(self.root)
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 218, in find_classes
      return find_classes(directory)
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 40, in find_classes
      classes = sorted(entry.name for entry in os.scandir(directory) if entry.is_dir())
  FileNotFoundError: [Errno 2] No such file or directory: '/home/rahul/projects/sparsify/imagenette/train'
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
      return f(*args, **kwargs)
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/train.py", line 575, in main
      train_dataset, train_loader, = helpers.get_dataset_and_dataloader(
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/utils/helpers.py", line 281, in get_dataset_and_dataloader
      dataset_path in DatasetRegistry.registered_datasets
  TypeError: argument of type 'method' is not iterable
  
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2023-07-07_20:52:56
  host      : quad-mle-1
  rank      : 0 (local_rank: 0)
  exitcode  : 1 (pid: 1351006)
  error_file: /tmp/torchelastic_fimqz_6i/none_vfy4yr00/attempt_0/0/error.json
  traceback : Traceback (most recent call last):
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/utils/helpers.py", line 271, in get_dataset_and_dataloader
      dataset = DatasetRegistry.create(
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/datasets/registry.py", line 58, in create
      return DatasetRegistry._CONSTRUCTORS[key](*args, **kwargs)
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/datasets/classification/imagefolder.py", line 110, in __init__
      super().__init__(root, transform=transforms.Compose(trans))
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 309, in __init__
      super().__init__(
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 144, in __init__
      classes, class_to_idx = self.find_classes(self.root)
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 218, in find_classes
      return find_classes(directory)
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torchvision/datasets/folder.py", line 40, in find_classes
      classes = sorted(entry.name for entry in os.scandir(directory) if entry.is_dir())
  FileNotFoundError: [Errno 2] No such file or directory: '/home/rahul/projects/sparsify/imagenette/train'
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/home/rahul/venvs/sparsify/lib/python3.8/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
      return f(*args, **kwargs)
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/train.py", line 575, in main
      train_dataset, train_loader, = helpers.get_dataset_and_dataloader(
    File "/home/rahul/projects/sparseml/src/sparseml/pytorch/image_classification/utils/helpers.py", line 281, in get_dataset_and_dataloader
      dataset_path in DatasetRegistry.registered_datasets
  TypeError: argument of type 'method' is not iterable
```

After this PR:
```bash
2023-07-07 21:01:22 __main__     INFO     running on device cuda:3
2023-07-07 21:01:22 __main__     INFO     running on device cuda:3
2023-07-07 21:01:22 __main__     INFO     running on device cuda:2
2023-07-07 21:01:22 __main__     INFO     running on device cuda:1
2023-07-07 21:01:22 __main__     INFO     running on device cuda:2
2023-07-07 21:01:22 __main__     INFO     running on device cuda:1
2023-07-07 21:01:22 __main__     INFO     running on device cuda:0
2023-07-07 21:01:22 __main__     INFO     running on device cuda:0
downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3.18k/3.18k [00:00<00:00, 1.12MB/s]
2023-07-07 21:01:23 sparseml.pytorch.utils.logger INFO     Logging all SparseML modifier-level logs to sparse_logs/07-07-2023_21.01.23.log
2023-07-07 21:01:23 __main__     INFO     
Initial validation results: None
2023-07-07 21:01:23 __main__     INFO     
Initial validation results: None
2023-07-07 21:01:23 __main__     INFO     Starting training from epoch 0
2023-07-07 21:01:23 __main__     INFO     Starting training from epoch 0
downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3.18k/3.18k [00:00<00:00, 1.51MB/s]
2023-07-07 21:01:23 sparseml.pytorch.utils.logger INFO     Logging all SparseML modifier-level logs to sparse_logs/07-07-2023_21.01.23.log
2023-07-07 21:01:23 __main__     INFO     
Initial validation results: None
2023-07-07 21:01:23 __main__     INFO     
Initial validation results: None
2023-07-07 21:01:23 __main__     INFO     Starting training from epoch 0
2023-07-07 21:01:23 __main__     INFO     Starting training from epoch 0
downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3.18k/3.18k [00:00<00:00, 1.42MB/s]
2023-07-07 21:01:23 sparseml.pytorch.utils.logger INFO     Logging all SparseML modifier-level logs to sparse_logs/07-07-2023_21.01.23.log
2023-07-07 21:01:23 __main__     INFO     
Initial validation results: None
2023-07-07 21:01:23 __main__     INFO     
Initial validation results: None
2023-07-07 21:01:23 __main__     INFO     Starting training from epoch 0
2023-07-07 21:01:23 __main__     INFO     Starting training from epoch 0
downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3.18k/3.18k [00:00<00:00, 1.07MB/s]
Test epoch -1/-1: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:10<00:00,  1.35s/it]
2023-07-07 21:01:34 __main__     INFO     
Initial validation results: ModuleRunResults(__loss__=2.3638906478881836, top1acc=8.600001335144043, top5acc=47.79999923706055)
2023-07-07 21:01:34 __main__     INFO     
Initial validation results: ModuleRunResults(__loss__=2.3638906478881836, top1acc=8.600001335144043, top5acc=47.79999923706055)
2023-07-07 21:01:34 __main__     INFO     Starting training from epoch 0
2023-07-07 21:01:34 __main__     INFO     Starting training from epoch 0
Train epoch 0/10: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏| 201/202 [00:21<00:00, 11.96it/s]2023-07-07 21:01:56 __main__     INFO     
Epoch 0 training results: ModuleRunResults(__loss__=1.1343241930007935, top1acc=76.61289978027344, top5acc=94.26178741455078)
2023-07-07 21:01:56 __main__     INFO     
Epoch 0 training results: ModuleRunResults(__loss__=1.1343241930007935, top1acc=76.61289978027344, top5acc=94.26178741455078)
Train epoch 0/10: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 202/202 [00:21<00:00,  9.31it/s]
2023-07-07 21:01:56 __main__     INFO     
Epoch 0 training results: ModuleRunResults(__loss__=1.146142601966858, top1acc=76.0545883178711, top5acc=94.97518920898438)
2023-07-07 21:01:56 __main__     INFO     
Epoch 0 training results: ModuleRunResults(__loss__=1.146142601966858, top1acc=76.0545883178711, top5acc=94.97518920898438)
2023-07-07 21:01:56 __main__     INFO     
Epoch 0 training results: ModuleRunResults(__loss__=1.124239206314087, top1acc=76.48883056640625, top5acc=93.82754516601562)
2023-07-07 21:01:56 __main__     INFO     
Epoch 0 training results: ModuleRunResults(__loss__=1.124239206314087, top1acc=76.48883056640625, top5acc=93.82754516601562)
2023-07-07 21:01:56 __main__     INFO     
Epoch 0 training results: ModuleRunResults(__loss__=1.1214579343795776, top1acc=75.9305191040039, top5acc=94.04466247558594)
2023-07-07 21:01:56 __main__     INFO     
Epoch 0 training results: ModuleRunResults(__loss__=1.1214579343795776, top1acc=75.9305191040039, top5acc=94.04466247558594)
Test epoch 0/10: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8/8 [00:01<00:00,  7.32it/s]
Train epoch 1/10:  82%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▊                               | 165/202 [00:14<00:03, 11.56it/s]^CWARNING:torch.distributed.elastic.agent.server.api:Received 2 death signal, shutting down workers

```

RELEVANT ISSUE: https://stackoverflow.com/a/1800999/21911160

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204958639658360