### PR TITLE
Square head distillation implementation for new SparseML framework

### DIFF
--- a/src/sparseml/core/model/pytorch.py
+++ b/src/sparseml/core/model/pytorch.py
@@ -47,7 +47,7 @@ class ModifiableModelPyTorch(ModifiableModel[Module, Module, Parameter]):
 
     def get_layers_params(
         self, targets: Union[str, List[str]]
-    ) -> Dict[str, ModelParameterizedLayer[Module, Parameter]]:
+    ) -> Dict[str, ModelParameterizedLayer[Parameter, Module]]:
         """
         :param targets: the target layers to get the parameters for
         :return: a dictionary of layer name to ModelParameterizedLayer
@@ -70,6 +70,7 @@ class ModifiableModelPyTorch(ModifiableModel[Module, Module, Parameter]):
     def set_layer(self, target: str, layer: Module) -> Module:
         """
         :param target: the target to set the layer for
+        :param layer: the layer to set
         """
         return set_layer(target, layer, self.model)
 

--- a/src/sparseml/core/modifier/modifier.py
+++ b/src/sparseml/core/modifier/modifier.py
@@ -58,7 +58,7 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
         :return: True if the modifier structure has been
             applied to the model
         """
-        return self._initialized_structure
+        return self.initialized_structure_
 
     @property
     def initialized(self) -> bool:

--- a/src/sparseml/modifiers/distillation/output/base.py
+++ b/src/sparseml/modifiers/distillation/output/base.py
@@ -28,6 +28,8 @@ class OutputDistillationModifier(Modifier):
     transforms_args: Union[Dict[str, Any], List[Dict[str, Any]]] = None
     comparison: str = "kl_divergence"
     comparison_args: Dict[str, Any] = None
+    orig_scale: float = 1.0
+    distill_scale: float = 1.0
 
     def on_initialize_structure(self, state: State, **kwargs):
         pass  # nothing needed for this modifier

--- a/src/sparseml/modifiers/distillation/output/pytorch.py
+++ b/src/sparseml/modifiers/distillation/output/pytorch.py
@@ -84,7 +84,10 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
             comparisons = [
                 wrapper.kd_last_comparison for wrapper in self._wrappers.values()
             ]
-            state.loss = self.orig_scale * state.loss + self.distill_scale * torch.Stack(comparisons).mean()
+            state.loss = (
+                self.orig_scale * state.loss
+                + self.distill_scale * torch.Stack(comparisons).mean()
+            )
 
     def on_end(self, state: State, event: Event, **kwargs):
         for wrapper in self._wrappers.values():

--- a/src/sparseml/modifiers/distillation/output/pytorch.py
+++ b/src/sparseml/modifiers/distillation/output/pytorch.py
@@ -84,7 +84,7 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
             comparisons = [
                 wrapper.kd_last_comparison for wrapper in self._wrappers.values()
             ]
-            state.loss = state.loss + torch.Stack(comparisons).mean()
+            state.loss = self.orig_scale * state.loss + self.distill_scale * torch.Stack(comparisons).mean()
 
     def on_end(self, state: State, event: Event, **kwargs):
         for wrapper in self._wrappers.values():

--- a/src/sparseml/modifiers/distillation/output/pytorch.py
+++ b/src/sparseml/modifiers/distillation/output/pytorch.py
@@ -26,7 +26,7 @@ __all__ = ["OutputDistillationModifierPyTorch"]
 
 
 class OutputDistillationModifierPyTorch(OutputDistillationModifier):
-    _wrappers: Dict[str, KDModuleWrapper] = None
+    wrappers_: Dict[str, KDModuleWrapper] = None
 
     def on_initialize(self, state: State, **kwargs) -> bool:
         if (
@@ -36,7 +36,7 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
         ):
             return False
 
-        self._wrappers = {}
+        self.wrappers_ = {}
 
         for target in (
             self.targets if isinstance(self.targets, list) else [self.targets]
@@ -62,19 +62,19 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
             ):
                 wrapper = self._create_wrapper(student_layer, teacher_layer, state)
                 state.model.set_layer(key, wrapper)
-                self._wrappers[key] = wrapper
+                self.wrappers_[key] = wrapper
 
         return True
 
     def on_finalize(self, state: State, **kwargs) -> bool:
