### PR TITLE
[BugFix] Fix session reset

### DIFF
--- a/src/sparseml/core/lifecycle/session.py
+++ b/src/sparseml/core/lifecycle/session.py
@@ -50,6 +50,9 @@ class SparsificationLifecycle:
             except Exception:
                 pass
 
+        if self.state and self.state.data:
+            # reset data if it exists
+            self.state.data.reset()
         self.state = None
         self.recipe_container = RecipeContainer()
         self.modifiers = []

--- a/src/sparseml/core/state.py
+++ b/src/sparseml/core/state.py
@@ -45,6 +45,14 @@ class Data:
     test: Optional[ModifiableData] = None
     calib: Optional[ModifiableData] = None
 
+    def reset(self):
+        """
+        Reset self to initial state
+        """
+        attribs = Data().__dict__
+        for attrib_name, attrib_value in attribs.items():
+            setattr(self, attrib_name, attrib_value)
+
 
 @dataclass
 class Hardware:

--- a/tests/sparseml/conftest.py
+++ b/tests/sparseml/conftest.py
@@ -92,3 +92,19 @@ def check_for_created_files():
         f"megabytes of temp files created in temp directory during pytest run. "
         f"Created files: {set(end_files_temp) - set(start_files_temp)}"
     )
+
+
+@pytest.fixture(autouse=True, scope="function")
+def setup_fresh_session():
+    """
+    setup any state tied to the execution of the given method in a
+    class.  setup_method is invoked for every test method of a class.
+    """
+    import sparseml.core.session as sml
+
+    active_session = sml.active_session()
+    # start with a clean session for each test
+    active_session.reset()
+    yield
+    # reset the session after each test
+    active_session.reset()


### PR DESCRIPTION
When session was reset; the state.data attribute wasn't being reset properly; this led to the following unexpected failure; (which only reveals itself if `tests/sparseml/core/test_state.py` was executed before `tests/sparseml/pytorch/modifiers/quantization/test_pytorch.py`) 
[here](https://github.com/neuralmagic/sparseml/actions/runs/6619351713/job/17979711097?pr=1752#step:8:2243)

This PR fixes this issue, by also resetting `state.data` when `active_session.reset()` is called

Additionally this PR also introduces a auto-use fixure; that resets the active session before and after every test_function call


Steps to reproduce bug:
```bash
 pytest tests/sparseml/core/test_state.py tests/sparseml/pytorch/modifiers/quantization/test_pytorch.py -s
```

Results in:
```bash
-- Docs: https://docs.pytest.org/en/stable/warnings.html
=================================================================== short test summary info ====================================================================
FAILED tests/sparseml/pytorch/modifiers/quantization/test_pytorch.py::test_quantization_oneshot[ConvNet] - TypeError: 'int' object is not iterable
FAILED tests/sparseml/pytorch/modifiers/quantization/test_pytorch.py::test_quantization_oneshot[LinearNet] - TypeError: 'int' object is not iterable
=========================================================== 2 failed, 18 passed, 2 warnings in 4.32s ====
```


After the proposed fix the tests pass irrespective of the order of execution:
```bash
$ pytest tests/sparseml/core/test_state.py tests/sparseml/pytorch/modifiers/quantization/test_pytorch.py -s                         (fix-session-reset|●3✚1-73)
===================================================================== test session starts ======================================================================
platform linux -- Python 3.8.12, pytest-6.2.5, py-1.11.0, pluggy-1.3.0
rootdir: /home/rahul/projects/sparseml, configfile: pyproject.toml
plugins: flaky-3.7.0, mock-3.6.1, anyio-4.0.0
collected 20 items                                                                                                                                             

tests/sparseml/core/test_state.py ...............
tests/sparseml/pytorch/modifiers/quantization/test_pytorch.py .....
```