### PR TITLE
Revert "Fix onnx export for quantized MPT models 2 (#1647)"

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -362,7 +362,8 @@ def _match_submodule_name_or_type(
     submodule_match = ""
     for name_or_type in names_or_types:
         name_to_compare = submodule_name[:]
-        name_to_compare = _maybe_discard_prefix(name_to_compare)
+        if name_to_compare.startswith("module."):
+            name_to_compare = name_to_compare[7:]
         if name_or_type == submodule.__class__.__name__:
             # type match, return type name
             return name_or_type
@@ -425,7 +426,8 @@ def _validate_set_module_schemes(
             matched = False
             for submodule_name, submodule in model.named_modules():
                 name_to_compare = submodule_name[:]
-                name_to_compare = _maybe_discard_prefix(name_to_compare)
+                if name_to_compare.startswith("module."):
+                    name_to_compare = name_to_compare[7:]
                 if name_to_compare.startswith(type_or_name) or (
                     submodule.__class__.__name__ == type_or_name
                 ):
@@ -451,10 +453,3 @@ def _validate_set_module_schemes(
     unmatched_ignore = _get_unmatched_types_or_names(ignore)
     if unmatched_ignore:
         raise ValueError(_build_error_str("ignore", unmatched_ignore))
-
-
-def _maybe_discard_prefix(name: str) -> str:
-    for prefix in ["module.", "model."]:
-        if name.startswith(prefix):
-            name = name.replace(prefix, "", 1)
-    return name


### PR DESCRIPTION
This reverts commit e8ff0f6bd5ed4fcb8d281f30462462b0125b4ddf.
These commit breaks our current YOLOv8 flows (After #1680 ); reverting them for now, a fix will be put in later for MPT models