### PR TITLE
Update Failed README Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ SparseML enables you to create a sparse model trained on your dataset in two way
 - [Sparsify From Scratch With the CLI](integrations/ultralytics-yolov5/tutorials/sparsify-from-scratch.md)
 
 ### Ultralytics YOLOv8
-- [Sparse Transfer Learning With the CLI](integrations/ultralytics-yolov5/tutorials/sparse-transfer-learning.md)
-- [Sparsify From Scratch With the CLI](integrations/ultralytics-yolov5/tutorials/sparsify-from-scratch.md)
+- [Sparse Transfer Learning With the CLI](integrations/ultralytics-yolov8/tutorials/sparse-transfer-learning.md)
+- [Sparsify From Scratch With the CLI](integrations/ultralytics-yolov8/tutorials/sparsify-from-scratch.md)
 
 ### Additional Examples
 
@@ -172,8 +172,8 @@ sparseml.yolov5.train \
   --hyp hyps/hyp.finetune.yaml --cfg yolov5s.yaml --patience 0
 ```
 
-- [YOLOv5 CLI](ultralytics-yolov5/tutorials/sparse-transfer-learning.md)
-- [YOLOv8 CLI](ultralytics-yolov8/tutorials/sparse-transfer-learning.md)
+- [YOLOv5 CLI](integrations/ultralytics-yolov5/tutorials/sparse-transfer-learning.md)
+- [YOLOv8 CLI](integrations/ultralytics-yolov8/tutorials/sparse-transfer-learning.md)
 - [Hugging Face CLI](integrations/huggingface-transformers/tutorials/sparse-transfer-learning-bert.md)
 - [Torchvision CLI](integrations/torchvision/tutorials/sparse-transfer-learning.md)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ SparseML enables you to create a sparse model trained on your dataset in two way
 
 ### Ultralytics YOLOv8
 - [Sparse Transfer Learning With the CLI](integrations/ultralytics-yolov8/tutorials/sparse-transfer-learning.md)
-- [Sparsify From Scratch With the CLI](integrations/ultralytics-yolov8/tutorials/sparsify-from-scratch.md)
 
 ### Additional Examples
 

--- a/integrations/ultralytics-yolov5/tutorials/sparse-transfer-learning.md
+++ b/integrations/ultralytics-yolov5/tutorials/sparse-transfer-learning.md
@@ -81,10 +81,10 @@ Let's try a step-by-step example of Sparse Transfer Learning YOLOv5s onto the VO
 
 To run sparse transfer learning, we first need to create/select a sparsification recipe. For sparse transfer, we need a recipe that instructs SparseML to maintain sparsity during training and to quantize the model over the final epochs.
 
-For the VOC dataset, there is a [transfer learning recipe available in SparseZoo](https://sparsezoo.neuralmagic.com/models/cv%2Fdetection%2Fyolov5-s%2Fpytorch%2Fultralytics%2Fcoco%2Fpruned75_quant-none), identified by the following stub:
+For the VOC dataset, there is a [transfer learning recipe available in SparseZoo](https://sparsezoo.neuralmagic.com/models/yolov5-x6-coco-pruned90_quantized?hardware=deepsparse-c6i.12xlarge&comparison=yolov5-x6-coco-base&tab=4), identified by the following stub:
 
 ```
-zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned75_quant-none?recipe_type=transfer_learn
+zoo:cv/detection/yolov5-x6/pytorch/ultralytics/coco/pruned90_quant-none?recipe=transfer_learn
 ```
 
 Here's what the transfer learning recipe looks like:


### PR DESCRIPTION
Short PR to fix broken links in the readme and yolo tutorials, this should fix the previously failing markdown-link-check 