### PR TITLE
[loggers] propagate loggers to modifier

### DIFF
--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from sparseml.core.event import EventType
 from sparseml.core.framework import Framework
 from sparseml.core.lifecycle import SparsificationLifecycle
+from sparseml.core.logger import BaseLogger
 from sparseml.core.recipe import Recipe
 from sparseml.core.state import ModifiedState, State
 
@@ -146,6 +147,7 @@ class SparseSession:
         start: Optional[float] = None,
         steps_per_epoch: Optional[int] = None,
         batches_per_step: Optional[int] = None,
+        loggers: Optional[List[BaseLogger]] = None,
         **kwargs,
     ) -> ModifiedState:
         """
@@ -175,6 +177,7 @@ class SparseSession:
         :param batches_per_step: the number of batches per step to use for
             sparsification
         :param kwargs: additional kwargs to pass to the lifecycle's initialize method
+        :param loggers: list of BaseLogger instances to use for logging
         :return: the modified state of the session after initializing
         """
 
@@ -195,6 +198,7 @@ class SparseSession:
             start=start,
             steps_per_epoch=steps_per_epoch,
             batches_per_step=batches_per_step,
+            loggers=loggers,
             **kwargs,
         )
 

--- a/src/sparseml/core/state.py
+++ b/src/sparseml/core/state.py
@@ -21,6 +21,7 @@ from pydantic import Field
 from sparseml.core.data import ModifiableData
 from sparseml.core.event import Event
 from sparseml.core.framework import Framework
+from sparseml.core.logger import BaseLogger
 from sparseml.core.model import ModifiableModel
 from sparseml.core.optimizer import ModifiableOptimizer
 
@@ -127,6 +128,7 @@ class State:
         start: float = None,
         steps_per_epoch: int = None,
         batches_per_step: int = None,
+        loggers: List[BaseLogger] = None,
         **kwargs,
     ) -> Dict:
         """
@@ -144,6 +146,7 @@ class State:
         :param start: The start index to update the state with
         :param steps_per_epoch: The steps per epoch to update the state with
         :param batches_per_step: The batches per step to update the state with
+        :param loggers: list of BaseLogger instances to use for logging
         :param kwargs: Additional keyword arguments to update the state with
         """
         if model is not None:
@@ -186,6 +189,8 @@ class State:
             if batches_per_step is not None:
                 self.start_event.batches_per_step = batches_per_step
 
+        if loggers is not None:
+            self.loggers = loggers
         return kwargs
 
 


### PR DESCRIPTION
- Propagate loggers from sesion -> state -> Modifier
- Initliaze loggers on initialize, reset loggers on finalize
- Add lifecycle

Test: Modifier adds logger on initilialize and resets them on finalize

local_test_file:
```python



from collections import OrderedDict
from typing import List
from sparseml.core.logger import LoggerManager, PythonLogger
from sparseml.modifiers.pruning.utils.pytorch.layer_mask import param_mask_name
from torch import Tensor
from torch.nn import Module
from torch.nn import (
    Linear,
    Module,
    Sequential,
)


class LinearNet(Module):

    def __init__(self):
        super().__init__()
        self.seq = Sequential(
            OrderedDict(
                [
                    ("fc1", Linear(8, 16, bias=True)),
                    ("fc2", Linear(16, 32, bias=True)),
                    (
                        "block1",
                        Sequential(
                            OrderedDict(
                                [
                                    ("fc1", Linear(32, 16, bias=True)),
                                    ("fc2", Linear(16, 8, bias=True)),
                                ]
                            )
                        ),
                    ),
                ]
            )
        )

    def forward(self, inp: Tensor):
        return self.seq(inp)



def _test_optims():
    import torch

    return [
        torch.optim.Adam,
        torch.optim.SGD,
    ]

def constant_pruning_modifier_e2e(model, optimizer):
    from sparseml.core import State
    from sparseml.core.event import Event, EventType
    from sparseml.core.framework import Framework
    from sparseml.modifiers.pruning.constant.pytorch import (
        ConstantPruningModifierPyTorch,
    )
    from sparseml.pytorch.utils import tensor_sparsity

    expected_sparsities = {
        name: tensor_sparsity(param.data)
        for name, param in model.named_parameters()
        if "weight" in name
    }

    # init modifier with model

    state = State(framework=Framework.pytorch)
    state.update(
        model=model,
        optimizer=optimizer(model.parameters(), lr=0.1),
        start=0,
        loggers=[PythonLogger()],
    )
    modifier = ConstantPruningModifierPyTorch(
        targets="__ALL_PRUNABLE__",
        start=0,
        end=1,
        update=0.5,
    )
    modifier.initialize(state)

    # logger should be initiliazed
    
    assert modifier.loggers_initialized_, "Logger was not initialized"
    assert isinstance(modifier.loggers_, LoggerManager), "Logger was not initialized"


    # apply modifier

    modifier.on_update(state, event=Event(type_=EventType.OPTIM_PRE_STEP))
    modifier.on_update(state, event=Event(type_=EventType.OPTIM_POST_STEP))
    modifier.on_end(state, None)
    modifier.finalize(state)
    
    # loggers should be reset
    
    assert modifier.loggers_ is None, "Logger was not reset"
    assert modifier.loggers_initialized_ is False, "Logger was not reset"





if __name__ == "__main__":
    model = LinearNet()
    optimizer = _test_optims()[0]
    constant_pruning_modifier_e2e(model, optimizer)
```

The file does not raise any assertions, so we know loggers were created and destroyed as expected.
