### PR TITLE
Remove protobuf upgrade step from GHA

### DIFF
--- a/.github/workflows/Integrations-post-merge-check.yaml
+++ b/.github/workflows/Integrations-post-merge-check.yaml
@@ -41,8 +41,6 @@ jobs:
         run: pip3 install -U pip && pip3 install setuptools sparsezoo/
       - name: "Clean sparsezoo directory"
         run: rm -r sparsezoo/
-      - name: "Upgrade protobuf version"
-        run: pip3 install --upgrade protobuf
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev,torchvision,deepsparse,onnxruntime,transformers,yolov5]
       - name: "🔬 Running integrations tests (cadence: commit}})"

--- a/.github/workflows/integrations-check.yaml
+++ b/.github/workflows/integrations-check.yaml
@@ -62,8 +62,6 @@ jobs:
         run: pip3 install -U pip && pip3 install setuptools sparsezoo/
       - name: "Clean sparsezoo directory"
         run: rm -r sparsezoo/
-      - name: "Upgrade protobuf version"
-        run: pip3 install --upgrade protobuf
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev,torchvision,deepsparse,onnxruntime,transformers,yolov5]
       - name: "🔬 Running integrations tests (cadence: pre-commit}})"

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -73,8 +73,6 @@ jobs:
         run: pip3 install -U pip && pip3 install setuptools sparsezoo/
       - name: "Clean sparsezoo directory"
         run: rm -r sparsezoo/
-      - name: "Upgrade protobuf version"
-        run: pip3 install --upgrade protobuf
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev,onnxruntime]
       - name: "🔬 Running base tests"
@@ -99,8 +97,6 @@ jobs:
         run: pip3 install -U pip && pip3 install setuptools sparsezoo/
       - name: "Clean sparsezoo directory"
         run: rm -r sparsezoo/
-      - name: "Upgrade protobuf version"
-        run: pip3 install --upgrade protobuf
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev,deepsparse,onnxruntime]
       - name: "🔬 Running deepsparse tests"


### PR DESCRIPTION
This PR removes protobuf upgrade step from workflow file causing integration test failures

The `protobuf` version should be dictated by the `setup.py` file