### PR TITLE
Deprecate the use of QLinearMatMul in favor of MatMultInteger

### DIFF
--- a/src/sparseml/exporters/onnx_to_deepsparse.py
+++ b/src/sparseml/exporters/onnx_to_deepsparse.py
@@ -60,6 +60,7 @@ class ONNXToDeepsparse(BaseExporter):
     def __init__(
         self,
         use_qlinear_conv: bool = False,
+        use_qlinear_matmul: bool = False,
         skip_input_quantize: bool = False,
         inplace: bool = True,
         export_input_model: bool = False,
@@ -77,19 +78,25 @@ class ONNXToDeepsparse(BaseExporter):
             sparseml_transforms.QuantizeQATEmbedding(),
             sparseml_transforms.PropagateEmbeddingQuantization(),
             sparseml_transforms.PropagateDequantThroughSplit(),
-            sparseml_transforms.MatMulToQLinearMatMul(),
-            sparseml_transforms.MatMulAddToMatMulIntegerAddCastMul(),
-            sparseml_transforms.MatMulToMatMulIntegerCastMul(),
-            sparseml_transforms.FoldReLUQuants(),
-            sparseml_transforms.ConvToQLinearConv()
-            if use_qlinear_conv
-            else sparseml_transforms.ConvToConvIntegerAddCastMul(),
-            sparseml_transforms.GemmToQLinearMatMul(),
-            sparseml_transforms.GemmToMatMulIntegerAddCastMul(),
-            sparseml_transforms.QuantizeResiduals(),
-            sparseml_transforms.RemoveDuplicateQConvWeights(),
-            sparseml_transforms.RemoveDuplicateQuantizeOps(),
         ]
+        if use_qlinear_matmul:
+            transforms.append(sparseml_transforms.MatMulToQLinearMatMul(),)
+
+        transforms.extend(
+            [
+                sparseml_transforms.MatMulAddToMatMulIntegerAddCastMul(),
+                sparseml_transforms.MatMulToMatMulIntegerCastMul(),
+                sparseml_transforms.FoldReLUQuants(),
+                sparseml_transforms.ConvToQLinearConv()
+                if use_qlinear_conv
+                else sparseml_transforms.ConvToConvIntegerAddCastMul(),
+                sparseml_transforms.GemmToQLinearMatMul(),
+                sparseml_transforms.GemmToMatMulIntegerAddCastMul(),
+                sparseml_transforms.QuantizeResiduals(),
+                sparseml_transforms.RemoveDuplicateQConvWeights(),
+                sparseml_transforms.RemoveDuplicateQuantizeOps(),
+            ]
+        )
 
         if skip_input_quantize:
             transforms.append(sparseml_transforms.SkipInputQuantize())

--- a/src/sparseml/exporters/onnx_to_deepsparse.py
+++ b/src/sparseml/exporters/onnx_to_deepsparse.py
@@ -80,7 +80,9 @@ class ONNXToDeepsparse(BaseExporter):
             sparseml_transforms.PropagateDequantThroughSplit(),
         ]
         if use_qlinear_matmul:
-            transforms.append(sparseml_transforms.MatMulToQLinearMatMul(),)
+            transforms.append(
+                sparseml_transforms.MatMulToQLinearMatMul(),
+            )
 
         transforms.extend(
             [

--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -585,8 +585,13 @@ def export_onnx(
             module.export_with_qlinearconv
         )
 
+        use_qlinear_matmul = hasattr(module, "export_with_qlinearmatmul") and (
+            module.export_with_qlinearmatmul
+        )
+
         exporter = ONNXToDeepsparse(
             use_qlinear_conv=use_qlinear_conv,
+            use_qlinear_matmul=use_qlinear_matmul,
             skip_input_quantize=skip_input_quantize,
         )
         exporter.export(pre_transforms_model=file_path, file_path=file_path)


### PR DESCRIPTION
Similar implementation as with QLinearConv