### PR TITLE
Enable quantization of tied embeddings

### DIFF
--- a/src/sparseml/pytorch/sparsification/quantization/helpers.py
+++ b/src/sparseml/pytorch/sparsification/quantization/helpers.py
@@ -706,7 +706,7 @@ def prepare_embeddings_qat(
     for submodule in module.modules():
         submodule_qconfig = getattr(submodule, "qconfig", None)
         submodule_qconfig = submodule_qconfig or qconfig
-        if type(submodule) is Embedding and submodule_qconfig is not None:
+        if isinstance(submodule, Embedding) and submodule_qconfig is not None:
             _prepare_qat_embedding(submodule, submodule_qconfig)
 
 


### PR DESCRIPTION
Tied embeddings are usually implemented in a way that they subclass `torch.nn.Embedding` and then implement the custom parts to handle using of the same matrix for embeddings and for the LM head. This PR enables detecting these modules during quantization as their type is not `Embedding`, but rather something custom defined by the LLM implementation. However, they are all subclasses of `torch.nn.Embedding` which we can utilize to detect them.

Before this PR, quantization modifier couldn't find tied embeddings modules as their type is not `torch.nn.Embedding`.