### PR TITLE
Fix Temp File Size Unit Test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.black]
 line-length = 88
 target-version = ['py36']
+
+[tool.pytest.ini_options]
+tmp_path_retention_policy = "none"


### PR DESCRIPTION
1. Adding `tmp_path_retention_policy = "none"` to `pyproject.toml` so that pytest deletes its temp files after every session, freeing up disk space. 
2. Because pytest takes care of deleting its own files, we can exclude them from the file size check in `conftest.py`

### Testing
run `make test TARGETS=transformers`

### Old Behavior
`check_for_created_files()` fails with error:
```
Failed: failed on teardown with "AssertionError: 2506.184633255005 megabytes of temp files created
 in temp directory during pytest run. 
```

### New Behavior
tests pass without errors