### PR TITLE
[Documentation] Add documentation and basic `doctests` to `sparseml/core`

### DIFF
--- a/src/sparseml/core/data/base.py
+++ b/src/sparseml/core/data/base.py
@@ -25,14 +25,30 @@ DT = TypeVar("DT")  # Dataset Type
 
 @dataclass
 class ModifiableData(Generic[DT], MultiFrameworkObject):
+    """
+    A base class for data that can be modified by modifiers.
+
+    :param data: The data to be modified
+    :param num_samples: The number of samples in the data
+    """
+
     data: DT = None
     num_samples: int = None
 
     def get_num_batches(self) -> int:
+        """
+        :return: The number of batches in the data
+        """
         raise NotImplementedError()
 
     def set_batch_size(self, batch_size: int):
+        """
+        :param batch_size: The new batch size to use
+        """
         raise NotImplementedError()
 
     def get_batch_size(self) -> int:
+        """
+        :return: The current batch size
+        """
         raise NotImplementedError()

--- a/src/sparseml/core/event.py
+++ b/src/sparseml/core/event.py
@@ -195,7 +195,7 @@ class Event:
             end
         :param update: The update interval, set to None or 0.0 to always
             update, otherwise must be greater than 0.0, defaults to None
-        :return: True if the event should be updated, False otherwise
+        :return: True if the event should trigger an update, False otherwise
         """
         current = self.current_index
 

--- a/src/sparseml/core/event.py
+++ b/src/sparseml/core/event.py
@@ -25,6 +25,10 @@ __all__ = [
 
 
 class EventType(Enum):
+    """
+    An Enum for defining the different types of events that can be triggered
+    """
+
     # training lifecycle
     PRE_INIT = "pre_init"
     INITIALIZE = "initialize"
@@ -40,6 +44,10 @@ class EventType(Enum):
     OPTIM_POST_STEP = "optim_post_step"
 
     def order(self) -> int:
+        """
+        :raises ValueError: if the event type is invalid
+        :return: The order of the event type, lower is earlier
+        """
         if self == EventType.PRE_INIT:
             return 0
         elif self == EventType.INITIALIZE:
@@ -62,33 +70,63 @@ class EventType(Enum):
 
 @dataclass
 class Event:
-    type_: EventType = None
+    """
+    A class for defining an event that can be triggered during training.
 
-    steps_per_epoch: int = None
-    batches_per_step: int = None
-    invocations_per_step: int = None
+    :param type_: The type of event
+    :param steps_per_epoch: The number of steps per epoch
+    :param batches_per_step: The number of batches per step
+    :param invocations_per_step: The number of invocations per step
+    :param global_step: The current global step
+    :param global_batch: The current global batch
+    """
+
+    type_: Optional[EventType] = None
+
+    steps_per_epoch: Optional[int] = None
+    batches_per_step: Optional[int] = None
+    invocations_per_step: Optional[int] = None
 
     global_step: int = 0
     global_batch: int = 0
 
     @property
     def epoch_based(self) -> bool:
+        """
+        :return: True if the event is based on epochs, False otherwise
+        """
         return self.steps_per_epoch is not None
 
     @property
     def epoch(self) -> int:
+        """
+        :raises ValueError: if the event is not epoch based
+        :return: The current epoch
+        """
         return self.global_step // self.steps_per_epoch
 
     @property
     def epoch_full(self) -> float:
+        """
+        :raises ValueError: if the event is not epoch based
+        :return: The current epoch with the fraction of the current step
+        """
         return self.global_step / float(self.steps_per_epoch)
 
     @property
     def epoch_step(self) -> int:
+        """
+        :raises ValueError: if the event is not epoch based
+        :return: The current step within the current epoch
+        """
         return self.global_step % self.steps_per_epoch
 
     @property
     def epoch_batch(self) -> int:
+        """
+        :raises ValueError: if the event is not epoch based
+        :return: The current batch within the current epoch
+        """
         batches_per_epoch = (
             self.steps_per_epoch * self.batches_per_step
             if self.batches_per_step
@@ -99,6 +137,11 @@ class Event:
 
     @property
     def current_index(self) -> float:
+        """
+        :raises ValueError: if the event is not epoch based
+        :return: The current index of the event, which is either the global step
+            or the epoch with the fraction of the current step
+        """
         if not self.epoch_based:
             return self.global_step
 
@@ -109,6 +152,9 @@ class Event:
 
     @current_index.setter
     def current_index(self, value: float):
+        """
+        Sets the current index of the event
+        """
         if not self.epoch_based:
             self.global_step = int(value)
             self.global_batch = (
@@ -128,6 +174,12 @@ class Event:
     def should_update(
         self, start: Optional[float], end: Optional[float], update: float
     ):
+        """
+        :param start: The start index to update at
+        :param end: The end index to update at
+        :param update: The update interval
+        :return: True if the event should be updated, False otherwise
+        """
         current = self.current_index
 
         if start is not None and current < start:
@@ -139,6 +191,9 @@ class Event:
         return update is None or update <= 0.0 or current % update < 1e-10
 
     def new_instance(self, **kwargs) -> "Event":
+        """
+        :return: A new instance of the event with the provided kwargs
+        """
         instance = deepcopy(self)
         for key, value in kwargs.items():
             setattr(instance, key, value)

--- a/src/sparseml/core/factory.py
+++ b/src/sparseml/core/factory.py
@@ -25,6 +25,18 @@ __all__ = ["ModifierFactory"]
 
 
 class ModifierFactory:
+    """
+    A factory for loading and registering modifiers
+
+    :param _MAIN_PACKAGE_PATH: The path to the main modifiers package
+    :param _EXPERIMENTAL_PACKAGE_PATH: The path to the experimental modifiers package
+    :param _loaded: Whether or not the factory has been loaded
+    :param _main_registry: The registry of main modifiers
+    :param _experimental_registry: The registry of experimental modifiers
+    :param _registered_registry: The registry of registered modifiers
+    :param _errors: The errors that occurred when loading the modifiers
+    """
+
     _MAIN_PACKAGE_PATH = "sparseml.modifiers"
     _EXPERIMENTAL_PACKAGE_PATH = "sparseml.modifiers.experimental"
 
@@ -36,6 +48,10 @@ class ModifierFactory:
 
     @staticmethod
     def refresh():
+        """
+        A method to refresh the factory by reloading the modifiers
+        Note: this will clear any previously registered modifiers
+        """
         ModifierFactory._main_registry = ModifierFactory.load_from_package(
             ModifierFactory._MAIN_PACKAGE_PATH
         )
@@ -46,6 +62,10 @@ class ModifierFactory:
 
     @staticmethod
     def load_from_package(package_path: str) -> Dict[str, Type[Modifier]]:
+        """
+        :param package_path: The path to the package to load modifiers from
+        :return: The loaded modifiers, as a mapping of name to class
+        """
         loaded = {}
         main_package = importlib.import_module(package_path)
 
@@ -93,6 +113,18 @@ class ModifierFactory:
         allow_experimental: bool,
         **kwargs,
     ) -> Modifier:
+        """
+        Instantiate a modifier of the given type from registered modifiers.
+
+        :raises ValueError: If no modifier of the given type is found
+        :param type_: The type of modifier to create
+        :param framework: The framework the modifier is for
+        :param allow_registered: Whether or not to allow registered modifiers
+        :param allow_experimental: Whether or not to allow experimental modifiers
+        :param kwargs: Additional keyword arguments to pass to the modifier
+            during instantiation
+        :return: The instantiated modifier
+        """
         if type_ in ModifierFactory._errors:
             raise ModifierFactory._errors[type_]
 
@@ -121,6 +153,15 @@ class ModifierFactory:
 
     @staticmethod
     def register(type_: str, modifier_class: Type[Modifier]):
+        """
+        Register a modifier class to be used by the factory.
+
+        :raises ValueError: If the provided class does not subclass the Modifier
+            base class or is not a type
+        :param type_: The type of modifier to register
+        :param modifier_class: The class of the modifier to register, must subclass
+            the Modifier base class
+        """
         if not issubclass(modifier_class, Modifier):
             raise ValueError(
                 "The provided class does not subclass the Modifier base class."

--- a/src/sparseml/core/framework.py
+++ b/src/sparseml/core/framework.py
@@ -20,6 +20,10 @@ __all__ = ["Framework"]
 
 
 class Framework(Enum):
+    """
+    An Enum for the different frameworks supported by SparseML
+    """
+
     general = "general"
     pytorch = "pytorch"
     tensorflow = "tensorflow"
@@ -29,6 +33,10 @@ class Framework(Enum):
 
     @classmethod
     def from_str(cls, framework: str) -> "Framework":
+        """
+        :param framework: The string to convert to a framework
+        :return: The corresponding framework enum for the given string
+        """
         framework = framework.lower().strip()
         if framework == "general":
             return cls.general
@@ -45,9 +53,15 @@ class Framework(Enum):
         raise ValueError(f"Unknown framework: {framework}")
 
     def __str__(self):
+        """
+        :return: The string representation of the framework
+        """
         return self.value
 
     def formatted(self) -> str:
+        """
+        :return: The formatted string representation of the framework
+        """
         if self == self.general:
             return "General"
         if self == self.pytorch:
@@ -63,4 +77,7 @@ class Framework(Enum):
         raise ValueError(f"Unknown framework: {self}")
 
     def class_name(self) -> str:
+        """
+        :return: The class name for the framework
+        """
         return self.formatted() if self != self.general else ""

--- a/src/sparseml/core/framework.py
+++ b/src/sparseml/core/framework.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 
-from enum import Enum
+from enum import Enum, unique
 
 
 __all__ = ["Framework"]
 
 
+@unique
 class Framework(Enum):
     """
