### PR TITLE
explicitly set ORT providers on all InferenceSession creations

### DIFF
--- a/tests/integrations/helpers.py
+++ b/tests/integrations/helpers.py
@@ -149,8 +149,8 @@ def model_inputs_outputs_test(
         output_names.append(output_a.name)
 
     # run sample forward and test absolute max diff
-    ort_sess_a = InferenceSession(model_path_a)
-    ort_sess_b = InferenceSession(model_path_b)
+    ort_sess_a = InferenceSession(model_path_a, providers=["CPUExecutionProvider"])
+    ort_sess_b = InferenceSession(model_path_b, providers=["CPUExecutionProvider"])
     forward_output_a = ort_sess_a.run(output_names, sample_input)
     forward_output_b = ort_sess_b.run(output_names, sample_input)
     for out_a, out_b in zip(forward_output_a, forward_output_b):

--- a/tests/sparseml/onnx/utils/test_graph_optimizer.py
+++ b/tests/sparseml/onnx/utils/test_graph_optimizer.py
@@ -61,12 +61,16 @@ def test_fold_conv_bn(model_lambda, inputs_dtype):
     assert not _model_has_conv_bn(model_folded)
 
     # Check that the outputs of the original and optimized graphs are equal
-    base_sess = rt.InferenceSession(base_model_path)
+    base_sess = rt.InferenceSession(
+        base_model_path, providers=["CPUExecutionProvider"]
+    )
     base_input_names = [inp.name for inp in base_sess.get_inputs()]
     base_input_shapes = [inp.shape for inp in base_sess.get_inputs()]
     base_output_names = [out.name for out in base_sess.get_outputs()]
 
-    folded_sess = rt.InferenceSession(folded_model_path)
+    folded_sess = rt.InferenceSession(
+        folded_model_path, providers=["CPUExecutionProvider"]
+    )
     folded_input_names = [inp.name for inp in folded_sess.get_inputs()]
     folded_input_shapes = [inp.shape for inp in folded_sess.get_inputs()]
     folded_output_names = [out.name for out in folded_sess.get_outputs()]

--- a/tests/sparseml/onnx/utils/test_graph_optimizer.py
+++ b/tests/sparseml/onnx/utils/test_graph_optimizer.py
@@ -61,9 +61,7 @@ def test_fold_conv_bn(model_lambda, inputs_dtype):
     assert not _model_has_conv_bn(model_folded)
 
     # Check that the outputs of the original and optimized graphs are equal
-    base_sess = rt.InferenceSession(
-        base_model_path, providers=["CPUExecutionProvider"]
-    )
+    base_sess = rt.InferenceSession(base_model_path, providers=["CPUExecutionProvider"])
     base_input_names = [inp.name for inp in base_sess.get_inputs()]
     base_input_shapes = [inp.shape for inp in base_sess.get_inputs()]
     base_output_names = [out.name for out in base_sess.get_outputs()]

--- a/tests/sparseml/pytorch/test_torch_to_onnx_exporter.py
+++ b/tests/sparseml/pytorch/test_torch_to_onnx_exporter.py
@@ -202,7 +202,7 @@ def test_export_per_channel_conv_4bit_model(tmp_path):
 
     # this checks all the I/O shapes check out
     # don't call session.run() b/c ort doesn't support channel-wise for ConvInteger
-    ort.InferenceSession(new_dir / "model.onnx")
+    ort.InferenceSession(new_dir / "model.onnx", providers=["CPUExecutionProvider"])
 
 
 @pytest.mark.skipif(
@@ -232,7 +232,9 @@ def test_export_and_load_per_channel_model(tmp_path, model, sample_batch):
     onnx_model = onnx.load(new_dir / "model.onnx")
     validate_onnx(onnx_model)
 
-    session = ort.InferenceSession(new_dir / "model.onnx")
+    session = ort.InferenceSession(
+        new_dir / "model.onnx", providers=["CPUExecutionProvider"]
+    )
     input_name = session.get_inputs()[0].name
     output_name = session.get_outputs()[0].name
     session.run(
@@ -461,7 +463,9 @@ def _assert_onnx_models_are_equal(
     assert len(old_model.graph.node) == len(new_model.graph.node)
     assert len(old_model.graph.initializer) == len(new_model.graph.initializer)
 
-    old_session = ort.InferenceSession(old_model_path)
+    old_session = ort.InferenceSession(
+        old_model_path, providers=["CPUExecutionProvider"]
+    )
     input_name = old_session.get_inputs()[0].name
     output_name = old_session.get_outputs()[0].name
     old_output = old_session.run(
@@ -471,7 +475,9 @@ def _assert_onnx_models_are_equal(
         else {input_name: sample_batch.numpy()},
     )
 
-    new_session = ort.InferenceSession(new_model_path)
+    new_session = ort.InferenceSession(
+        new_model_path, providers=["CPUExecutionProvider"]
+    )
     new_output = new_session.run(
         [output_name],
         sample_batch


### PR DESCRIPTION
latest version of ORT has a hard requirement for providers to be set. this PR updates any inference session that does not have it set 

**test_plan:**
QA Team + GHA