### PR TITLE
Add latest tagged docker image

### DIFF
--- a/.github/workflows/build-and-publish-release-images.yaml
+++ b/.github/workflows/build-and-publish-release-images.yaml
@@ -43,6 +43,18 @@ jobs:
         run: |
           echo ${{ steps.extract_tag.outputs.tag }}
 
+      - name: Build and  push sparseml latest using default cuda 11.1.1
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker
+          build-args: |
+            DEPS=all
+            VERSION=${{ steps.extract_tag.outputs.tag }}
+          push: true
+          tags: |
+            ghcr.io/neuralmagic/sparseml:latest
+
       - name: Build and  push sparseml with all dependencies and default cuda 11.1.1
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         uses: docker/build-push-action@v2


### PR DESCRIPTION
This PR updates the `.github/workflows/build-and-publish-release-images.yaml` workflow file, to also build and push a latest sparseml image with all dependencies and cuda 11.1.1; this image also includes all dependencies.