### PR TITLE
[Bug Fix] Reducing Memory Requirements for Sequential OBCQ

### DIFF
--- a/src/sparseml/core/state.py
+++ b/src/sparseml/core/state.py
@@ -177,10 +177,6 @@ class State:
 
         if "device" in kwargs:
             self.hardware.device = kwargs["device"]
-            print("\n\n\n------------------------------------------------------------")
-            print("SKIPPING MODEL.to(device)")
-            print("------------------------------------------------------------\n\n\n")
-            # self.model.model.to(self.hardware.device)
 
         if (
             start is not None

--- a/src/sparseml/core/state.py
+++ b/src/sparseml/core/state.py
@@ -177,7 +177,10 @@ class State:
 
         if "device" in kwargs:
             self.hardware.device = kwargs["device"]
-            self.model.model.to(self.hardware.device)
+            print("\n\n\n------------------------------------------------------------")
+            print("SKIPPING MODEL.to(device)")
+            print("------------------------------------------------------------\n\n\n")
+            # self.model.model.to(self.hardware.device)
 
         if (
             start is not None

--- a/src/sparseml/modifiers/obcq/pytorch.py
+++ b/src/sparseml/modifiers/obcq/pytorch.py
@@ -83,7 +83,6 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
         :param model: PyTorch model to sparsify
         :param device: device to run sparsification on, preferably a GPU
         """
-
         self.model = model
         self.compressible_layers_ = self.compressible_layers()
         self.model = self.model.model

--- a/src/sparseml/modifiers/obcq/pytorch.py
+++ b/src/sparseml/modifiers/obcq/pytorch.py
@@ -83,6 +83,7 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
         :param model: PyTorch model to sparsify
         :param device: device to run sparsification on, preferably a GPU
         """
+
         self.model = model
         self.compressible_layers_ = self.compressible_layers()
         self.model = self.model.model

--- a/src/sparseml/modifiers/obcq/utils/layer_compressor.py
+++ b/src/sparseml/modifiers/obcq/utils/layer_compressor.py
@@ -154,6 +154,12 @@ class LayerCompressor:
 
         self.inputs = None
         torch.cuda.empty_cache()
+
+        print("\n\n\n--------------------------------------------------")
+        print("MOVING LAYER BACK TO CPU")
+        print("--------------------------------------------------\n\n\n")
+        self.layer.to("cpu")
+
         return {"outputs": outputs}
 
     def sequentially_compress(self, **kwargs):

--- a/src/sparseml/modifiers/obcq/utils/layer_compressor.py
+++ b/src/sparseml/modifiers/obcq/utils/layer_compressor.py
@@ -153,12 +153,9 @@ class LayerCompressor:
             outputs.append(self.layer(self.inputs[j], **passed_in_kwargs)[0])
 
         self.inputs = None
-        torch.cuda.empty_cache()
-
-        print("\n\n\n--------------------------------------------------")
-        print("MOVING LAYER BACK TO CPU")
-        print("--------------------------------------------------\n\n\n")
+        # once we've finished compressing the layer, move it back to CPU to save memory
         self.layer.to("cpu")
+        torch.cuda.empty_cache()
 
         return {"outputs": outputs}
 

--- a/tests/sparseml/core/test_state.py
+++ b/tests/sparseml/core/test_state.py
@@ -116,7 +116,12 @@ class TestState:
         state = State(framework=Framework.pytorch)
         model = get_linear_net_with_device(device="cuda")
         assert model.device == "cuda"
+        assert state.hardware.device is None
 
         state.update(model=model, device="cpu")
         assert state.model.model == model
-        assert state.model.model.device == "cpu"
+
+        # update does not move the model to the device on initialization, it is a
+        # parameter used by individual modifiers to control device management
+        assert state.model.model.device == "cuda"
+        assert state.hardware.device == "cpu"

--- a/tests/sparseml/transformers/obcq/test_obcq.py
+++ b/tests/sparseml/transformers/obcq/test_obcq.py
@@ -12,13 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from sparseml.modifiers.obcq.utils.helpers import ppl_eval_general
 from sparseml.transformers.data import TransformersDataset
 from sparseml.transformers.sparsification.obcq.obcq import one_shot
 from sparseml.transformers.sparsification.obcq.utils.helpers import llama_forward
 
 
-def test_obcq_tinystories():
+@pytest.mark.parametrize(
+    "recipe_file_path",
+    [
+        "tests/sparseml/transformers/obcq/test_tiny.yaml",
+        "tests/sparseml/transformers/obcq/test_tiny2.yaml",
+    ],
+)
+def test_obcq_tinystories(recipe_file_path):
     tiny_model_path = "Xenova/llama2.c-stories15M"
     device = "cuda:0"
 
@@ -28,7 +37,7 @@ def test_obcq_tinystories():
         dataset_name="open_platypus",
         num_samples=64,
         device=device,
-        recipe_file="tests/sparseml/transformers/obcq/test_tiny.yaml",
+        recipe_file=recipe_file_path,
     )
 
     dataset = TransformersDataset.load_from_registry(

--- a/tests/sparseml/transformers/obcq/test_tiny.yaml
+++ b/tests/sparseml/transformers/obcq/test_tiny.yaml
@@ -27,7 +27,7 @@ test_stage:
     SparseGPTModifier:
       sparsity: 0.5
       block_size: 128
-      sequential_update: False
+      sequential_update: True
       quantize: True
       percdamp: 0.01
       prunen: 0

--- a/tests/sparseml/transformers/obcq/test_tiny2.yaml
+++ b/tests/sparseml/transformers/obcq/test_tiny2.yaml
@@ -1,0 +1,19 @@
+test_stage:
+  obcq_modifiers:
+    SparseGPTModifier:
+      sparsity: 0.5
+      block_size: 128
+      sequential_update: True
+      quantize: False
+      percdamp: 0.01
+      prunen: 0
+      prunem: 0
+      targets: [
+        "model.layers.0",
+        "model.layers.1",
+        "model.layers.2",
+        "model.layers.3",
+        "model.layers.4",
+        "model.layers.5"
+      ]
+      target_ids: ["attention_mask", "position_ids"]  


### PR DESCRIPTION
Previously, the OBCQ script would move the entire input model to the GPU during initialization. This PR removes this and instead loads the model layer by layer. 

CAVEAT: This fix is only for the SparseGPTModifier. For the  quantization and smoothquant modifiers, the model is still fully loaded onto the device in order to run calibration. Do we want to add additional options to run calibration on the CPU (would also need to fix the fp16 issues) while keeping OBCQ on the GPU, or update the quantization modifiers themselves to be able to run layer by layer (probably more work)?

### Testing

test_recipe.yaml
```
test_stage:
  obcq_modifiers:
    SparseGPTModifier:
      sparsity: 0.5
      block_size: 128
      sequential_update: True
      quantize: False
      percdamp: 0.01
      mask_structure: "0:0"
      targets: [
        "re:model.layers.\\d*$"
      ]
      target_ids: ["attention_mask", "position_ids"]  
```

To run:
```
python src/sparseml/transformers/sparsification/obcq/obcq.py /path/to/llama open-platypus --recipe test_recipe.yaml --eval wikitext
```

Memory requirements with change (from nvidia-smi): ~9.6GB
Before Change: >16GB
