### PR TITLE
YOLOV8 Fix modify arch for quantization call

### DIFF
--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -233,7 +233,7 @@ class SparseTrainer(BaseTrainer):
             )
             self.checkpoint_manager = ScheduledModifierManager.from_yaml(ckpt["recipe"])
             if self.checkpoint_manager.quantization_modifiers:
-                self._modify_arch_for_quantization()
+                _modify_arch_for_quantization(self.model)
             self.checkpoint_manager.apply_structure(self.model, epoch=float("inf"))
 
         else:
@@ -245,7 +245,7 @@ class SparseTrainer(BaseTrainer):
                 f"at epoch {ckpt['epoch']}"
             )
             if self.manager.quantization_modifiers:
-                self._modify_arch_for_quantization()
+                _modify_arch_for_quantization(self.model)
             self.manager.apply_structure(self.model, epoch=ckpt["epoch"])
 
     def resume_training(self, ckpt):


### PR DESCRIPTION
Certain calls for `_modify_arch_for_quantization` still referred to the class specific implementation which was removed in #1498. The PR fixes the functional calls for all call references.

Test:
a. python -m torch.distributed.run --no_python --nproc_per_node 2 sparseml.ultralytics.train   --recipe ~/recipes/yolov8/test_yolov8n_recipe.yaml  --model zoo:cv/detection/yolov8-n/pytorch/ultralytics/coco/pruned48_quant-none   --data VOC.yaml   --batch 4
b. python -m torch.distributed.run --no_python --nproc_per_node 2 sparseml.ultralytics.train   --recipe ~/recipes/yolov8/test_yolov8n_recipe.yaml  --model runs/detect/train/weights/last.pt  --data VOC.yaml   --batch 4 --resume