### PR TITLE
[Bugfix] .dict() method on Recipe

### DIFF
--- a/src/sparseml/core/recipe/modifier.py
+++ b/src/sparseml/core/recipe/modifier.py
@@ -113,4 +113,4 @@ class RecipeModifier(RecipeBase):
         """
         :return: the dictionary representation of the modifier
         """
-        return {self.type: self.args}
+        return {self.type: self.args, "group": self.group}

--- a/src/sparseml/core/recipe/recipe.py
+++ b/src/sparseml/core/recipe/recipe.py
@@ -399,10 +399,12 @@ class Recipe(RecipeBase):
         ...             targets: ['re:.*weight']
         ... '''
         >>> recipe = Recipe.create_instance(recipe_str)
-        >>> recipe.dict()
-        Traceback (most recent call last):
-        ...
-        KeyError: 'group'
+        >>> recipe_dict = recipe.dict()
+        >>> stage = recipe_dict["stages"]["test"]
+        >>> pruning_mods = stage[0]['modifiers']['pruning']
+        >>> modifier_args = pruning_mods[0]['ConstantPruningModifier']
+        >>> modifier_args == {'start': 0.0, 'end': 2.0, 'targets': ['re:.*weight']}
+        True
 
         :return: A dictionary representation of the recipe
         """
@@ -451,3 +453,29 @@ def _load_json_or_yaml_string(content: str) -> Dict[str, Any]:
             return yaml.safe_load(content)
         except yaml.YAMLError as err:
             raise ValueError(f"Could not parse recipe from string {content}") from err
+
+
+def t():
+    recipe_str = """
+    test_stage:
+        pruning_modifiers:
+            ConstantPruningModifier:
+                start: 0.0
+                end: 2.0
+                targets: ['re:.*weight']
+    """
+    recipe = Recipe.create_instance(recipe_str)
+    d = recipe.dict()
+    pruning_mods = d["stages"]["test"][0]["modifiers"]["pruning"]
+    assert len(pruning_mods) == 1
+
+    modifier_args = pruning_mods[0]["ConstantPruningModifier"]
+    assert modifier_args == {"start": 0.0, "end": 2.0, "targets": ["re:.*weight"]}
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()
+
+    t()

--- a/src/sparseml/core/recipe/recipe.py
+++ b/src/sparseml/core/recipe/recipe.py
@@ -453,29 +453,3 @@ def _load_json_or_yaml_string(content: str) -> Dict[str, Any]:
             return yaml.safe_load(content)
         except yaml.YAMLError as err:
             raise ValueError(f"Could not parse recipe from string {content}") from err
-
-
-def t():
-    recipe_str = """
-    test_stage:
-        pruning_modifiers:
-            ConstantPruningModifier:
-                start: 0.0
-                end: 2.0
-                targets: ['re:.*weight']
-    """
-    recipe = Recipe.create_instance(recipe_str)
-    d = recipe.dict()
-    pruning_mods = d["stages"]["test"][0]["modifiers"]["pruning"]
-    assert len(pruning_mods) == 1
-
-    modifier_args = pruning_mods[0]["ConstantPruningModifier"]
-    assert modifier_args == {"start": 0.0, "end": 2.0, "targets": ["re:.*weight"]}
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod()
-
-    t()


### PR DESCRIPTION
This PR fixes a bug in Recipe classes .dict() method, needed to support serialization



Before:
```python
>>> recipe_str = '''
... test_stage:
...     pruning_modifiers:
...         ConstantPruningModifier:
...             start: 0.0
...             end: 2.0
 ...             targets: ['re:.*weight']
 ... '''
 >>> recipe = Recipe.create_instance(recipe_str)
 >>> recipe.dict()
 Traceback (most recent call last):
 ...
 KeyError: 'group'
```

```python
>>> recipe_str = '''
... test_stage:
...     pruning_modifiers:
...         ConstantPruningModifier:
...             start: 0.0
...             end: 2.0
...             targets: ['re:.*weight']
... '''
>>> recipe = Recipe.create_instance(recipe_str)
>>> recipe_dict = recipe.dict()
>>> stage = recipe_dict["stages"]["test"]
>>> pruning_mods = stage[0]['modifiers']['pruning']
>>> modifier_args = pruning_mods[0]['ConstantPruningModifier']
>>> modifier_args == {'start': 0.0, 'end': 2.0, 'targets': ['re:.*weight']}
True
```
