### PR TITLE
Fix Constant Pruning Modifier

### DIFF
--- a/src/sparseml/modifiers/pruning/constant/pytorch.py
+++ b/src/sparseml/modifiers/pruning/constant/pytorch.py
@@ -54,7 +54,7 @@ class ConstantPruningModifierPyTorch(ConstantPruningModifier, LayerParamMasking)
     def on_start(self, state: State, event: Event, **kwargs):
         for layer_param_name, parameterized_layer in self.parameterized_layers_.items():
             self.update_mask(
-                layer_param_name, parameterized_layer.param.data.abs() < self._epsilon
+                layer_param_name, parameterized_layer.param.data.abs() > self._epsilon
             )
 
         self.enable_masks()


### PR DESCRIPTION
The mask calculation in the constant pruning modifier was inverted, this one character PR fixes it!

### Testing
Constant pruning modifier is tested in this branch: https://github.com/neuralmagic/sparseml/tree/modifier-refactor-constant-pruning-bug

Run `python bug_constant_pruning` to confirm constant pruning modifier is working as intended