### PR TITLE
[BugFix] Modifiers not started if start is set to 0

### DIFF
--- a/src/sparseml/core/modifier/modifier.py
+++ b/src/sparseml/core/modifier/modifier.py
@@ -143,7 +143,7 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
             self.on_update(state, event, **kwargs)
 
     def should_start(self, event: Event):
-        if not self.start:
+        if self.start is None:
             return False
 
         current = event.current_index


### PR DESCRIPTION
This PR fixes a bug where Modifier Updates were not applied if the modifier starts at epoch 0;

This was due to an if condition in `Modifiier should_start(..)` method, the condition was checking for Falsy values rather than `None`. As 0 is a Falsy value, `should_start` was always returning False (Wrongly)

Current PR addresses that by enforcing a stricter check

Test, verified manually: can be tested with any Valid recipe from the new framework and setting modifier start to 0

Example recipe:
```yaml
test_stage:
  pruning_modifiers:
    ConstantPruningModifier:
      start: 0
      end: 2
      targets: ['re:.*weight']
      leave_enabled: True
```