### PR TITLE
Prototype kv cache injection for llama with GQA

### DIFF
--- a/src/sparseml/exporters/transforms/kv_cache/configs.py
+++ b/src/sparseml/exporters/transforms/kv_cache/configs.py
@@ -133,7 +133,7 @@ LLAMA_CONFIG = KeyValueCacheConfig(
     additional_transforms=AdditionalTransformsLLAMA,
     key_num_attention_heads="num_attention_heads",
     key_num_embedding_hidden_size="hidden_size",
-    transpose_value_input=(0, 2, 1, 3),
+    transpose_value_input=None,
     transpose_key_input=None,
     multiply_batch_by_num_att_heads=False,
 )


### PR DESCRIPTION
Grouped Query Attention (GQA) affects the ONNX export and subsequently the KV cache injection. Llama2 7B and 13B don't use GQA so this logic wasn't needed for those models. This is controlled by `num_key_value_heads` in the config.

https://huggingface.co/docs/transformers/main/model_doc/llama#transformers.LlamaConfig.num_key_value_heads
> num_key_value_heads (int, optional) — This is the number of key_value heads that should be used to implement Grouped Query Attention. If num_key_value_heads=num_attention_heads, the model will use Multi Head Attention (MHA), if num_key_value_heads=1 the model will use Multi Query Attention (MQA) otherwise GQA is used. When converting a multi-head checkpoint to a GQA checkpoint, each group key and value head should be constructed by meanpooling all the original heads within that group. For more details checkout [this paper](https://arxiv.org/pdf/2305.13245.pdf). If it is not specified, will default to num_attention_heads`.

TinyLlama was used as a test since it also uses GQA like 34B and 70B: https://huggingface.co/PY007/TinyLlama-1.1B-step-50K-105b/blob/main/config.json