### PR TITLE
Fix Concatenate Compatibility

### DIFF
--- a/src/sparseml/modifiers/obcq/utils/helpers.py
+++ b/src/sparseml/modifiers/obcq/utils/helpers.py
@@ -158,10 +158,10 @@ def ppl_eval_general(
 
         vocabulary_size = logits[0].shape[-1]
         logits = [logit[:, :-1, :].view(-1, vocabulary_size) for logit in logits]
-        logits = torch.concatenate(logits, dim=0).contiguous().to(torch.float32)
+        logits = torch.cat(logits, dim=0).contiguous().to(torch.float32)
 
         labels = [sample[:, 1:].view(-1) for sample in samples]
-        labels = torch.concatenate(labels, dim=0).to(dev)
+        labels = torch.cat(labels, dim=0).to(dev)
         neg_log_likelihood += torch.nn.functional.cross_entropy(
             logits,
             labels,

--- a/src/sparseml/transformers/data/base_llm.py
+++ b/src/sparseml/transformers/data/base_llm.py
@@ -100,7 +100,7 @@ class TransformersDataset(RegistryMixin, Dataset):
             if len(tokenized_sample) == self._seqlen:
                 tokenized_sample[-1] = self.tokenizer.eos_token_id
             else:
-                tokenized_sample = torch.concatenate(
+                tokenized_sample = torch.cat(
                     (
                         tokenized_sample,
                         torch.tensor((self.tokenizer.eos_token_id,)),


### PR DESCRIPTION
Replacing `torch.concatenate` calls with `torch.cat`, they are the same function but `concatenate` is an alias that doesn't exist in earlier versions of pytorch.

### Before on torch 1.12.0
```
Traceback (most recent call last):
  File "src/sparseml/transformers/sparsification/obcq/obcq.py", line 167, in <module>
    one_shot(
  File "src/sparseml/transformers/sparsification/obcq/obcq.py", line 89, in one_shot
    dataset = TransformersDataset.load_from_registry(
  File "/home/michael/sml/lib/python3.8/site-packages/sparsezoo/utils/registry.py", line 120, in load_from_registry
    return constructor(**constructor_kwargs)
  File "/home/michael/code/sparseml/src/sparseml/transformers/data/open_platypus.py", line 68, in __init__
    self.create_dataloader(processed_data)
  File "/home/michael/code/sparseml/src/sparseml/transformers/data/base_llm.py", line 94, in create_dataloader
    tokenized_sample = self._add_end_token(tokenized_sample)
  File "/home/michael/code/sparseml/src/sparseml/transformers/data/base_llm.py", line 103, in _add_end_token
    tokenized_sample = torch.concatenate(
AttributeError: module 'torch' has no attribute 'concatenate'
```

### After
OBCQ script runs successfully 