### PR TITLE
[ONNXGraph] delete_orphaned_node_branches utility function

### DIFF
--- a/src/sparseml/exporters/transforms/kv_cache/transforms_base.py
+++ b/src/sparseml/exporters/transforms/kv_cache/transforms_base.py
@@ -157,7 +157,6 @@ class AdditionalTransformsBase(OnnxTransform):
         """
 
         graph = ONNXGraph(model)
-        orphaned_nodes = []
         for node in nodes:
             child_node = graph.get_node_children(node)[0]
 
@@ -172,11 +171,7 @@ class AdditionalTransformsBase(OnnxTransform):
                 if input_name_child_node == output_to_replace:
                     graph.update_node_input(child_node, input_name, idx)
 
-            orphaned_nodes.extend(graph.find_orphaned_nodes(node))
-
-        graph.delete_nodes(orphaned_nodes)
-        graph.update()
-        graph.delete_unused_initializers()
+        graph.delete_orphaned_node_branches()
 
         _LOGGER.info(
             f"Successfully swapped {len(nodes)} nodes for input '{input_name}'"

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -353,7 +353,7 @@ class ONNXGraph(object):
                 orphaned_nodes.append(node)
         return orphaned_nodes
 
-    def delete_orphaned_nodes(self):
+    def delete_orphaned_node_branches(self):
         """
         Deletes all nodes in the graph that are not inputs to other nodes or outputs of
         the graph. Additionally deletes all nodes that would become orphaned

--- a/src/sparseml/onnx/utils/graph_editor.py
+++ b/src/sparseml/onnx/utils/graph_editor.py
@@ -365,6 +365,8 @@ class ONNXGraph(object):
         while orphaned_nodes:
             # no need to refresh self, delete nodes should update internal graph edges
             self.delete_nodes(orphaned_nodes)
+            self.update()
+            self.delete_unused_initializers()
             # update now orphaned nodes, can only run up to len(nodes) times
             orphaned_nodes = self.get_orphaned_nodes(graph_output_ids=graph_output_ids)
 


### PR DESCRIPTION
utility function that deletes all node branches in an ONNX graph that do not lead to a model output
necessary for the latest LLM graph transformations as rewiring the graphs to take positions and causal masks directly leaves the graphs with orphaned node branches

**example_usage:**
```python
import onnx
from sparseml.onnx.utils import ONNXGraph

model = onnx.load(PATH_TO_MODEL)
graph = ONNXGraph(model)

graph.delete_orphaned_node_branches()
```

**test_plan:**
@dbogunowicz to test with LLMs story. will verify that extraneous nodes are deleted and model correctness remains