### PR TITLE
Fix channelwise export

### DIFF
--- a/src/sparseml/exporters/transforms/matmul_to_qlinearmatmul.py
+++ b/src/sparseml/exporters/transforms/matmul_to_qlinearmatmul.py
@@ -97,7 +97,7 @@ class MatMulToQLinearMatMul(OnnxTransform):
             for quantize_linear_parent in [match.parents[0][0], match.parents[1][0]]:
                 if graph.get_init_by_name(quantize_linear_parent.input[0]):
                     continue
-                next_node = graph.get_node_single_child(match.children[-1])
+                next_node = graph.get_node_single_child(match.children[0][-1])
                 if next_node.op_type in COMMON_QUANTIZABLE_OP_TYPES:
                     # the Q/DQ block after this matmul directly feeds into another
                     # quantizable op, it is more likely that this Q/DQ is relevant

--- a/src/sparseml/exporters/transforms/matmul_to_qlinearmatmul.py
+++ b/src/sparseml/exporters/transforms/matmul_to_qlinearmatmul.py
@@ -98,7 +98,7 @@ class MatMulToQLinearMatMul(OnnxTransform):
                 if graph.get_init_by_name(quantize_linear_parent.input[0]):
                     continue
                 next_node = graph.get_node_single_child(match.children[0][-1])
-                if next_node.op_type in COMMON_QUANTIZABLE_OP_TYPES:
+                if next_node and next_node.op_type in COMMON_QUANTIZABLE_OP_TYPES:
                     # the Q/DQ block after this matmul directly feeds into another
                     # quantizable op, it is more likely that this Q/DQ is relevant
                     # to that block - ignore match

--- a/src/sparseml/exporters/transforms/utils/helpers.py
+++ b/src/sparseml/exporters/transforms/utils/helpers.py
@@ -30,10 +30,12 @@ __all__ = [
     "quantize_array",
     "assert_node_type",
     "QUANTIZE_OP_NAMES",
+    "COMMON_QUANTIZABLE_OP_TYPES",
     "attribute_to_kwarg",
 ]
 
 QUANTIZE_OP_NAMES = ["QuantizeLinear", "DequantizeLinear"]
+COMMON_QUANTIZABLE_OP_TYPES = ["Add", "Conv", "Gemm", "MatMul"]
 
 QuantizationParams = NamedTuple(
     "QuantizationParams",

--- a/src/sparseml/exporters/transforms/utils/helpers.py
+++ b/src/sparseml/exporters/transforms/utils/helpers.py
@@ -130,6 +130,7 @@ def quantize_array(
     scale: numpy.ndarray,
     zero_point: numpy.ndarray,
     dtype: Any = numpy.uint8,
+    axis: int = 0,
 ) -> numpy.ndarray:
     try:
         import torch  # noqa: F401
@@ -149,7 +150,7 @@ def quantize_array(
                 tensor,
                 scale,
                 zero_point,
-                0,  # channel axis
+                axis,
                 tensor_dtype,
             )
         else:  # per-tensor quantization


### PR DESCRIPTION
This diff fixes ONNXToDeepSparse QDQ to Quantized graph conversion;

The problems were two fold:
 - Axis was always assumed to be zero; while this works for Convs it will fail for MatMuls (axis = 1) and Gemms (axis selection based on `transA` or `transB` attribute)
 - MatMul node matching errors where some matmuls were incorrectly converted to QlinearMatMuls; fixed by @bfineran in diff #1700 and the commit is cherry-picked in this PR
 
 Test plan(Manual):
 
 Previously failing conversions distilbert qdq and codegen qdq now complete successfully; the generated models have been shared on the `/network`
 
 -> August 14th, 2023 (Monday EST: 14:30 PM) Manually verified QDQ -> Quant conversion using a distilbert model and ran it through deepsparse.benchmark
 
 Test Code:
 ```python
import onnx
from sparseml.exporters.onnx_to_deepsparse import ONNXToDeepsparse

model_path = "/home/rahul/experiments/distilbert/int4-channel-ptq/deployment-qdq/model.onnx"

model = onnx.load(model_path)

exporter = ONNXToDeepsparse()
exporter.apply(model)

new_model_path = "/home/rahul/folded-distil-test.onnx"
onnx.save(model, new_model_path)
```