-    An Enum for the different frameworks supported by SparseML
+    An Enum to represent different frameworks recognized by SparseML
     """
 
     general = "general"
@@ -34,6 +35,10 @@ class Framework(Enum):
     @classmethod
     def from_str(cls, framework: str) -> "Framework":
         """
+        Factory method for creating a framework enum from a string.
+        The string is case insensitive and whitespace is stripped before
+        checking for a match.
+
         :param framework: The string to convert to a framework
         :return: The corresponding framework enum for the given string
         """
@@ -78,6 +83,10 @@ class Framework(Enum):
 
     def class_name(self) -> str:
         """
+        Get the class name for the framework.
+        This is the formatted string representation of the framework.
+        If the framework is `general`, an empty string is returned
+
         :return: The class name for the framework
         """
         return self.formatted() if self != self.general else ""

--- a/src/sparseml/core/framework_object.py
+++ b/src/sparseml/core/framework_object.py
@@ -14,6 +14,7 @@
 
 
 import importlib
+from typing import Optional
 
 from sparseml.core.framework import Framework
 
@@ -23,15 +24,16 @@ __all__ = ["MultiFrameworkObject"]
 
 class MultiFrameworkObject:
     """
-    A base class for objects that can be instantiated for different frameworks.
+    A base class for objects that can be instantiated for different ML frameworks.
+
     Subclassing this will allow loading framework specific implementations
     of the subclassed object, if they exist. If they do not exist, the subclass
-    instance will be returned directly.
+    instance will be returned directly
     """
 
     def __new__(
         cls,
-        framework: Framework = None,
+        framework: Optional[Framework] = None,
         enable_experimental: bool = False,
         **kwargs,
     ):

--- a/src/sparseml/core/framework_object.py
+++ b/src/sparseml/core/framework_object.py
@@ -22,6 +22,13 @@ __all__ = ["MultiFrameworkObject"]
 
 
 class MultiFrameworkObject:
+    """
+    A base class for objects that can be instantiated for different frameworks.
+    Subclassing this will allow loading framework specific implementations
+    of the subclassed object, if they exist. If they do not exist, the subclass
+    instance will be returned directly.
+    """
+
     def __new__(
         cls,
         framework: Framework = None,
@@ -63,6 +70,13 @@ class MultiFrameworkObject:
 
     @staticmethod
     def load_framework_class(package: str, class_name: str):
+        """
+        Load the class from the given package and class name.
+
+        :param package: The package to load the class from
+        :param class_name: The name of the class to load
+        :return: The loaded class module
+        """
         module = importlib.import_module(package)
 
         return getattr(module, class_name)

--- a/src/sparseml/core/lifecycle/event.py
+++ b/src/sparseml/core/lifecycle/event.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 
 from sparseml.core.event import Event, EventType
 
@@ -26,7 +26,16 @@ __all__ = [
 
 
 class EventLifecycle(ABC, Event):
-    type_first: EventType = None
+    """
+    A lifecycle for events to be used in a SparseML session.
+    Handles the logic for when events should be called and what
+    events should be called
+
+    :param type_first: The first event type to be called
+    :param start: The start event to base the lifecycle off of
+    """
+
+    type_first: Optional[EventType] = None
     step_count: int = 0
     batch_count: int = 0
 
@@ -39,6 +48,10 @@ class EventLifecycle(ABC, Event):
         self.global_batch = start.global_batch
 
     def events_from_type(self, type_: EventType) -> List[Event]:
+        """
+        :param type_: The event type to get the events for
+        :return: The list of events for the given type
+        """
         if type_ == EventType.BATCH_START:
             return self.batch_start_events()
 
@@ -57,6 +70,9 @@ class EventLifecycle(ABC, Event):
         raise ValueError(f"invalid event type {type_}")
 
     def check_step_batches_count(self, increment: bool) -> bool:
+        """
+        :return: True if the batch count is at the step count, False otherwise
+        """
         if self.batches_per_step is None or self.batches_per_step < 2:
             return True
 
@@ -69,6 +85,9 @@ class EventLifecycle(ABC, Event):
         return at_step
 
     def check_step_invocations_count(self, increment: bool) -> bool:
+        """
+        :return: True if the invocation count is at the step count, False otherwise
+        """
         if self.invocations_per_step is None or self.invocations_per_step < 2:
             return True
 
@@ -82,28 +101,44 @@ class EventLifecycle(ABC, Event):
 
     @abstractmethod
     def batch_start_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the batch start
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def loss_calculated_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the loss calculated
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def optim_pre_step_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the optim pre step
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def optim_post_step_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the optim post step
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def batch_end_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the batch end
+        """
         raise NotImplementedError()
 
 
 class WrappedOptimEventLifecycle(EventLifecycle):
     """
-    Optimizer is wrapped and no batch or optim callbacks
+    An event lifecycle for when the optimizer is wrapped and no batch or optim
+    callbacks are used.
         - batch_start: must not be invoked, auto triggered
           from loss calculated if that is called, otherwise from pre_step
         - loss_calculated: must be called before batch_end and optim_pre_step
@@ -113,9 +148,16 @@ class WrappedOptimEventLifecycle(EventLifecycle):
     """
 
     def batch_start_events(self) -> List[Event]:
+        """
+        :raises ValueError: if invoked as this should not be called
+        """
         raise ValueError("batch start should not be invoked when only wrapped optim")
 
     def loss_calculated_events(self) -> List[Event]:
+        """
+        :raises ValueError: if invoked before loss calculation
+        :return: The list of events to be called for the loss calculated
+        """
         if self.type_first != EventType.LOSS_CALCULATED:
             raise ValueError("loss calculated must be called first for wrapped optim")
 
@@ -145,6 +187,9 @@ class WrappedOptimEventLifecycle(EventLifecycle):
             ]
 
     def optim_pre_step_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the optim pre step
+        """
         if (
             self.type_first == EventType.OPTIM_PRE_STEP
             and self.type_ is not None
@@ -178,6 +223,9 @@ class WrappedOptimEventLifecycle(EventLifecycle):
         ]
 
     def optim_post_step_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the optim post step
+        """
         if self.type_ != EventType.OPTIM_PRE_STEP:
             raise ValueError("optim post step must be called after optim pre step")
 
@@ -196,12 +244,15 @@ class WrappedOptimEventLifecycle(EventLifecycle):
         ]
 
     def batch_end_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the batch end
+        """
         raise ValueError("batch end should not be invoked when only wrapped optim")
 
 
 class CallbacksEventLifecycle(EventLifecycle):
     """
-    Optimizer is not wrapped, callbacks must be used
+    An event lifecycle for when the optimizer is not wrapped and callbacks are used.
         - batch_start: must be called first
         - loss_calculated: must be called before batch_end and optim_post_step
         - batch_end: must be called before next batch start
@@ -210,6 +261,9 @@ class CallbacksEventLifecycle(EventLifecycle):
     """
 
     def batch_start_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the batch start
+        """
         if self.type_first != EventType.BATCH_START:
             raise ValueError("batch start must be called first for callbacks")
 
@@ -222,6 +276,9 @@ class CallbacksEventLifecycle(EventLifecycle):
         return [self.new_instance(type_=EventType.BATCH_START)]
 
     def loss_calculated_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the loss calculated
+        """
         if self.type_ != EventType.BATCH_START:
             raise ValueError("loss calculated must be called after batch start")
 
@@ -230,6 +287,9 @@ class CallbacksEventLifecycle(EventLifecycle):
         return [self.new_instance(type_=EventType.LOSS_CALCULATED)]
 
     def optim_pre_step_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the optim pre step
+        """
         if (
             self.type_ != EventType.BATCH_START
             and self.type_ != EventType.LOSS_CALCULATED
@@ -248,6 +308,9 @@ class CallbacksEventLifecycle(EventLifecycle):
         ]
 
     def optim_post_step_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the optim post step
+        """
         if self.type_ != EventType.OPTIM_PRE_STEP:
             raise ValueError("optim post step must be called after optim pre step")
 
@@ -263,6 +326,9 @@ class CallbacksEventLifecycle(EventLifecycle):
         ]
 
     def batch_end_events(self) -> List[Event]:
+        """
+        :return: The list of events to be called for the batch end
+        """
         if (
             self.type_ != EventType.OPTIM_POST_STEP
             and self.type_ != EventType.LOSS_CALCULATED

--- a/src/sparseml/core/lifecycle/event.py
+++ b/src/sparseml/core/lifecycle/event.py
@@ -28,8 +28,11 @@ __all__ = [
 class EventLifecycle(ABC, Event):
     """
     A lifecycle for events to be used in a SparseML session.
-    Handles the logic for when events should be called and what
-    events should be called
+    Provides base utilities and also defines the contract that
+    all inheritors must follow.
+
+    The order in which the events are called is determined by
+    the inheritors of this class.
 
     :param type_first: The first event type to be called
     :param start: The start event to base the lifecycle off of
