### PR TITLE
[Test fix] Add stronger check for calibration_dataloader

### DIFF
--- a/src/sparseml/modifiers/quantization/pytorch.py
+++ b/src/sparseml/modifiers/quantization/pytorch.py
@@ -14,7 +14,7 @@
 
 import logging
 from itertools import cycle
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Iterable, Optional
 
 import torch
 from torch.nn import Module
@@ -180,7 +180,12 @@ class QuantizationModifierPyTorch(QuantizationModifier):
                 "calibration_data_loader with initialize(...) method."
             )
 
-        elif not self.calibration_dataloader_:
+        elif not isinstance(self.calibration_dataloader_, Iterable):
+            _LOGGER.debug(
+                "Expected calibration_dataloader_ to be an Iterable."
+                " But got %s, skipping quantization calibration",
+                type(self.calibration_dataloader_),
+            )
             return
 
         self._calibrate(module)


### PR DESCRIPTION
We are seeing some  weird behavior; There's a quantization test failing in GHA here: https://github.com/neuralmagic/sparseml/actions/runs/6619351710/job/17979710828?pr=1752#step:8:2243


This does not fail when run standalone;  the recent hunch is some previous test is missing proper teardown; which is affecting this test;

Best solution would be to figure out which test causes this and fixing that; this PR proposes a different solution, where a stronger check is placed on the calibration data loader

The failing test passes with this change