### PR TITLE
support relative paths in sparseml.tarnsformers.export_onnx

### DIFF
--- a/src/sparseml/transformers/export.py
+++ b/src/sparseml/transformers/export.py
@@ -578,6 +578,9 @@ def export(
     data_args: Optional[str] = None,
     one_shot: Optional[str] = None,
 ):
+    if os.path.exists(model_path):
+        # expand to absolute path to support downstream logic
+        model_path = os.path.abspath(model_path)
     export_transformer_to_onnx(
         task=task,
         model_path=model_path,


### PR DESCRIPTION
fixes internally reported issue where output directories were unable to be created for transformers onnx export
specifically, this commit https://github.com/neuralmagic/sparseml/commit/b52a13da852051bfd7d100652c57929b4c5ffdde tries to access the parent directory of a model which does not work for relative paths

this PR unwraps any file inputs to the script to their absolute path to unblock this and future workflows

**test_plan:**
reproduced issue with local file path and confirmed fix resolves:
```
sparseml.transformers.export_onnx --sequence_length 128 --task text_generation --model_path  opt-350m
```