-        for key, wrapper in self._wrappers.items():
+        for key, wrapper in self.wrappers_.items():
             state.model.set_layer(key, wrapper.student_layer)
             del wrapper
 
         return True
 
     def on_start(self, state: State, event: Event, **kwargs):
-        for wrapper in self._wrappers.values():
+        for wrapper in self.wrappers_.values():
             wrapper.kdenabled_ = True
 
     def on_update(self, state: State, event: Event, **kwargs):
@@ -82,7 +82,7 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
             self.start, self.end, self.update
         ):
             comparisons = [
-                wrapper.kd_last_comparison for wrapper in self._wrappers.values()
+                wrapper.kd_last_comparison for wrapper in self.wrappers_.values()
             ]
             state.loss = (
                 self.orig_scale * state.loss
@@ -90,7 +90,7 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
             )
 
     def on_end(self, state: State, event: Event, **kwargs):
-        for wrapper in self._wrappers.values():
+        for wrapper in self.wrappers_.values():
             wrapper.kdenabled_ = False
 
     def _create_wrapper(

--- a/src/sparseml/modifiers/distillation/utils/pytorch/kd_factory.py
+++ b/src/sparseml/modifiers/distillation/utils/pytorch/kd_factory.py
@@ -202,6 +202,12 @@ def recursive_combine(
     val_two: TensorOrCollectionType,
     func: Callable[[Tensor, Tensor], Tensor],
 ):
+    if type(val_one) != type(val_two):
+        raise ValueError(
+            f"val_one type of {type(val_one)} must match "
+            f"val_two type of {type(val_two)}"
+        )
+
     if isinstance(val_one, Tensor):
         return func(val_one, val_two)
 
@@ -393,9 +399,30 @@ def cross_entropy_comparison(
 
         return TF.cross_entropy(val_one, val_two, reduction=reduction)
 
-    def _create_projection(
+    def _create_comparison(
         val_one: TensorOrCollectionType, val_two: TensorOrCollectionType
     ) -> TensorOrCollectionType:
         return recursive_combine(val_one, val_two, _cross_entropy)
 
-    return _create_projection
+    return _create_comparison
+
+
+@KDFactory.register_comparison_decorator("square_head")
+def square_head_comparison(
+    name: str, **kwargs
+):
+    if name != "square_head":
+        raise ValueError(f"Invalid projection name: {name}")
+
+    def _square_head(val_one: Tensor, val_two: Tensor) -> Tensor:
+        numerator = torch.sum(torch.square(val_two - val_one))
+        denominator = torch.sum(torch.square(val_two))
+
+        return numerator / denominator
+
+    def _create_comparison(
+        val_one: TensorOrCollectionType, val_two: TensorOrCollectionType
+    ) -> TensorOrCollectionType:
+        return recursive_combine(val_one, val_two, _square_head)
+
+    return _create_comparison

--- a/src/sparseml/modifiers/distillation/utils/pytorch/kd_factory.py
+++ b/src/sparseml/modifiers/distillation/utils/pytorch/kd_factory.py
@@ -408,9 +408,7 @@ def cross_entropy_comparison(
 
 
 @KDFactory.register_comparison_decorator("square_head")
-def square_head_comparison(
-    name: str, **kwargs
-):
+def square_head_comparison(name: str, **kwargs):
     if name != "square_head":
         raise ValueError(f"Invalid projection name: {name}")
 

--- a/src/sparseml/modifiers/pruning/constant/base.py
+++ b/src/sparseml/modifiers/pruning/constant/base.py
@@ -22,7 +22,7 @@ __all__ = ["ConstantPruningModifier"]
 
 class ConstantPruningModifier(Modifier):
     targets: Union[str, List[str]]
-    _epsilon: float = 10e-9
+    epsilon_: float = 10e-9
 
     def on_initialize_structure(self, state: State, **kwargs):
         pass  # nothing needed for this modifier

--- a/src/sparseml/modifiers/pruning/constant/pytorch.py
+++ b/src/sparseml/modifiers/pruning/constant/pytorch.py
@@ -21,14 +21,14 @@ from sparseml.modifiers.pruning.utils.pytorch import LayerParamMasking
 
 class ConstantPruningModifierPyTorch(ConstantPruningModifier, LayerParamMasking):
     parameterized_layers_: Dict[str, ModelParameterizedLayer] = None
-    _save_masks: bool = False
-    _use_hooks: bool = False
+    save_masks_: bool = False
+    use_hooks_: bool = False
 
     def on_initialize(self, state: State, **kwargs) -> bool:
         if "save_masks" in kwargs:
-            self._save_masks = kwargs["save_masks"]
+            self.save_masks_ = kwargs["save_masks"]
         if "use_hooks" in kwargs:
-            self._use_hooks = kwargs["use_hooks"]
+            self.use_hooks_ = kwargs["use_hooks"]
 
         if not state.model or not state.start_event:
             return False
@@ -39,8 +39,8 @@ class ConstantPruningModifierPyTorch(ConstantPruningModifier, LayerParamMasking)
             self.add_mask(
                 layer_param_name,
                 parameterized_layer,
-                persistent=self._save_masks,
-                add_hooks=self._use_hooks,
+                persistent=self.save_masks_,
+                add_hooks=self.use_hooks_,
             )
 
         return True
@@ -54,13 +54,13 @@ class ConstantPruningModifierPyTorch(ConstantPruningModifier, LayerParamMasking)
     def on_start(self, state: State, event: Event, **kwargs):
         for layer_param_name, parameterized_layer in self.parameterized_layers_.items():
             self.update_mask(
-                layer_param_name, parameterized_layer.param.data.abs() > self._epsilon
+                layer_param_name, parameterized_layer.param.data.abs() > self.epsilon_
             )
 
         self.enable_masks()
 
     def on_update(self, state: State, event: Event, **kwargs):
-        if self._use_hooks:
+        if self.use_hooks_:
             # hooks are used to update, so nothing to do here
             return
 

--- a/src/sparseml/modifiers/pruning/magnitude/pytorch.py
+++ b/src/sparseml/modifiers/pruning/magnitude/pytorch.py
@@ -31,8 +31,8 @@ from sparseml.modifiers.pruning.utils.pytorch import (
 
 class MagnitudePruningModifierPyTorch(MagnitudePruningModifier, LayerParamMasking):
     parameterized_layers_: Dict[str, ModelParameterizedLayer] = None
-    _save_masks: bool = False
-    _use_hooks: bool = False
+    save_masks_: bool = False
+    use_hooks_: bool = False
     scheduler_function_: SchedulerCalculationType = None
     mask_creator_function_: MaskCreatorType = None
     current_sparsity_: float = None
@@ -42,9 +42,9 @@ class MagnitudePruningModifierPyTorch(MagnitudePruningModifier, LayerParamMaskin
             raise NotImplementedError("global pruning not implemented yet for PyTorch")
 
         if "save_masks" in kwargs:
-            self._save_masks = kwargs["save_masks"]
+            self.save_masks_ = kwargs["save_masks"]
         if "use_hooks" in kwargs:
-            self._use_hooks = kwargs["use_hooks"]
+            self.use_hooks_ = kwargs["use_hooks"]
 
         if not state.model or not state.start_event:
             return False
@@ -70,8 +70,8 @@ class MagnitudePruningModifierPyTorch(MagnitudePruningModifier, LayerParamMaskin
             self.add_mask(
                 layer_param_name,
                 parameterized_layer,
-                persistent=self._save_masks,
-                add_hooks=self._use_hooks,
+                persistent=self.save_masks_,
+                add_hooks=self.use_hooks_,
             )
 
         return True
@@ -129,9 +129,9 @@ class MagnitudePruningModifierPyTorch(MagnitudePruningModifier, LayerParamMaskin
             self._update_masks(event)
 
     def _update_masks(self, event: Event):
-        if event.type_ == EventType.OPTIM_PRE_STEP and not self._use_hooks:
+        if event.type_ == EventType.OPTIM_PRE_STEP and not self.use_hooks_:
             for layer_param_name, _ in self.parameterized_layers_.items():
                 self.apply_mask_gradient(layer_param_name)
-        elif event.type_ == EventType.OPTIM_POST_STEP and not self._use_hooks:
+        elif event.type_ == EventType.OPTIM_POST_STEP and not self.use_hooks_:
             for layer_param_name, _ in self.parameterized_layers_.items():
                 self.apply_mask_weight(layer_param_name)


### PR DESCRIPTION
Example recipe for what this enables:

```
OutputDistillationModifier:
    targets: ['layer.1', 'layer.2']
    transforms: []
    comparison: "square_head"
    orig_scale: 1.0
    distill_scale: 1.0
```