### PR TITLE
[feature] Rename `compress_layers` -> `targets`

### DIFF
--- a/src/sparseml/modifiers/obcq/base.py
+++ b/src/sparseml/modifiers/obcq/base.py
@@ -41,7 +41,7 @@ class SparseGPTModifier(Modifier):
         True saves on GPU memory
     :param prunen: N for N:M pruning
     :param prunem: M for N:M pruning
-    :param compress_layers: list of layer names to compress during OBCQ, or '__ALL__'
+    :param targets: list of layer names to compress during OBCQ, or '__ALL__'
         to compress every layer in the model
     :param target_ids: list of keys in model output to cache
     :param layer_prefix: name of model attribute that contains the list of layers, i.e.
@@ -55,7 +55,7 @@ class SparseGPTModifier(Modifier):
     sequential_update: Optional[bool] = True
     prunen: Optional[int] = 0
     prunem: Optional[int] = 0
-    compress_layers: Union[str, List[str], None] = ALL_TOKEN
+    targets: Union[str, List[str], None] = ALL_TOKEN
     target_ids: Optional[List[str]] = None
     layer_prefix: Optional[str] = None
 

--- a/src/sparseml/modifiers/obcq/pytorch.py
+++ b/src/sparseml/modifiers/obcq/pytorch.py
@@ -56,7 +56,7 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
 
         :return: list of Pytorch modules to compress
         """
-        compressible_dict = self.model.get_layers(self.compress_layers)
+        compressible_dict = self.model.get_layers(self.targets)
         return [v for _, v in compressible_dict.items()]
 
     def on_initialize(self, state: "State", **kwargs) -> bool:

--- a/src/sparseml/transformers/sparsification/obcq/example.yaml
+++ b/src/sparseml/transformers/sparsification/obcq/example.yaml
@@ -18,7 +18,7 @@ test_stage:
       percdamp: 0.01
       prunen: 0
       prunem: 0
-      compress_layers: [
+      targets: [
         "model.decoder.layers.0",
         "model.decoder.layers.1",
         "model.decoder.layers.2",

--- a/src/sparseml/transformers/sparsification/obcq/example_llama.yaml
+++ b/src/sparseml/transformers/sparsification/obcq/example_llama.yaml
@@ -52,7 +52,7 @@ test_stage:
       percdamp: 0.01
       prunen: 0
       prunem: 0
-      compress_layers: [
+      targets: [
         "model.layers.0",
         "model.layers.1",
         "model.layers.2",


### PR DESCRIPTION
This PR renames `compress_layers` param in `SparseGPTModifier`

Test recipe:
```yaml
# llama_small_recipe.yaml

test_stage:
  obcq_modifiers:
    QuantizationModifier:
      ignore: ["lm_head", "Embedding", "OPTLearnedPositionalEmbedding", "QuantizableBatchMatMul", "BMMLeftInput_QK", "BMMRightInput_QK", "BMMOutput_QK", "BMMLeftInput_PV", "BMMRightInput_PV", "BMMOutput_PV"]
      post_oneshot_calibration: True
      scheme_overrides:
        ReLU:
          input_activations: null
          output_activations: null
        LayerNorm:
          input_activations: null
          output_activations: null
    SparseGPTModifier:
      sparsity: 0.5
      block_size: 128
      sequential_update: False
      quantize: True
      percdamp: 0.01
      prunen: 0
      prunem: 0
      targets: [
        "model.decoder.layers.0"
      ]
      target_ids: ["attention_mask"]
      layer_prefix: "decoder"
```

Perplexity Eval:

```bash
python src/sparseml/transformers/sparsification/obcq/obcq.py facebook/opt-1.3b
 c4 --recipe local/llama_small_recipe.yaml --eval wikitext2 
Found cached dataset json (/home/rahul/.cache/huggingface/datasets/allenai___json/allenai--c4-6fbe877195f42de5/0.0.0/fe5dd6ea2639a6df622901539cb550cf8797e5a6b2dd7af1cf934bed8e233e6e)
2023-10-18 17:04:34 sparseml.modifiers.quantization.pytorch INFO     Running quantization calibration using calibration_dataloader
2023-10-18 17:04:45 sparseml.modifiers.obcq.pytorch INFO     
===== Compressing layer 0/0 =====
2023-10-18 17:04:46 sparseml.modifiers.obcq.utils.layer_compressor INFO     Compressing self_attn.k_proj.module...
2023-10-18 17:04:47 sparseml.modifiers.obcq.utils.sparsegpt INFO     time 0.56
2023-10-18 17:04:47 sparseml.modifiers.obcq.utils.sparsegpt INFO     error 31129.56
2023-10-18 17:04:47 sparseml.modifiers.obcq.utils.layer_compressor INFO     Compressing self_attn.v_proj.module...
2023-10-18 17:04:47 sparseml.modifiers.obcq.utils.sparsegpt INFO     time 0.44
2023-10-18 17:04:47 sparseml.modifiers.obcq.utils.sparsegpt INFO     error 7156.07
2023-10-18 17:04:47 sparseml.modifiers.obcq.utils.layer_compressor INFO     Compressing self_attn.q_proj.module...
2023-10-18 17:04:47 sparseml.modifiers.obcq.utils.sparsegpt INFO     time 0.44
2023-10-18 17:04:47 sparseml.modifiers.obcq.utils.sparsegpt INFO     error 31903.02
2023-10-18 17:04:47 sparseml.modifiers.obcq.utils.layer_compressor INFO     Compressing self_attn.out_proj.module...
2023-10-18 17:04:48 sparseml.modifiers.obcq.utils.sparsegpt INFO     time 0.44
2023-10-18 17:04:48 sparseml.modifiers.obcq.utils.sparsegpt INFO     error 25.32
2023-10-18 17:04:48 sparseml.modifiers.obcq.utils.layer_compressor INFO     Compressing fc1.module...
2023-10-18 17:04:48 sparseml.modifiers.obcq.utils.sparsegpt INFO     time 0.46
2023-10-18 17:04:48 sparseml.modifiers.obcq.utils.sparsegpt INFO     error 31037.05
2023-10-18 17:04:48 sparseml.modifiers.obcq.utils.layer_compressor INFO     Compressing fc2.module...
2023-10-18 17:04:50 sparseml.modifiers.obcq.utils.sparsegpt INFO     time 1.93
2023-10-18 17:04:50 sparseml.modifiers.obcq.utils.sparsegpt INFO     error 284.96
2023-10-18 17:04:51 sparseml.modifiers.quantization.pytorch INFO     Running quantization calibration using calibration_dataloader
Downloading builder script: 100%|██████████████████████████████████████████████████████████████████████████████| 8.48k/8.48k [00:00<00:00, 6.26MB/s]
Downloading metadata: 100%|████████████████████████████████████████████████████████████████████████████████████| 6.84k/6.84k [00:00<00:00, 3.59MB/s]
Downloading readme: 100%|██████████████████████████████████████████████████████████████████████████████████████| 9.62k/9.62k [00:00<00:00, 4.19MB/s]
Downloading and preparing dataset wikitext/wikitext-2-raw-v1 to /home/rahul/.cache/huggingface/datasets/wikitext/wikitext-2-raw-v1/1.0.0/a241db52902eaf2c6aa732210bead40c090019a499ceb13bcbfa3f8ab646a126...
Downloading data: 100%|████████████████████████████████████████████████████████████████████████████████████████| 4.72M/4.72M [00:00<00:00, 11.2MB/s]
Dataset wikitext downloaded and prepared to /home/rahul/.cache/huggingface/datasets/wikitext/wikitext-2-raw-v1/1.0.0/a241db52902eaf2c6aa732210bead40c090019a499ceb13bcbfa3f8ab646a126. Subsequent calls will reuse this data.
2023-10-18 17:05:08 sparseml.modifiers.obcq.utils.helpers INFO     Evaluating perplexity...
2023-10-18 17:05:12 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.4565, device='cuda:0')
2023-10-18 17:05:16 sparseml.modifiers.obcq.utils.helpers INFO     tensor(16.6085, device='cuda:0')
2023-10-18 17:05:21 sparseml.modifiers.obcq.utils.helpers INFO     tensor(17.0098, device='cuda:0')
2023-10-18 17:05:25 sparseml.modifiers.obcq.utils.helpers INFO     tensor(16.6345, device='cuda:0')
2023-10-18 17:05:29 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.3444, device='cuda:0')
2023-10-18 17:05:34 sparseml.modifiers.obcq.utils.helpers INFO     tensor(16.2035, device='cuda:0')
2023-10-18 17:05:38 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.3615, device='cuda:0')
2023-10-18 17:05:42 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.3593, device='cuda:0')
2023-10-18 17:05:47 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.1442, device='cuda:0')
2023-10-18 17:05:51 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.1357, device='cuda:0')
2023-10-18 17:05:56 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.1277, device='cuda:0')
2023-10-18 17:06:00 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.5246, device='cuda:0')
2023-10-18 17:06:04 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.7131, device='cuda:0')
2023-10-18 17:06:09 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.6395, device='cuda:0')
2023-10-18 17:06:13 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.5373, device='cuda:0')
2023-10-18 17:06:18 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.4753, device='cuda:0')
2023-10-18 17:06:22 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.4658, device='cuda:0')
2023-10-18 17:06:26 sparseml.modifiers.obcq.utils.helpers INFO     tensor(15.5323, device='cuda:0')
2023-10-18 17:06:26 sparseml.modifiers.obcq.utils.helpers INFO     Perplexity: 15.532339
```