### PR TITLE
[LLAMA] update pattern to consider initializers

### DIFF
--- a/src/sparseml/exporters/transforms/kv_cache/transforms_llama.py
+++ b/src/sparseml/exporters/transforms/kv_cache/transforms_llama.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import warnings
 
 import numpy
 import onnx
@@ -119,7 +120,15 @@ class AdditionalTransformsLLAMA(AdditionalTransformsBase):
                 node.input[2] = self.SLICE_MAX_INT_NAME
                 self.log_match(node)
 
-        _LOGGER.info(f"Found {nodes_found} slice nodes to update")
+        valid_node_counts = [64, 80]
+        if nodes_found not in valid_node_counts:
+            warnings.warn(
+                f"Number of Slice nodes updated {nodes_found} does not match the "
+                f"expected values {valid_node_counts} for the 7 billion and 13 billion "
+                "parameter models."
+            )
+
+        _LOGGER.info(f"Found {nodes_found} Slice nodes to update")
 
         model.graph.initializer.append(max_int_tensor)
         ONNXGraph(model).delete_orphaned_node_branches()

--- a/src/sparseml/exporters/transforms/kv_cache/transforms_llama.py
+++ b/src/sparseml/exporters/transforms/kv_cache/transforms_llama.py
@@ -124,7 +124,7 @@ class AdditionalTransformsLLAMA(AdditionalTransformsBase):
         if nodes_found not in valid_node_counts:
             warnings.warn(
                 f"Number of Slice nodes updated {nodes_found} does not match the "
-                f"expected values {valid_node_counts} for the 7 billion and 13 billion "
+                f"expected values {valid_node_counts} for the 7 billion or 13 billion "
                 "parameter models."
             )
 

--- a/src/sparseml/exporters/transforms/kv_cache/transforms_llama.py
+++ b/src/sparseml/exporters/transforms/kv_cache/transforms_llama.py
@@ -109,7 +109,7 @@ class AdditionalTransformsLLAMA(AdditionalTransformsBase):
                 init = get_init_by_name(model, node.input[0])
                 data_parent = ONNXGraph(model).get_node_single_parent(node, 0)
 
-                # The Slice nodes may be initializers or constants
+                # The Slice nodes may have data which are initializers or constants
                 if init is not None:
                     valid_node = True
                 elif data_parent is not None and len(data_parent.input) == 0:

--- a/src/sparseml/exporters/transforms/kv_cache/transforms_llama.py
+++ b/src/sparseml/exporters/transforms/kv_cache/transforms_llama.py
@@ -108,19 +108,17 @@ class AdditionalTransformsLLAMA(AdditionalTransformsBase):
             if node.op_type == "Slice":
                 init = get_init_by_name(model, node.input[0])
                 data_parent = ONNXGraph(model).get_node_single_parent(node, 0)
-
                 # The Slice nodes may have data which are initializers or constants
-                if init is not None:
-                    valid_node = True
-                elif data_parent is not None and len(data_parent.input) == 0:
+                if init is not None or (
+                    data_parent is not None and len(data_parent.input) == 0
+                ):
                     valid_node = True
 
-                if valid_node:
-                    nodes_found += 1
-                    node.input[2] = self.SLICE_MAX_INT_NAME
-                    self.log_match(node)
+            if valid_node:
+                nodes_found += 1
+                node.input[2] = self.SLICE_MAX_INT_NAME
+                self.log_match(node)
 
-        assert nodes_found == 64
         _LOGGER.info(f"Found {nodes_found} slice nodes to update")
 
         model.graph.initializer.append(max_int_tensor)


### PR DESCRIPTION
For the quantized models, the Slice nodes that need to be updated have input values stored as initializers, while for the dense models, they're stored as constants. This PR updates to check for both.