@@ -137,7 +140,7 @@ class EventLifecycle(ABC, Event):
 
 class WrappedOptimEventLifecycle(EventLifecycle):
     """
-    An event lifecycle for when the optimizer is wrapped and no batch or optim
+    An event lifecycle for when the optimizer is wrapped and no batch or optimizer
     callbacks are used.
         - batch_start: must not be invoked, auto triggered
           from loss calculated if that is called, otherwise from pre_step

--- a/src/sparseml/core/model/base.py
+++ b/src/sparseml/core/model/base.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Dict, Generic, List, TypeVar, Union
+from typing import Dict, Generic, List, Optional, TypeVar, Union
 
+from sparseml.core.framework import Framework
 from sparseml.core.framework_object import MultiFrameworkObject
 
 
@@ -28,6 +29,15 @@ PT = TypeVar("PT")
 
 @dataclass
 class ModelParameterizedLayer(Generic[LT, PT]):
+    """
+    A dataclass for holding a parameter and its layer
+
+    :param layer_name: the name of the layer
+    :param layer: the layer object
+    :param param_name: the name of the parameter
+    :param param: the parameter object
+    """
+
     layer_name: str
     layer: LT
     param_name: str
@@ -36,30 +46,66 @@ class ModelParameterizedLayer(Generic[LT, PT]):
 
 @dataclass
 class ModifiableModel(Generic[MT, LT, PT], MultiFrameworkObject):
+    """
+    A dataclass for holding a model and utility methods for modifying it
+
+    :param framework: the framework the model is in
+    :param model: the model object
+    """
+
     model: MT = None
 
-    def __init__(self, framework=None, model=None):
+    def __init__(self, framework: Optional[Framework] = None, model=None):
         self.model = model
 
     def get_layers_params(
         self, targets: Union[str, List[str]]
     ) -> Dict[str, ModelParameterizedLayer[LT, PT]]:
+        """
+        :param targets: the targets to get the layers and params for
+        :return: a dictionary of the layer name to ModelParameterizedLayer instance
+            for that layer
+        """
         raise NotImplementedError()
 
     def get_layers(self, targets: Union[str, List[str]]) -> Dict[str, LT]:
+        """
+        :param targets: the targets to get the layers for
+        :return: a dictionary of the layer name to layer instance for that layer
+        """
         raise NotImplementedError()
 
     def get_layer(self, target: str) -> LT:
+        """
+        :param target: the target to get the layer for
+        :return: the layer instance corresponding to the target
+        """
         raise NotImplementedError()
 
     def set_layer(self, target: str, layer: LT):
+        """
+        :param target: the target to set the layer for
+        :param layer: the layer instance to set
+        """
         raise NotImplementedError()
 
     def get_params(self, targets: Union[str, List[str]]) -> Dict[str, PT]:
+        """
+        :param targets: the targets to get the params for
+        :return: a dictionary of the param name to param instance for that param
+        """
         raise NotImplementedError()
 
     def get_param(self, target: str) -> PT:
+        """
+        :param target: the target to get the param for
+        :return: the param instance corresponding to the target
+        """
         raise NotImplementedError()
 
     def set_param(self, target: str, param: PT):
+        """
+        :param target: the target to set the param for
+        :param param: the param instance to set
+        """
         raise NotImplementedError()

--- a/src/sparseml/core/model/base.py
+++ b/src/sparseml/core/model/base.py
@@ -47,7 +47,14 @@ class ModelParameterizedLayer(Generic[LT, PT]):
 @dataclass
 class ModifiableModel(Generic[MT, LT, PT], MultiFrameworkObject):
     """
-    A dataclass for holding a model and utility methods for modifying it
+    A MultiFrameWorkObject for holding a model. Also defines the
+    contract that must be followed for framework specific implementations.
+
+    Automatically instantiates the correct subclass object based on the
+    specified framework if it exists. If the framework is not specified,
+    the default "general" framework will be used. The inheritors of this class
+    must be named in the following format: ModifiableModel{framework.class_name()}
+    to be searchable by the MultiFrameworkObject factory method.
 
     :param framework: the framework the model is in
     :param model: the model object

--- a/src/sparseml/core/model/pytorch.py
+++ b/src/sparseml/core/model/pytorch.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from torch.nn import Module, Parameter
 
