### PR TITLE
Update datasets to 2.14.6 for fsspec compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ _pytorch_vision_deps = _pytorch_deps + [
 _transformers_deps = _pytorch_deps + [
     f"{'nm-transformers' if is_release else 'nm-transformers-nightly'}"
     f"~={version_nm_deps}",
-    "datasets<=2.11",
+    "datasets<=2.14.6",
     "scikit-learn",
     "seqeval",
     "einops",


### PR DESCRIPTION
This error was originally reported for deepsparse, but affects sparseml as well. Asana ticket: [NotImplementedError: Loading a dataset cached in a LocalFileSystem is not supported. (from datasets)](https://app.asana.com/0/1203126676641557/1205796604651399/f) 

The latest `fsspec` release(2023.10.0) caused a breaking change with the datasets library. Upgrading our datasets version fixes the issue. Alternatively, we can downgrade `fsspec`