### PR TITLE
Add mistral to obcq

### DIFF
--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -36,7 +36,7 @@ __all__ = ["one_shot"]
 
 _LOGGER = logging.getLogger(__name__)
 SUPPORTED_DATASETS = ["wikitext2", "ptb", "c4", "open_platypus"]
-SUPPORTED_MODELS = ["opt", "llama"]
+SUPPORTED_MODELS = ["opt", "llama", "mistral"]
 
 
 def one_shot(
@@ -76,6 +76,9 @@ def one_shot(
         model_loader_fn = SparseCasualLM.opt_model_from_pretrained
         forward_fn = opt_forward
     elif "llama" in model_path.lower():
+        model_loader_fn = SparseCasualLM.llama_model_from_pretrained
+        forward_fn = llama_forward
+    elif "mistral" or "zephyr" in model_path.lower():
         model_loader_fn = SparseCasualLM.llama_model_from_pretrained
         forward_fn = llama_forward
     else:

--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Optional
 
 from torch.nn import Module
+from transformers import AutoConfig
 
 import sparseml.core.session as session_manager
 from sparseml.core.framework import Framework
@@ -70,16 +71,20 @@ def one_shot(
         if deploy_dir.exists():
             raise RuntimeError(f"deploy_dir={deploy_dir} already exists")
 
+    # Load the configuration from the model path
+    config = AutoConfig.from_pretrained(model_path)
+    model_type = config.model_type.lower()
+
     model_loader_fn = None
     forward_fn = None
-    if "opt" in model_path.lower():
+    if "opt" in model_type:
         model_loader_fn = SparseCasualLM.opt_model_from_pretrained
         forward_fn = opt_forward
-    elif "llama" in model_path.lower():
+    elif "llama" in model_type:
         model_loader_fn = SparseCasualLM.llama_model_from_pretrained
         forward_fn = llama_forward
-    elif "mistral" or "zephyr" in model_path.lower():
-        model_loader_fn = SparseCasualLM.llama_model_from_pretrained
+    elif "mistral" in model_type:
+        model_loader_fn = SparseCasualLM.auto_model_from_pretrained
         forward_fn = llama_forward
     else:
         raise ValueError(f"model_path={model_path} should be one of {SUPPORTED_MODELS}")

--- a/src/sparseml/transformers/utils/model.py
+++ b/src/sparseml/transformers/utils/model.py
@@ -25,7 +25,6 @@ from transformers import (
     AutoModelForQuestionAnswering,
     AutoModelForSequenceClassification,
     AutoModelForTokenClassification,
-    LlamaForCausalLM,
     OPTForCausalLM,
 )
 from transformers.file_utils import WEIGHTS_NAME
@@ -457,7 +456,7 @@ class SparseCasualLM:
         :param model_path: hugging face path to model
         :return: loaded pretrained model
         """
-        model = LlamaForCausalLM.from_pretrained(model_path, torch_dtype="auto")
+        model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype="auto")
         model.eval()
         model.seqlen = model.config.max_position_embeddings
         return model

--- a/src/sparseml/transformers/utils/model.py
+++ b/src/sparseml/transformers/utils/model.py
@@ -25,6 +25,7 @@ from transformers import (
     AutoModelForQuestionAnswering,
     AutoModelForSequenceClassification,
     AutoModelForTokenClassification,
+    LlamaForCausalLM,
     OPTForCausalLM,
 )
 from transformers.file_utils import WEIGHTS_NAME
@@ -452,6 +453,19 @@ class SparseCasualLM:
     def llama_model_from_pretrained(model_path: str) -> torch.nn.Module:
         """
         Load a pretrained Llama model from the specified hugging face path
+
+        :param model_path: hugging face path to model
+        :return: loaded pretrained model
+        """
+        model = LlamaForCausalLM.from_pretrained(model_path, torch_dtype="auto")
+        model.eval()
+        model.seqlen = model.config.max_position_embeddings
+        return model
+
+    @staticmethod
+    def auto_model_from_pretrained(model_path: str) -> torch.nn.Module:
+        """
+        Load a pretrained model using auto from the specified hugging face path
 
         :param model_path: hugging face path to model
         :return: loaded pretrained model


### PR DESCRIPTION
Adds mistral support for the obcq script using the latest [nm-transformers](https://github.com/neuralmagic/transformers). This diff experiments with loading with the simple AutoModel interface and finding the model arch name from the config file's `model_type`

Here is a sample recipe I used for zephyr-beta
```yaml
test_stage:
  obcq_modifiers:
    QuantizationModifier:
      ignore:
        - MistralRotaryEmbedding
        - MistralRMSNorm
        - SiLUActivation
        - model.layers.1.mlp.down_proj
        - model.layers.31.mlp.down_proj
        - model.layers.30.mlp.down_proj
        - model.layers.30.mlp.gate_proj
        - model.layers.30.mlp.up_proj
      post_oneshot_calibration: True
      scheme_overrides:
        Embedding:
          input_activations: null
          weights:
            num_bits: 8
            symmetric: False
    SparseGPTModifier:
      sparsity: 0.5
      block_size: 128
      sequential_update: False
      quantize: True
      percdamp: 0.01
      prunen: 0
      prunem: 0
      targets: [
        "model.layers.0",
        "model.layers.1",
        "model.layers.2",
        "model.layers.3",
        "model.layers.4",
        "model.layers.5",
        "model.layers.6",
        "model.layers.7",
        "model.layers.8",
        "model.layers.9",
        "model.layers.10",
        "model.layers.11",
        "model.layers.12",
        "model.layers.13",
        "model.layers.14",
        "model.layers.15",
        "model.layers.16",
        "model.layers.17",
        "model.layers.18",
        "model.layers.19",
        "model.layers.20",
        "model.layers.21",
        "model.layers.22",
        "model.layers.23",
        "model.layers.24",
        "model.layers.25",
        "model.layers.26",
        "model.layers.27",
        "model.layers.28",
        "model.layers.29",
        "model.layers.30",
        "model.layers.31",
      ]
      target_ids: ["attention_mask", "position_ids"]  
```