+from sparseml.core.framework import Framework
 from sparseml.core.model.base import ModelParameterizedLayer, ModifiableModel
 from sparseml.utils.pytorch import (
     get_layer,
@@ -32,28 +33,64 @@ __all__ = ["ModifiableModelPyTorch"]
 
 
 class ModifiableModelPyTorch(ModifiableModel[Module, Module, Parameter]):
-    def __init__(self, framework=None, model=None):
+    """
+    A ModifiableModel implementation for PyTorch models
+
+    :param framework: the framework the model is in
+    :param model: the model object
+    """
+
+    def __init__(
+        self, framework: Optional[Framework] = None, model: Optional[Module] = None
+    ):
         super().__init__(framework=framework, model=model)
 
     def get_layers_params(
         self, targets: Union[str, List[str]]
     ) -> Dict[str, ModelParameterizedLayer[Module, Parameter]]:
+        """
+        :param targets: the target layers to get the parameters for
+        :return: a dictionary of layer name to ModelParameterizedLayer
+            instances for the given targets
+        """
         return get_layers_params(targets, self.model)
 
     def get_layers(self, targets: Union[str, List[str]]) -> Dict[str, Module]:
+        """
+        :returns: a dictionary of layer name to layer for the given targets
+        """
         return get_layers(targets, self.model)
 
     def get_layer(self, target: str) -> Tuple[str, Module]:
+        """
+        :returns: the layer for the given target
+        """
         return get_layer(target, self.model)
 
     def set_layer(self, target: str, layer: Module) -> Module:
+        """
+        :param target: the target to set the layer for
+        """
         return set_layer(target, layer, self.model)
 
     def get_params(self, targets: Union[str, List[str]]) -> Dict[str, Parameter]:
+        """
+        :param targets: the target parameters to get, can be a single target or
+            a list of targets
+        :return: a dictionary of parameter name to parameter for the given targets
+        """
         return get_params(targets, self.model)
 
     def get_param(self, target: str) -> Tuple[str, Parameter]:
+        """
+        :returns: a tuple of the parameter name and its Parameter instance
+            for the given target
+        """
         return get_param(target, self.model)
 
     def set_param(self, target: str, param: Parameter):
+        """
+        :param target: the target to set the parameter for
+        :param param: the parameter to set
+        """
         return set_param(target, param, self.model)

--- a/src/sparseml/core/modifier/base.py
+++ b/src/sparseml/core/modifier/base.py
@@ -23,45 +23,97 @@ __all__ = ["ModifierInterface"]
 
 
 class ModifierInterface(ABC):
+    """
+    Defines the contract that all modifiers must implement
+    """
+
     @property
     @abstractmethod
     def initialized_structure(self) -> bool:
+        """
+        :return: True if the modifier structure has been
+            applied to the model
+        """
         raise NotImplementedError()
 
     @property
     @abstractmethod
     def initialized(self) -> bool:
+        """
+        :return: True if the modifier has been initialized
+        """
         raise NotImplementedError()
 
     @property
     @abstractmethod
     def finalized(self) -> bool:
+        """
+        :return: True if the modifier has been finalized
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def check_initialized(self):
+        """
+        Check if the modifier has been initialized and
+        raise an error if not
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def calculate_start(self) -> float:
+        """
+        :return: the start step for the modifier
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def calculate_end(self) -> float:
+        """
+        :return: the end step for the modifier
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def pre_initialize_structure(self, state: State, **kwargs):
+        """
+        Apply the modifier structure to the model
+
+        :param state: The current state of the model
+        :param kwargs: Additional arguments for the modifier
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def initialize(self, state: State, **kwargs):
+        """
+        Initialize the modifier
+
+        :param state: The current state of the model
+        :param kwargs: Additional keyword arguments
+            for modifier initialization
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def finalize(self, state: State, **kwargs):
+        """
+        Finalize the modifier
+
+        :param state: The current state of the model
+        :param kwargs: Additional keyword arguments for
+            modifier finalization
+        """
         raise NotImplementedError()
 
     @abstractmethod
     def update_event(self, state: State, event: Event, **kwargs):
+        """
+        Update the modifier based on the event
+
+        :param state: The current state of the model
+        :param event: The event to update the modifier with
+        :param kwargs: Additional keyword arguments for
+            modifier update
+        """
         raise NotImplementedError()

--- a/src/sparseml/core/modifier/modifier.py
+++ b/src/sparseml/core/modifier/modifier.py
@@ -83,13 +83,15 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
 
     def calculate_start(self) -> float:
         """
-        :return: the start step for the modifier if set, else -1
+        Calculate and return the start epoch for the modifier.
+
+        :return: the start epoch for the modifier if set, else -1
         """
         return self.start if self.start is not None else -1
 
     def calculate_end(self) -> float:
         """
-        :return: the end step for the modifier if set, else -1
+        :return: the end epoch for the modifier if set, else -1
         """
         return self.end if self.end is not None else -1
 

--- a/src/sparseml/core/modifier/modifier.py
+++ b/src/sparseml/core/modifier/modifier.py
@@ -299,7 +299,7 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
 
     def on_event(self, state: State, event: Event, **kwargs):
         """
-        on_event is called whenever an update event is triggered
+        on_event is called whenever an event is triggered
 
         :param state: The current state of the model
         :param event: The event that triggered the update

--- a/src/sparseml/core/modifier/modifier.py
+++ b/src/sparseml/core/modifier/modifier.py
@@ -27,6 +27,19 @@ __all__ = ["Modifier"]
 
 
 class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
+    """
+    A base class for all modifiers to inherit from.
+    Modifiers are used to modify the training process for a model.
+    Defines base attributes and methods available to all modifiers
+
+    :param index: The index of the modifier in the list of modifiers
+        for the model
+    :param group: The group name for the modifier
+    :param start: The start step for the modifier
+    :param end: The end step for the modifier
+    :param update: The update step for the modifier
+    """
+
     index: int = None
     group: str = None
     start: float = None
@@ -41,31 +54,62 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
 
     @property
     def initialized_structure(self) -> bool:
+        """
+        :return: True if the modifier structure has been
+            applied to the model
+        """
         return self._initialized_structure
 
     @property
     def initialized(self) -> bool:
+        """
+        :return: True if the modifier has been initialized
+        """
         return self.initialized_
 
     @property
     def finalized(self) -> bool:
+        """
+        :return: True if the modifier has been finalized
+        """
         return self.finalized_
 
     def check_initialized(self):
+        """
+        :raises RuntimeError: if the modifier has not been initialized
+        """
         if not self.initialized_:
             raise RuntimeError("modifier has not been initialized")
 
     def calculate_start(self) -> float:
+        """
+        :return: the start step for the modifier if set, else -1
+        """
         return self.start if self.start is not None else -1
 
     def calculate_end(self) -> float:
+        """
+        :return: the end step for the modifier if set, else -1
+        """
         return self.end if self.end is not None else -1
 
     def pre_initialize_structure(self, state: State, **kwargs):
+        """
+        :param state: The current state of the model
+        :param kwargs: Additional arguments for initializing the structure
+            of the model in question
+        """
         self.on_initialize_structure(state, **kwargs)
         self.initialized_structure_ = True
 
     def initialize(self, state: State, **kwargs):
+        """
+        Initialize the modifier for the given model and state.
+
+        :raises RuntimeError: if the modifier has already been finalized
+        :param state: The current state of the model
+        :param kwargs: Additional arguments for initializing the modifier
+        """
         if self.initialized_:
             return
 
@@ -90,6 +134,13 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
             self.started_ = True
 
     def finalize(self, state: State, **kwargs):
+        """
+        Finalize the modifier for the given model and state.
+
+        :raises RuntimeError: if the modifier has not been initialized
+        :param state: The current state of the model
+        :param kwargs: Additional arguments for finalizing the modifier
+        """
         if self.finalized_:
             return
 
@@ -107,6 +158,15 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
         self.finalized_ = finalized
 
     def update_event(self, state: State, event: Event, **kwargs):
+        """
+        Update modifier based on the given event.
+
+        :raises RuntimeError: if the modifier has not been initialized
+        :raises RuntimeError: if the modifier has been finalized
+        :param state: The current state of the model
+        :param event: The event to update the modifier with
+        :param kwargs: Additional arguments for updating the modifier
+        """
         if not self.initialized_:
             raise RuntimeError("cannot update an uninitialized modifier")
 
@@ -142,7 +202,11 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
         if self.started_ and not self.ended_:
             self.on_update(state, event, **kwargs)
 
-    def should_start(self, event: Event):
+    def should_start(self, event: Event) -> bool:
+        """
+        :param event: The event to check if the modifier should start
+        :return: True if the modifier should start based on the given event
+        """
         if not self.start:
             return False
 
@@ -151,27 +215,90 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
         return self.start <= current and (self.end is None or current < self.end)
 
     def should_end(self, event: Event):
+        """
+        :param event: The event to check if the modifier should end
+        :return: True if the modifier should end based on the given event
+        """
         current = event.current_index
 
         return self.end is not None and current >= self.end
 
     def on_initialize_structure(self, state: State, **kwargs):
+        """
+        on_initialize_structure is called before the model is initialized
+        with the modifier structure. Must be implemented by the inheriting
+        modifier.
+
+        :param state: The current state of the model
+        :param kwargs: Additional arguments for initializing the structure
+            of the model in question
+        """
         raise NotImplementedError()
 
     def on_initialize(self, state: State, **kwargs) -> bool:
+        """
+        on_initialize is called on modifier initialization and
+        must be implemented by the inheriting modifier.
+
+        :param state: The current state of the model
+        :param kwargs: Additional arguments for initializing the modifier
+        :return: True if the modifier was initialized successfully,
+            False otherwise
+        """
         raise NotImplementedError()
 
     def on_finalize(self, state: State, **kwargs) -> bool:
+        """
+        on_finalize is called on modifier finalization and
+        must be implemented by the inheriting modifier.
+
+        :param state: The current state of the model
+        :param kwargs: Additional arguments for finalizing the modifier
+        :return: True if the modifier was finalized successfully,
+            False otherwise
+        """
         raise NotImplementedError()
 
     def on_start(self, state: State, event: Event, **kwargs):
+        """
+        on_start is called when the modifier starts and
+        must be implemented by the inheriting modifier.
+
+        :param state: The current state of the model
+        :param event: The event that triggered the start
+        :param kwargs: Additional arguments for starting the modifier
+        """
         raise NotImplementedError()
 
     def on_update(self, state: State, event: Event, **kwargs):
+        """
+        on_update is called when the model in question must be
+        updated based on passed in event. Must be implemented by the
+        inheriting modifier.
+
+        :param state: The current state of the model
+        :param event: The event that triggered the update
+        :param kwargs: Additional arguments for updating the model
+        """
         raise NotImplementedError()
 
     def on_end(self, state: State, event: Event, **kwargs):
+        """
+        on_end is called when the modifier ends and must be implemented
+        by the inheriting modifier.
+
+        :param state: The current state of the model
+        :param event: The event that triggered the end
+        :param kwargs: Additional arguments for ending the modifier
+        """
         raise NotImplementedError()
 
     def on_event(self, state: State, event: Event, **kwargs):
+        """
+        on_event is called whenever an update event is triggered
+
+        :param state: The current state of the model
+        :param event: The event that triggered the update
+        :param kwargs: Additional arguments for updating the model
+        """
         pass

--- a/src/sparseml/core/modifier/modifier.py
+++ b/src/sparseml/core/modifier/modifier.py
@@ -161,11 +161,13 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
 
     def update_event(self, state: State, event: Event, **kwargs):
         """
-        Update modifier based on the given event.
+        Update modifier based on the given event. In turn calls
+        on_start, on_update, and on_end based on the event and
+        modifier settings.
 
         :raises RuntimeError: if the modifier has not been initialized
         :raises RuntimeError: if the modifier has been finalized
-        :param state: The current state of the model
+        :param state: The current state of sparsification
         :param event: The event to update the modifier with
         :param kwargs: Additional arguments for updating the modifier
         """

--- a/src/sparseml/core/modifier/stage.py
+++ b/src/sparseml/core/modifier/stage.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -27,27 +27,55 @@ __all__ = ["StageModifiers"]
 
 
 class StageModifiers(ModifierInterface, BaseModel):
+    """
+    Represents a collection of modifiers that are applied together as a stage.
+
+    :param modifiers: The modifiers to apply as a stage
+    :param index: The index of the stage, if applicable
+    :param group: The group name of the stage, if applicable
+    """
+
     modifiers: List["Modifier"] = Field(default_factory=list)
-    index: int = None
-    group: str = None
+    index: Optional[int] = None
+    group: Optional[str] = None
 
     @property
     def initialized_structure(self) -> bool:
+        """
+        :return: True if any of the stage modifiers have initialized structure,
+            False otherwise
+        """
         return any(mod.initialized_structure for mod in self.modifiers)
 
     @property
     def initialized(self) -> bool:
+        """
+        :return: True if all of the stage modifiers have been initialized,
+            False otherwise
+        """
         return all(mod.initialized for mod in self.modifiers)
 
     @property
     def finalized(self) -> bool:
+        """
+        :return: True if all of the stage modifiers have been finalized,
+            False otherwise
+        """
         return all(mod.finalized for mod in self.modifiers)
 
     def check_initialized(self):
+        """
+        Check if all of the stage modifiers have been initialized,
+        raises an exception if not
+        """
+
         for modifier in self.modifiers:
             modifier.check_initialized()
 
     def calculate_start(self) -> float:
+        """
+        :return: The minimum start time of all the stage modifiers
+        """
         return min(
             mod.calculate_start()
             for mod in self.modifiers
@@ -55,22 +83,54 @@ class StageModifiers(ModifierInterface, BaseModel):
         )
 
     def calculate_end(self) -> float:
+        """
+        :return: The maximum end time of all the stage modifiers
+        """
         return max(
             mod.calculate_end() for mod in self.modifiers if mod.calculate_end() >= 0
         )
 
     def pre_initialize_structure(self, state: "State", **kwargs):
+        """
+        Pre initialize the structure for all stage modifiers
+
+        :param state: The current state of the training
+        :param kwargs: Additional kwargs to pass to the modifier(s)
+            pre_initialize_structure method
+        """
         for modifier in self.modifiers:
             modifier.pre_initialize_structure(state, **kwargs)
 
     def initialize(self, state: "State", **kwargs):
+        """
+        Initialize all the stage modifiers
+
+        :param state: The state of current session
+        :param kwargs: Additional kwargs to pass to the modifier(s)
+            initialize method
+        """
         for modifier in self.modifiers:
             modifier.initialize(state, **kwargs)
 
     def finalize(self, state: "State", **kwargs):
+        """
+        Finalize all the stage modifiers
+
+        :param state: The state of current session
+        :param kwargs: Additional kwargs to pass to the modifier(s)
+            finalize method
+        """
         for modifier in self.modifiers:
             modifier.finalize(state, **kwargs)
 
     def update_event(self, state: "State", event: "Event", **kwargs):
+        """
+        Propagate the event to all the stage modifiers
+
+        :param state: The state of current session
+        :param event: The event to propagate
+        :param kwargs: Additional kwargs to pass to the modifier(s)
+            update_event method
+        """
         for modifier in self.modifiers:
             modifier.update_event(state, event, **kwargs)

--- a/src/sparseml/core/optimizer/base.py
+++ b/src/sparseml/core/optimizer/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, Generic, List, TypeVar, Union
+from typing import Any, Generic, List, Optional, TypeVar, Union
 
 from sparseml.core.framework_object import MultiFrameworkObject
 
@@ -27,31 +27,75 @@ PGT = TypeVar("PGT")
 
 @dataclass
 class ModifiableOptimizer(Generic[OT, PGT], MultiFrameworkObject):
-    optimizer: OT = None
+    """
+    Generic class to wrap an optimizer
+
+    :param optimizer: the optimizer to wrap
+    :param attach_optim_callbacks: if True, will attach callbacks to the optimizer
+    :param framework: the framework the optimizer is for
+    """
+
+    optimizer: Optional[OT] = None
 
     def __init__(self, optimizer=None, attach_optim_callbacks=False, framework=None):
         self.optimizer = optimizer
 
     def get_param_groups(self) -> List[PGT]:
+        """
+        :return: the parameter groups for the optimizer
+        """
         raise NotImplementedError()
 
     def set_param_groups(self, param_groups: List[PGT]):
+        """
+        Set the parameter groups for the optimizer
+
+        :param param_groups: the parameter groups to set
+        """
         raise NotImplementedError()
 
     def get_learning_rate(
         self, group_index: Union[int, None] = None
     ) -> Union[float, List[float]]:
+        """
+        Get learning rate for the given group index or all groups
+        from the optimizer
+
+        :param group_index: the index of the group to get the learning rate for,
+            set to None to get all learning rates
+        :return: the learning rate or list of learning rates
+        """
         raise NotImplementedError()
 
     def set_learning_rate(self, lr: float, group_index: Union[int, None] = None):
+        """
+        Set the learning rate for the given group index or all groups
+        """
         raise NotImplementedError()
 
     def get_attribute(
         self, name: str, group_index: Union[int, None] = None
     ) -> Union[Any, List[Any]]:
+        """
+        Get the attribute for the given group index or all groups
+        from the optimizer
+
+        :param name: the name of the attribute to get
+        :param group_index: the index of the group to get the attribute for,
+            set to None to get all attributes
+        :return: the attribute value or the list of attribute values
+        """
         raise NotImplementedError()
 
     def set_attribute(
         self, name: str, value: Any, group_index: Union[int, None] = None
     ):
+        """
+        Set the attribute for the given group index or all groups in the optimizer
+
+        :param name: the name of the attribute to set
+        :param value: the value to set the attribute to
+        :param group_index: the index of the group to set the attribute for,
+            set to None to set attribute in all groups
+        """
         raise NotImplementedError()

--- a/src/sparseml/core/optimizer/pytorch.py
+++ b/src/sparseml/core/optimizer/pytorch.py
@@ -23,6 +23,14 @@ __all__ = ["ModifiableOptimizerPyTorch"]
 
 
 class ModifiableOptimizerPyTorch(ModifiableOptimizer[Optimizer, Dict[str, Any]]):
+    """
+    A ModifiableOptimizer implementation for PyTorch optimizers
+
+    :param optimizer: the torch optimizer to wrap
+    :param attach_optim_callbacks: if True, will attach callbacks to the optimizer
+    :param framework: the framework the optimizer is for (PyTorch)
+    """
+
     def __init__(self, optimizer=None, attach_optim_callbacks=False, framework=None):
         super().__init__(
             optimizer=optimizer,
@@ -31,19 +39,46 @@ class ModifiableOptimizerPyTorch(ModifiableOptimizer[Optimizer, Dict[str, Any]])
         )
 
     def get_param_groups(self) -> List[Dict[str, Any]]:
+        """
+        Get the parameter groups for the optimizer
+
+        :return: a list of dictionaries representing parameter groups for
+            the optimizer
+        """
         return self.optimizer.param_groups
 
     def set_param_groups(self, param_groups: List[Dict[str, Any]]):
+        """
+        Set the parameter groups for the optimizer
+
+        :param param_groups: the parameter groups to set, must be a list of
+            dictionaries representing parameter groups for the optimizer
+        """
         self.optimizer.param_groups = param_groups
 
     def get_learning_rate(
         self, group_idx: Union[int, None] = None
     ) -> Union[float, List[float]]:
+        """
+        Get the learning rate for the given group index from the optimizer
+
+        :param group_idx: the index of the group to get the learning rate for,
+            set to None to get all learning rates
+        :return: the learning rate or list of learning rates
+        """
         if group_idx is not None:
             return self.optimizer.param_groups[group_idx]["lr"]
         return [group["lr"] for group in self.optimizer.param_groups]
 
     def set_learning_rate(self, lr: float, group_idx: Union[int, None] = None):
+        """
+        Set the learning rate for the given group index or all groups
+        in the optimizer
+
+        :param lr: the learning rate to set
+        :param group_idx: the index of the group to set the learning rate for,
+            set to None to set learning rates for all parameter groups
+        """
         if group_idx is not None:
             self.optimizer.param_groups[group_idx]["lr"] = lr
         else:
@@ -53,6 +88,14 @@ class ModifiableOptimizerPyTorch(ModifiableOptimizer[Optimizer, Dict[str, Any]])
     def get_attribute(
         self, attr_name: str, group_idx: Union[int, None] = None
     ) -> Union[Any, List[Any]]:
+        """
+        Get the attribute value for the given group index from the optimizer
+
+        :param attr_name: the name of the attribute to get
+        :param group_idx: the index of the group to get the attribute for,
+            set to None to get the attribute(s) value for all groups
+        :return: the attribute value or list of attribute values
+        """
         if group_idx is not None:
             return self.optimizer.param_groups[group_idx].get(attr_name, None)
         return [group.get(attr_name, None) for group in self.optimizer.param_groups]
@@ -60,6 +103,14 @@ class ModifiableOptimizerPyTorch(ModifiableOptimizer[Optimizer, Dict[str, Any]])
     def set_attribute(
         self, attr_name: str, value: Any, group_idx: Union[int, None] = None
     ):
+        """
+        Set the attribute for the given group index or all groups in the optimizer
+
+        :param attr_name: the name of the attribute to set
+        :param value: the value to set the attribute to
+        :param group_idx: the index of the group to set the attribute for,
+            set to None to set attribute in all groups
+        """
         if group_idx is not None:
             self.optimizer.param_groups[group_idx][attr_name] = value
         else:

--- a/src/sparseml/core/recipe/args.py
+++ b/src/sparseml/core/recipe/args.py
@@ -21,25 +21,115 @@ __all__ = ["RecipeArgs"]
 
 
 class RecipeArgs(Dict[str, Any]):
+    """
+    A dict to represent recipe arguments that can be evaluated
+    and used to override values in a recipe
+
+    Use constructor to create a new RecipeArgs instance:
+    >>> RecipeArgs(a=1, b=2, c=3)
+    {'a': 1, 'b': 2, 'c': 3}
+
+    Use another dict instance to create a new RecipeArgs instance:
+    >>> RecipeArgs({"a": 1, "b": 2, "c": 3})
+    {'a': 1, 'b': 2, 'c': 3}
+
+    Use another RecipeArgs instance to create a new RecipeArgs instance:
+    >>> RecipeArgs(RecipeArgs(a=1, b=2))
+    {'a': 1, 'b': 2}
+
+    RecipeArgs is a dict and can be used as such:
+    >>> isinstance(RecipeArgs(a=1, b=2, c=3), dict)
+    True
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._evaluated: "Optional[RecipeArgs]" = None
 
     def combine(self, other: Union["RecipeArgs", Dict[str, Any]]) -> "RecipeArgs":
+        """
+        Helper to combine current recipe args with another set of RecipeArgs
+        or a dict
+
+        Combine with another RecipeArgs instance:
+        >>> RecipeArgs(a=1, b=2, c=3).combine(RecipeArgs(d=4, e=5))
+        {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5}
+
+        Combine with a valid str --> any dict:
+        >>> RecipeArgs(a=1, b=2, c=3).combine({"d": 4, "e": 5})
+        {'a': 1, 'b': 2, 'c': 3, 'd': 4, 'e': 5}
+
+        Combine with an invalid dict raises ValueError:
+        >>> RecipeArgs(a=1, b=2, c=3).combine({1:3})
+        Traceback (most recent call last):
+        ...
+        ValueError: `other` must be a RecipeArgs ...
+
+        :param other: The other recipe args or dict to combine with the current
+            RecipeArgs instance
+        :return: The combined recipe args
+        """
         combined = RecipeArgs()
         combined.update(self)
 
         if other:
+            for key in other.keys():
+                if not isinstance(key, str):
+                    raise ValueError(
+                        "`other` must be a RecipeArgs instance or dict with str keys"
+                        f" but got {key=} of type {type(key)}"
+                    )
             combined.update(other)
 
         return combined
 
-    def evaluate(self, parent: "RecipeArgs" = None) -> "RecipeArgs":
+    def evaluate(self, parent: Optional["RecipeArgs"] = None) -> "RecipeArgs":
+        """
+        Evaluate the current recipe args and return a new RecipeArgs instance
+        with the evaluated values
+
+        Evaluate with no parent:
+        >>> a = RecipeArgs(a="eval(2*3)", b=2, c=3)
+        >>> a
+        {'a': 'eval(2*3)', 'b': 2, 'c': 3}
+        >>> a.evaluate()
+        {'a': 6.0, 'b': 2, 'c': 3}
+
+        Evaluate with a parent:
+        >>> RecipeArgs(a="eval(2 * 3)", b=2).evaluate(
+        ... parent=RecipeArgs(c="eval(a * b)"))
+        {'a': 6.0, 'b': 2, 'c': 12.0}
+
+        :param parent: Optional extra recipe args to combine with the current
+            instance before evaluating
+        :return: The evaluated recipe args
+        """
         self._evaluated = RecipeArgs.eval_args(self.combine(parent))
 
         return self._evaluated
 
     def evaluate_ext(self, target: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Evaluate external target dict with the current recipe args and return
+        the resulting evaluated dict
+
+        Empty dict is returned when target is empty:
+        >>> RecipeArgs(a=1, b=2, c=3).evaluate_ext({})
+        {}
+
+        Evaluate target with values from current recipe args:
+        >>> RecipeArgs(a=6).evaluate_ext({"b": "eval(a * 2)"})
+        {'b': 12.0}
+
+        Reusing target's evaluated values results in NameError:
+        >>> RecipeArgs().evaluate_ext({"b": 2, "c": "eval(a * b)"})
+        Traceback (most recent call last):
+        ...
+        NameError: name 'b' is not defined
+
+        :param target: The target dict to evaluate
+        :return: The combined RecipeArgs instance with the evaluated values
+        """
         args = RecipeArgs.eval_args(self)
         resolved = {}
 
@@ -49,7 +139,32 @@ class RecipeArgs(Dict[str, Any]):
         return resolved
 
     @staticmethod
-    def eval_str(target: str, args: Dict[str, Any] = None) -> Union[str, float]:
+    def eval_str(
+        target: str, args: Optional[Dict[str, Any]] = None
+    ) -> Union[str, float]:
+        """
+        Evaluate the target string with the supplied args and return the
+        resulting evaluated value
+
+        Evaluate a simple string:
+        >>> RecipeArgs.eval_str("eval(2 * 3)")
+        6.0
+
+        Evaluate a string with a variable:
+        >>> RecipeArgs.eval_str("eval(a * 3)", {"a": 2})
+        6.0
+
+        Evaluate a string with a variable but no args raises NameError:
+        >>> RecipeArgs.eval_str("eval(a * 3)")
+        Traceback (most recent call last):
+        ...
+        NameError: name 'a' is not defined
+
+        :param target: The target string to evaluate
+        :param args: The args to use for the evaluation, these will be used
+            as the local namespace for the eval
+        :return: The evaluated value of the target string
+        """
         if "eval(" not in target:
             return target
 
@@ -69,6 +184,29 @@ class RecipeArgs(Dict[str, Any]):
 
     @staticmethod
     def eval_args(args: Dict[str, Any]) -> "RecipeArgs":
+        """
+        Evaluate supplied args and return a new RecipeArgs instance with the
+        evaluated values
+
+        Evaluate args with no eval strings:
+        >>> RecipeArgs.eval_args({"a": 1, "b": 2, "c": 3})
+        {'a': 1, 'b': 2, 'c': 3}
+
+        Evaluate args with eval strings:
+        >>> RecipeArgs.eval_args({"a": "eval(2 * 3)", "b": 2, "c": 3})
+        {'a': 6.0, 'b': 2, 'c': 3}
+
+        Evaluate args with eval strings and variables:
+        >>> RecipeArgs.eval_args({"a": 3, "b": "eval(a*2)", "c": 3})
+        {'a': 3, 'b': 6.0, 'c': 3}
+
+        Order of evaluation is automatically handled:
+        >>> RecipeArgs.eval_args({"a": "eval(b * 2)", "b": 2, "c": 3})
+        {'a': 4.0, 'b': 2, 'c': 3}
+
+        :param args: The args to evaluate, must be a dict of str to any
+        :return: The evaluated recipe args instance
+        """
         resolved = args.copy()
 
         while True:
@@ -87,6 +225,31 @@ class RecipeArgs(Dict[str, Any]):
 
     @staticmethod
     def eval_obj(target: Any, args: Dict[str, Any] = None) -> Any:
+        """
+        A more generic version of eval_str that can evaluate any object
+        recursively, supports str, dict, and list types
+
+        Evaluate a simple str:
+        >>> RecipeArgs.eval_obj("eval(2 * 3)")
+        6.0
+
+        >>> RecipeArgs.eval_obj("eval(a * 3)", {"a": 2})
+        6.0
+
+        Evaluate a simple dict:
+        >>> RecipeArgs.eval_obj({"a": "eval(2 * 3)"})
+        {'a': 6.0}
+
+        >>> RecipeArgs.eval_obj({"a": "eval(a * 3)"}, {"a": 2})
+        {'a': 6.0}
+
+        Evaluate a simple list:
+        >>> RecipeArgs.eval_obj(["eval(2 * 3)"])
+        [6.0]
+
+        >>> RecipeArgs.eval_obj(["eval(a * 3)"], {"a": 2})
+        [6.0]
+        """
         if isinstance(target, str):
             return RecipeArgs.eval_str(target, args)
         elif isinstance(target, dict):
@@ -97,3 +260,9 @@ class RecipeArgs(Dict[str, Any]):
             return [RecipeArgs.eval_obj(item, args) for item in target]
 
         return target
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/src/sparseml/core/recipe/base.py
+++ b/src/sparseml/core/recipe/base.py
@@ -25,9 +25,15 @@ __all__ = ["RecipeBase"]
 
 
 class RecipeBase(BaseModel, ABC):
-    """ "
-    Base class that defines the contract for a Recipe,
-    RecipeStage, and RecipeModifier
+    """
+    Defines the contract that `Recipe` and its components
+    such as `RecipeModifier` and `RecipeStage` must follow.
+
+    All inheritors of this class must implement the following methods:
+        - calculate_start
+        - calculate_end
+        - evaluate
+        - create_modifier
     """
 
     @abstractmethod

--- a/src/sparseml/core/recipe/base.py
+++ b/src/sparseml/core/recipe/base.py
@@ -25,6 +25,11 @@ __all__ = ["RecipeBase"]
 
 
 class RecipeBase(BaseModel, ABC):
+    """ "
+    Base class that defines the contract for a Recipe,
+    RecipeStage, and RecipeModifier
+    """
+
     @abstractmethod
     def calculate_start(self) -> int:
         raise NotImplementedError()

--- a/src/sparseml/core/recipe/container.py
+++ b/src/sparseml/core/recipe/container.py
@@ -62,39 +62,6 @@ class RecipeContainer:
         `check_compile_recipe` to re-compile the recipes into a single compiled_recipe.
         If no recipe is provided, does nothing and returns the kwargs.
 
-
-        No recipe provided:
-        >>> container = RecipeContainer()
-        >>> kwargs = dict(irrelevant_kwarg="prune")
-        >>> result = container.update(**kwargs)
-        >>> result == kwargs
-        True
-
-        With Recipe provided compiled_recipe is reset:
-        >>> from sparseml.core import Recipe
-        >>> recipe_str = '''
-        ... test_stage:
-        ...     pruning_modifiers:
-        ...         ConstantPruningModifier:
-        ...             start: 0.0
-        ...             end: 2.0
-        ...             targets: ['re:.*weight']
-        ... '''
-        >>> container = RecipeContainer(
-        ...    compiled_recipe=Recipe.create_instance(recipe_str)
-        ... )
-        >>> container.compiled_recipe is not None
-        True
-        >>> result = container.update(recipe=recipe_str)
-        >>> container.compiled_recipe is None
-        True
-
-        Recompile the updated container with check_compile_recipe:
-        >>> _ = container.check_compile_recipe()
-        >>> container.compiled_recipe is not None
-        True
-
-
         Can provide multiple recipes to update the container with:
         >>> container = RecipeContainer()
         >>> recipe_str_1 = '''
@@ -114,12 +81,12 @@ class RecipeContainer:
         ...             targets: ['re:.*weight']
         ... '''
         >>> result = container.update(recipe=[recipe_str_1, recipe_str_2])
-        >>> len(container.recipes)
-        2
 
         :param recipe: the recipe to update the container with
         :param recipe_stage: the recipe stage to update the container with
         :param recipe_args: the recipe args to update the recipe with
+        :param kwargs: additional kwargs to return
+        :return: the passed in kwargs
         """
         if recipe is not None:
             self.compiled_recipe = None
@@ -163,9 +130,3 @@ class RecipeContainer:
             return True
 
         return False
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod()

--- a/src/sparseml/core/recipe/modifier.py
+++ b/src/sparseml/core/recipe/modifier.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pydantic import root_validator
 
@@ -27,24 +27,49 @@ __all__ = ["RecipeModifier"]
 
 
 class RecipeModifier(RecipeBase):
+    """
+    A RecipeModifier is a modifier that is defined in a recipe and can be
+    evaluated and used to create a Framework specific Modifier instance using
+    the ModifierFactory.
+
+    :param type: the type of modifier to create
+    :param group: the group to assign the modifier to
+    :param args: the args to use for the modifier
+    :param args_evaluated: the evaluated args for the modifier
+    """
+
     type: str
-    group: str = None
-    args: Dict[str, Any] = None
-    args_evaluated: Dict[str, Any] = None
+    group: Optional[str] = None
+    args: Optional[Dict[str, Any]] = None
+    args_evaluated: Optional[Dict[str, Any]] = None
 
     def calculate_start(self) -> int:
+        """
+        :raises: ValueError if args have not been evaluated
+        :return: the start epoch for the modifier, -1 if no start is defined
+        """
         if not self.args_evaluated:
             raise ValueError("args must be evaluated before calculating start")
 
         return self.args_evaluated.get("start", -1)
 
     def calculate_end(self) -> int:
+        """
+        :raises: ValueError if args have not been evaluated
+        :return: the end epoch for the modifier, -1 if no end is defined
+        """
         if not self.args_evaluated:
             raise ValueError("args must be evaluated before calculating end")
 
         return self.args_evaluated.get("end", -1)
 
-    def evaluate(self, args: RecipeArgs = None, shift: int = None):
+    def evaluate(self, args: Optional[RecipeArgs] = None, shift: Optional[int] = None):
+        """
+        Evaluate the args for the modifier and shift the start and end if provided
+
+        :param args: the args to use for evaluation
+        :param shift: the amount to shift the start and end by
+        """
         if not self.args:
             raise ValueError("args must be set before evaluating")
 
@@ -58,6 +83,12 @@ class RecipeModifier(RecipeBase):
             self.args_evaluated["end"] += shift
 
     def create_modifier(self, framework: Framework) -> "Modifier":
+        """
+        Create a Framework specific Modifier instance using the ModifierFactory
+
+        :param framework: the framework to create the modifier for
+        :return: the created modifier
+        """
         if not ModifierFactory._loaded:
             ModifierFactory.refresh()
         return ModifierFactory.create(
@@ -79,4 +110,7 @@ class RecipeModifier(RecipeBase):
         return modifier
 
     def dict(self, *args, **kwargs) -> Dict[str, Any]:
+        """
+        :return: the dictionary representation of the modifier
+        """
         return {self.type: self.args}

--- a/src/sparseml/core/recipe/recipe.py
+++ b/src/sparseml/core/recipe/recipe.py
@@ -196,7 +196,11 @@ class Recipe(RecipeBase):
 
     def calculate_start(self) -> int:
         """
-        :return: The start of the recipe, the minimum start of all stages
+        Calculate and return the start epoch of the recipe.
+        The start epoch is the minimum start epoch of all stages.
+        Must have at least one stage to calculate the start epoch
+
+        :return: The start epoch of the stage
         """
         return min(
             stage.calculate_start()
@@ -206,6 +210,9 @@ class Recipe(RecipeBase):
 
     def calculate_end(self) -> int:
         """
+        Calculate and return the end epoch of the recipe.
+        The end epoch is the maximum end epoch of all stages.
+
         :return: The end of the recipe, the maximum end of all stages. If no stages
             found, returns 0
         """

--- a/src/sparseml/core/recipe/recipe.py
+++ b/src/sparseml/core/recipe/recipe.py
@@ -15,7 +15,7 @@
 import json
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import yaml
 from pydantic import Field, root_validator
@@ -32,10 +32,34 @@ __all__ = ["Recipe", "RecipeTuple"]
 
 
 class Recipe(RecipeBase):
+    """
+    A class to represent a recipe for a model. A
+    recipe can be used to prune and/or quantize a model.
+    """
+
     @staticmethod
     def create_instance(path: str) -> "Recipe":
         """
         Create a recipe instance from a file, or string
+
+        Using SparseZoo recipe stubs is not yet supported:
+        >>> stub = "zoo:cv/classification/mobilenet_v2-1.0/\
+        ... pytorch/sparseml/imagenet/base-none"
+        >>> Recipe.create_instance(stub)
+        Traceback (most recent call last):
+        ...
+        NotImplementedError: Using SparseZoo stubs is not yet supported
+
+        Using a recipe string or file is supported:
+        >>> recipe_str = '''
+        ... test_stage:
+        ...     pruning_modifiers:
+        ...         ConstantPruningModifier:
+        ...             start: 0.0
+        ...             end: 2.0
+        ...             targets: ['re:.*weight']
+        ... '''
+        >>> recipe = Recipe.create_instance(recipe_str)
 
         :param path: The path to the recipe file or
             SparseZoo stub or the recipe string, must be a valid
@@ -67,8 +91,33 @@ class Recipe(RecipeBase):
 
     @staticmethod
     def simplify_recipe(
-        recipe: Union["Recipe", "RecipeTuple"], shift: int = None
+        recipe: Union["Recipe", "RecipeTuple"], shift: Optional[int] = None
     ) -> "Recipe":
+        """
+        Simplify a RecipeTuple by removing stages that are not in the target_stages
+        and shifting the start and end of the recipe by the shift amount
+
+
+        Using a RecipeTuple instance with shift:
+        >>> recipe_str = '''
+        ... test_stage:
+        ...     pruning_modifiers:
+        ...         ConstantPruningModifier:
+        ...             start: 0.0
+        ...             end: 2.0
+        ...             targets: ['re:.*weight']
+        ... '''
+        >>> recipe = Recipe.create_instance(recipe_str)
+        >>> recipe_tuple = RecipeTuple(recipe, ["test"], {})
+        >>> simplified = Recipe.simplify_recipe(recipe_tuple, shift=2)
+        >>> simplified.stages[0].modifiers[0].args_evaluated["start"]
+        2.0
+
+        :param recipe: The Recipe or RecipeTuple instance to simplify
+        :param shift: The amount to shift the start and end of the recipe by,
+            defaults to None (No shift)
+        :return: The simplified Recipe instance
+        """
         stages = []
         if isinstance(recipe, RecipeTuple):
             stage_names = recipe.target_stages
@@ -93,6 +142,38 @@ class Recipe(RecipeBase):
     def simplify_combine_recipes(
         recipes: List[Union["Recipe", "RecipeTuple"]]
     ) -> "Recipe":
+        """
+        A method to combine multiple recipes into one recipe
+        Automatically calculates the start and end of the combined recipe
+        and shifts the start and end of the recipes accordingly
+
+        Using two RecipeTuple instances:
+        >>> recipe_str_1 = '''
+        ... test_stage:
+        ...     pruning_modifiers:
+        ...         ConstantPruningModifier:
+        ...             start: 0.0
+        ...             end: 2.0
+        ...             targets: ['re:.*weight']
+        ... '''
+        >>> recipe_str_2 = '''
+        ... test_stage:
+        ...     pruning_modifiers:
+        ...         ConstantPruningModifier:
+        ...             start: 3.0
+        ...             end: 5.0
+        ...             targets: ['re:.*weight']
+        ... '''
+        >>> recipe_1, recipe_2 = (Recipe.create_instance(recipe_str_1),
+        ... Recipe.create_instance(recipe_str_2))
+        >>> combined = Recipe.simplify_combine_recipes(
+        ... [RecipeTuple(recipe_1, ["test"], {}), RecipeTuple(recipe_2, ["test"], {})])
+        >>> len(combined.stages)
+        2
+
+        :param recipes: The list of Recipe/RecipeTuple instances to combine
+        :return: The combined Recipe instance
+        """
 
         combined = Recipe()
 
@@ -114,6 +195,9 @@ class Recipe(RecipeBase):
     args_evaluated: RecipeArgs = Field(default_factory=RecipeArgs)
 
     def calculate_start(self) -> int:
+        """
+        :return: The start of the recipe, the minimum start of all stages
+        """
         return min(
             stage.calculate_start()
             for stage in self.stages
@@ -121,20 +205,74 @@ class Recipe(RecipeBase):
         )
 
     def calculate_end(self) -> int:
+        """
+        :return: The end of the recipe, the maximum end of all stages. If no stages
+            found, returns 0
+        """
         if len(self.stages) == 0:
             return 0
         return max(
             stage.calculate_end() for stage in self.stages if stage.calculate_end() >= 0
         )
 
-    def evaluate(self, args: Dict[str, Any] = None, shift: int = None):
+    def evaluate(
+        self, args: Optional[Dict[str, Any]] = None, shift: Optional[int] = None
+    ):
+        """
+        Evaluate the recipe by evaluating all stages and combining the args
+        with existing recipe_args
+
+        Evaluate with no shift:
+        >>> recipe_str = '''
+        ... test_stage:
+        ...     pruning_modifiers:
+        ...         ConstantPruningModifier:
+        ...             start: eval(start_epoch)
+        ...             end: 2.0
+        ...             targets: ['re:.*weight']
+        ... '''
+        >>> recipe = Recipe.create_instance(recipe_str)
+        >>> recipe.evaluate({"start_epoch": 1})
+        >>> recipe.stages[0].modifiers[0].args_evaluated["start"]
+        1.0
+
+        Evaluate with shift:
+        >>> recipe.evaluate({"start_epoch": 2}, shift=2)
+        >>> recipe.stages[0].modifiers[0].args_evaluated["start"]
+        4.0
+
+        :param args: The args to evaluate the recipe with
+        :param shift: The amount to shift the start and end of the recipe by,
+            defaults to None (No shift)
+        """
         args = self.args.combine(args) if self.args else RecipeArgs(**(args or {}))
         self.args_evaluated = args.evaluate()
         for stage in self.stages:
             stage.evaluate(self.args_evaluated, shift)
 
     def create_modifier(self, framework: Framework) -> List["StageModifiers"]:
-        if self.args_evaluated is None:
+        """
+        Create and return a list of StageModifiers for each stage in the recipe
+
+        >>> recipe_str = '''
+        ... test_stage:
+        ...     pruning_modifiers:
+        ...         ConstantPruningModifier:
+        ...             start: 0.0
+        ...             end: 2.0
+        ...             targets: ['re:.*weight']
+        ... '''
+        >>> recipe = Recipe.create_instance(recipe_str)
+        >>> stage_modifiers = recipe.create_modifier(Framework.pytorch)
+        >>> len(stage_modifiers) == 1
+        True
+        >>> len(stage_modifiers[0].modifiers) == 1
+        True
+
+        :param framework: The framework to create the modifiers for
+        :return: A list of StageModifiers for each stage in the recipe
+        """
+        if not self.args_evaluated:
             self.evaluate()
         modifiers = []
 
@@ -148,6 +286,7 @@ class Recipe(RecipeBase):
 
     @root_validator(pre=True)
     def remap_stages(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+
         stages = []
 
         modifiers = RecipeStage.extract_dict_modifiers(values)
@@ -164,6 +303,9 @@ class Recipe(RecipeBase):
     @staticmethod
     def extract_dict_stages(values: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
+        Extract stages from a dict of values, acceptable dictionary structures
+        are shown below
+
         Accepted stage formats:
         - stages:
           first_stage:
@@ -188,6 +330,26 @@ class Recipe(RecipeBase):
             ...
           - ModifierTypeTwo
             ...
+
+        >>> values = {
+        ... "stages": {
+        ...     "first_stage": {
+        ...         "modifiers": {
+        ...             "ModifierTypeOne": {
+        ...                 "start": 0.0,
+        ...                 "end": 2.0,
+        ...                 }
+        ...         }
+        ...     }
+        ... }
+        ... }
+        >>> Recipe.extract_dict_stages(values) # doctest: +NORMALIZE_WHITESPACE
+        [{'modifiers': {'ModifierTypeOne': {'start': 0.0, 'end': 2.0}},
+        'group': 'first_stage'}]
+
+        :param values: The values dict to extract stages from
+        :return: A list of stages, where each stage is a dict of
+            modifiers and their group
         """
 
         stages = []
@@ -221,6 +383,23 @@ class Recipe(RecipeBase):
         return stages
 
     def dict(self, *args, **kwargs) -> Dict[str, Any]:
+        """
+        >>> recipe_str = '''
+        ... test_stage:
+        ...     pruning_modifiers:
+        ...         ConstantPruningModifier:
+        ...             start: 0.0
+        ...             end: 2.0
+        ...             targets: ['re:.*weight']
+        ... '''
+        >>> recipe = Recipe.create_instance(recipe_str)
+        >>> recipe.dict()
+        Traceback (most recent call last):
+        ...
+        KeyError: 'group'
+
+        :return: A dictionary representation of the recipe
+        """
         dict_ = super().dict(*args, **kwargs)
         stages = {}
 
@@ -240,6 +419,14 @@ class Recipe(RecipeBase):
 
 @dataclass
 class RecipeTuple:
+    """
+    A simple dataclass to hold a recipe, it's target_stages, and override_args
+
+    :param recipe: The Recipe instance to hold
+    :param target_stages: The target stages to use when simplifying the recipe
+    :param override_args: The override args to use when simplifying the recipe
+    """
+
     recipe: Recipe
     target_stages: List[str]
     override_args: Dict[str, Any]
@@ -255,3 +442,9 @@ def _load_json_or_yaml_string(content: str) -> Dict[str, Any]:
             return yaml.safe_load(content)
         except yaml.YAMLError as err:
             raise ValueError(f"Could not parse recipe from string {content}") from err
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -57,7 +57,8 @@ class _CallbackContainer:
 
 class SparseSession:
     """
-    A session for sparsification that holds the current state of the sparsification
+    A session for sparsification that holds the lifecycle
+    and state for the current sparsification session
     """
 
     def __init__(self):
@@ -66,6 +67,10 @@ class SparseSession:
     @property
     def lifecycle(self) -> SparsificationLifecycle:
         """
+        Lifecycle is used to keep track of where we are in the sparsification
+        process and what modifiers are active. It also provides the ability
+        to invoke events on the lifecycle.
+
         :return: the lifecycle for the session
         """
         return self._lifecycle
@@ -73,6 +78,10 @@ class SparseSession:
     @property
     def state(self) -> State:
         """
+        State of the current sparsification session. State instance
+        is used to store all information such as the recipe, model
+        optimizer, data, etc. that is needed for sparsification.
+
         :return: the current state of the session
         """
         return self._lifecycle.state
@@ -100,8 +109,8 @@ class SparseSession:
         :param recipe_stage: the stage to use for the sparsification
         :param recipe_args: the args to use for overriding the recipe defaults
         :param framework: the framework to use for the sparsification
-        :return: the modified state of the session after pre-initializing the
-            structure
+        :return: A ModifiedState instance holding the modified model and modifier_data
+            after pre-initializing the structure
         """
         mod_data = self._lifecycle.pre_initialize_structure(
             model=model,

--- a/src/sparseml/core/state.py
+++ b/src/sparseml/core/state.py
@@ -14,12 +14,12 @@
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field
 
 from sparseml.core.data import ModifiableData
-from sparseml.core.event import Event, EventType
+from sparseml.core.event import Event
 from sparseml.core.framework import Framework
 from sparseml.core.model import ModifiableModel
 from sparseml.core.optimizer import ModifiableOptimizer
@@ -30,26 +30,67 @@ __all__ = ["State", "Data", "Hardware", "ModifiedState"]
 
 @dataclass
 class Data:
-    train: ModifiableData = None
-    val: ModifiableData = None
-    test: ModifiableData = None
-    calib: ModifiableData = None
+    """
+    A dataclass to hold different data sets for training, validation,
+    testing, and/or calibration. Each data set is a ModifiableData instance.
+
+    :param train: The training data set
+    :param val: The validation data set
+    :param test: The testing data set
+    :param calib: The calibration data set
+    """
+
+    train: Optional[ModifiableData] = None
+    val: Optional[ModifiableData] = None
+    test: Optional[ModifiableData] = None
+    calib: Optional[ModifiableData] = None
 
 
 @dataclass
 class Hardware:
-    device: str = None
-    devices: List[str] = None
-    rank: int = None
-    world_size: int = None
-    local_rank: int = None
-    local_world_size: int = None
-    distributed: bool = None
-    distributed_strategy: str = None
+    """
+    A dataclass to hold information about the hardware being used
+
+    :param device: The current device being used for training
+    :param devices: List of all devices to be used for training
+    :param rank: The rank of the current device
+    :param world_size: The total number of devices being used
+    :param local_rank: The local rank of the current device
+    :param local_world_size: The total number of devices being used on the local machine
+    :param distributed: Whether or not distributed training is being used
+    :param distributed_strategy: The distributed strategy being used
+    """
+
+    device: Optional[str] = None
+    devices: Optional[List[str]] = None
+    rank: Optional[int] = None
+    world_size: Optional[int] = None
+    local_rank: Optional[int] = None
+    local_world_size: Optional[int] = None
+    distributed: Optional[bool] = None
+    distributed_strategy: Optional[str] = None
 
 
 @dataclass
 class State:
+    """
+    State class holds information about the current sparsification state
+
+    :param framework: The framework being used
+    :param model: The model being used for training
+    :param teacher_model: The teacher model being used for training
+    :param optimizer: The optimizer being used for training
+    :param optim_wrapped: Whether or not the optimizer has been wrapped
+    :param loss: The loss function being used for training
+    :param batch_data: The current batch of data being used for training
+    :param data: The data sets being used for training, validation, testing,
+        and/or calibration, wrapped in a Data instance
+    :param hardware: Hardware Instance holding info about the target hardware being used
+    :param start_event: The start event to begin training
+    :param last_event: The last event to stop training
+    :param loggers: List of loggers to use for logging training information
+    """
+
     framework: Framework
     model: ModifiableModel = None
     teacher_model: ModifiableModel = None
@@ -88,6 +129,23 @@ class State:
         batches_per_step: int = None,
         **kwargs,
     ) -> Dict:
+        """
+        Update the state with the given parameters
+
+        :param model: The model to update the state with
+        :param teacher_model: The teacher model to update the state with
+        :param optimizer: The optimizer to update the state with
+        :param attach_optim_callbacks: Whether or not to attach optimizer callbacks
+        :param train_data: The training data to update the state with
+        :param val_data: The validation data to update the state with
+        :param test_data: The testing data to update the state with
+        :param calib_data: The calibration data to update the state with
+        :param copy_data: Whether or not to copy the data
+        :param start: The start index to update the state with
+        :param steps_per_epoch: The steps per epoch to update the state with
+        :param batches_per_step: The batches per step to update the state with
+        :param kwargs: Additional keyword arguments to update the state with
+        """
         if model is not None:
             self.model = ModifiableModel(framework=self.framework, model=model)
         if teacher_model is not None:
@@ -133,10 +191,21 @@ class State:
 
 @dataclass
 class ModifiedState:
-    model: Any = None
-    optimizer: Any = None
-    loss: Any = None
-    modifier_data: List[Dict[str, Any]] = None
+    """
+    A dataclass to represent a modified model,
+    optimizer, and loss
+
+    :param model: The modified model
+    :param optimizer: The modified optimizer
+    :param loss: The modified loss
+    :param modifier_data: The modifier data used to modify the
+        model, optimizer, and loss
+    """
+
+    model: Optional[Any] = None
+    optimizer: Optional[Any] = None
+    loss: Optional[Any] = None
+    modifier_data: Optional[List[Dict[str, Any]]] = None
 
     def __init__(self, model, optimizer, loss, modifier_data):
         self.model = model


### PR DESCRIPTION
This PR will add documentation to the newly added classes/methods for the Modifier Refactor Push:

Files to document:

- [X] src/sparseml/core/__init__.py
- [X] src/sparseml/core/data/__init__.py
- [X] src/sparseml/core/data/base.py
- [X] src/sparseml/core/data/pytorch.py
- [X] src/sparseml/core/event.py
- [X] src/sparseml/core/factory.py
- [X] src/sparseml/core/framework.py
- [X] src/sparseml/core/framework_object.py
- [X] src/sparseml/core/lifecycle/__init__.py
- [X] src/sparseml/core/lifecycle/event.py
- [X] src/sparseml/core/lifecycle/session.py
- [x] src/sparseml/core/model/__init__.py
- [x] src/sparseml/core/model/base.py
- [x] src/sparseml/core/model/pytorch.py
- [x] src/sparseml/core/modifier/__init__.py
- [x] src/sparseml/core/modifier/base.py
- [x] src/sparseml/core/modifier/modifier.py
- [x] src/sparseml/core/modifier/stage.py
- [x] src/sparseml/core/optimizer/__init__.py
- [x] src/sparseml/core/optimizer/base.py
- [x] src/sparseml/core/optimizer/pytorch.py
- [x] src/sparseml/core/recipe/__init__.py
- [x] src/sparseml/core/recipe/args.py
- [x] src/sparseml/core/recipe/base.py
- [x] src/sparseml/core/recipe/container.py
- [ ] src/sparseml/core/recipe/metadata.py
- [x] src/sparseml/core/recipe/modifier.py
- [x] src/sparseml/core/recipe/recipe.py
- [x] src/sparseml/core/recipe/stage.py
- [x] src/sparseml/core/session.py
- [x] src/sparseml/core/state.py
