### PR TITLE
Deprecate SSD Resnet Tests

### DIFF
--- a/tests/sparseml/pytorch/models/detection/test_ssd_resnet.py
+++ b/tests/sparseml/pytorch/models/detection/test_ssd_resnet.py
@@ -29,9 +29,7 @@ from sparseml.pytorch.models import (
 from tests.sparseml.pytorch.models.utils import compare_model
 
 
-@pytest.mark.skip(
-    reason="SSD Resnet models deprecated"
-)
+@pytest.mark.skip(reason="SSD Resnet models deprecated")
 @pytest.mark.parametrize(
     "key,pretrained,pretrained_backbone,test_input,match_const",
     [

--- a/tests/sparseml/pytorch/models/detection/test_ssd_resnet.py
+++ b/tests/sparseml/pytorch/models/detection/test_ssd_resnet.py
@@ -29,13 +29,8 @@ from sparseml.pytorch.models import (
 from tests.sparseml.pytorch.models.utils import compare_model
 
 
-@pytest.mark.skipif(
-    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
-    reason="Skipping pytorch tests",
-)
-@pytest.mark.skipif(
-    os.getenv("NM_ML_SKIP_MODEL_TESTS", False),
-    reason="Skipping model tests",
+@pytest.mark.skip(
+    reason="SSD Resnet models deprecated"
 )
 @pytest.mark.parametrize(
     "key,pretrained,pretrained_backbone,test_input,match_const",

--- a/tests/sparseml/pytorch/models/detection/test_ssd_resnet.py
+++ b/tests/sparseml/pytorch/models/detection/test_ssd_resnet.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from typing import Callable, Union
 
 import pytest


### PR DESCRIPTION
These models are deprecated and no longer on SparseZoo as of V2, so we can skip this failing test