### PR TITLE
Update transformers/__init__.py to warn about nm_transformers

### DIFF
--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -40,11 +40,10 @@ def _check_transformers_install():
     # check for NM integration in transformers version
     import transformers as _transformers
 
-    if not _transformers.NM_INTEGRATED:
+    if not getattr(_transformers, "NM_INTEGRATED", False):
         _LOGGER.warning(
-            "the neuralmagic fork of transformers may not be installed. it can be "
-            "installed via "
-            f"`pip install {_NM_TRANSFORMERS_NIGHTLY}`"
+            "The neuralmagic fork of transformers may not be installed. It can be "
+            "installed via `pip install nm_transformers`"
         )
 
 

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -41,10 +41,15 @@ def _check_transformers_install():
     import transformers as _transformers
 
     if not getattr(_transformers, "NM_INTEGRATED", False):
-        _LOGGER.warning(
-            "The neuralmagic fork of transformers may not be installed. It can be "
-            "installed via `pip install nm_transformers`"
+        message = (
+            "****************************************************************\n"
+            "WARNING: It appears that the Neural Magic fork of Transformers is not installed!\n"
+            "This is CRITICAL for the proper application of quantization in SparseML flows.\n\n"
+            "To resolve this, please run: `pip uninstall transformers;pip install nm-transformers`\n"
+            "Failing to do so is UNSUPPORTED and may significantly affect model performance.\n"
+            "****************************************************************"
         )
+        _LOGGER.warning(message)
 
 
 _check_transformers_install()


### PR DESCRIPTION
This would fail if the attribute wasn't present rather than warn

```
  File "sparseml/src/sparseml/transformers/__init__.py", line 43, in _check_transformers_install
    if not _transformers.NM_INTEGRATED:
  File "lib/python3.10/site-packages/transformers/utils/import_utils.py", line 1177, in __getattr__
    raise AttributeError(f"module {self.__name__} has no attribute {name}")
AttributeError: module transformers has no attribute NM_INTEGRATED
```