### PR TITLE
Fix Create Files Unit Test

### DIFF
--- a/tests/sparseml/conftest.py
+++ b/tests/sparseml/conftest.py
@@ -49,7 +49,8 @@ def check_for_created_files():
     if os.path.isdir(log_dir):
         shutil.rmtree(log_dir)
 
-    end_files_root = _get_files(directory=r".")
+    # allow creation of __pycache__ directories
+    end_files_root = [f_path for f_path in _get_files(directory=r".") if "__pycache__" not in f_path]
     end_files_temp = _get_files(directory=tempfile.gettempdir())
 
     # assert no files created in root directory while running

--- a/tests/sparseml/conftest.py
+++ b/tests/sparseml/conftest.py
@@ -50,7 +50,9 @@ def check_for_created_files():
         shutil.rmtree(log_dir)
 
     # allow creation of __pycache__ directories
-    end_files_root = [f_path for f_path in _get_files(directory=r".") if "__pycache__" not in f_path]
+    end_files_root = [
+        f_path for f_path in _get_files(directory=r".") if "__pycache__" not in f_path
+    ]
     end_files_temp = _get_files(directory=tempfile.gettempdir())
 
     # assert no files created in root directory while running


### PR DESCRIPTION
This is a very similar fix to [deepsparse PR 1117](https://github.com/neuralmagic/deepsparse/pull/1117). `check_for_created_files()` is intended to insure large extraneous files(i.e from LLMs) aren't left in the root directory when running tests. This test case was failing due to `__pycache__` files. These files are small so it should be fine that they are created. To fix the test I filtered out the `__pycache__` directories files from the added files check.

### Testing Instructions
Run `make clean` then `make test`

### Previous Output
```
E       AssertionError: 18 files created in current working directory during pytest run. Created files: {'/home/sadkins/sparseml/src/sparseml/deepsparse/sparsification/__pycache__/info.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/tensorflow_v1/framework/__pycache__/__init__.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/tensorflow_v1/__pycache__/base.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/tensorflow_v1/sparsification/__pycache__/__init__.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/tensorflow_v1/__pycache__/__init__.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/keras/framework/__pycache__/info.cpython-38.pyc',
'/home/sadkins/sparseml/src/sparseml/keras/__pycache__/__init__.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/deepsparse/sparsification/__pycache__/__init__.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/deepsparse/framework/__pycache__/info.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/keras/sparsification/__pycache__/info.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/keras/__pycache__/base.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/tensorflow_v1/sparsification/__pycache__/info.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/keras/sparsification/__pycache__/__init__.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/tensorflow_v1/framework/__pycache__/info.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/deepsparse/framework/__pycache__/__init__.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/keras/framework/__pycache__/__init__.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/deepsparse/__pycache__/__init__.cpython-38.pyc', 
'/home/sadkins/sparseml/src/sparseml/deepsparse/__pycache__/base.cpython-38.pyc'
```

### Updated Output
No assertion thrown