### PR TITLE
[OBCQ][Recipe UX change] Prunen-prunem-to-mask-structure

### DIFF
--- a/src/sparseml/modifiers/obcq/base.py
+++ b/src/sparseml/modifiers/obcq/base.py
@@ -37,15 +37,17 @@ class SparseGPTModifier(Modifier):
 
     :param sparsity: Sparsity to compress model to
     :param block_size: Used to determine number of columns to compress in one pass
-    :param quantize: Whether or not to quantize weights during SparseGPT. Set to True
-        to quantize using an existing quantization modifier, or pass in the configuration
-        for a quantization modifier if one does not already exist in the recipe
+    :param quantize: Whether or not to quantize weights during SparseGPT. Set to
+        True to quantize using an existing quantization modifier, or pass in the
+        configuration for a quantization modifier if one does not already exist
+        in the recipe
     :param dampening_frac: Amount of dampening to apply to H, as a fraction of the
         diagonal norm
     :param sequential_update: Whether or not to update weights sequentially by layer,
         True saves on GPU memory
-    :param prunen: N for N:M pruning
-    :param prunem: M for N:M pruning
+    :param mask_structure: String to define the structure of the mask to apply.
+        Must be of the form N:M where N, M are integers that define a custom block
+        shape. Defaults to 0:0 which represents an unstructured mask.
     :param targets: list of layer names to compress during OBCQ, or '__ALL__'
         to compress every layer in the model
     :param target_ids: list of keys in model output to cache
@@ -58,8 +60,9 @@ class SparseGPTModifier(Modifier):
     quantize: Union[bool, Dict]
     dampening_frac: Optional[float] = 0.01
     sequential_update: Optional[bool] = True
-    prunen: Optional[int] = 0
-    prunem: Optional[int] = 0
+    mask_structure: str = "0:0"
+    prunen_: Optional[int] = None
+    prunem_: Optional[int] = None
     targets: Union[str, List[str], None] = ALL_TOKEN
     target_ids: Optional[List[str]] = None
     layer_prefix: Optional[str] = None

--- a/src/sparseml/modifiers/obcq/base.py
+++ b/src/sparseml/modifiers/obcq/base.py
@@ -38,8 +38,8 @@ class SparseGPTModifier(Modifier):
     :param sparsity: Sparsity to compress model to
     :param block_size: Used to determine number of columns to compress in one pass
     :param quantize: Whether or not to quantize weights during SparseGPT. Set to True
-    to quantize using an existing quantization modifier, or pass in the configuration
-    for a quantization modifier if one does not already exist in the recipe
+        to quantize using an existing quantization modifier, or pass in the configuration
+        for a quantization modifier if one does not already exist in the recipe
     :param dampening_frac: Amount of dampening to apply to H, as a fraction of the
         diagonal norm
     :param sequential_update: Whether or not to update weights sequentially by layer,
@@ -135,7 +135,7 @@ class SparseGPTModifier(Modifier):
             **modifier_args,
         )
 
-    def _validate_layerwise_sparisity(self):
+    def _validate_layerwise_sparsity(self):
         if isinstance(self.sparsity, float):
             return  # single sparsity will be applied to all layers
 

--- a/src/sparseml/modifiers/obcq/pytorch.py
+++ b/src/sparseml/modifiers/obcq/pytorch.py
@@ -54,7 +54,7 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
 
         :param state: session state storing input model and calibration data
         """
-        self._validate_layerwise_sparisity()
+        self._validate_layerwise_sparsity()
 
         if not self.initialized_structure_:
             self.on_initialize_structure(state, **kwargs)

--- a/src/sparseml/transformers/sparsification/obcq/example.yaml
+++ b/src/sparseml/transformers/sparsification/obcq/example.yaml
@@ -16,8 +16,7 @@ test_stage:
               input_activations: null
               output_activations: null
       percdamp: 0.01
-      prunen: 0
-      prunem: 0
+      mask_structure: "0:0"
       targets: [
         "model.decoder.layers.0",
         "model.decoder.layers.1",

--- a/src/sparseml/transformers/sparsification/obcq/example_llama.yaml
+++ b/src/sparseml/transformers/sparsification/obcq/example_llama.yaml
@@ -50,8 +50,7 @@ test_stage:
       sequential_update: False
       quantize: True
       percdamp: 0.01
-      prunen: 0
-      prunem: 0
+      mask_structure: "0:0"
       targets: [
         "model.layers.0",
         "model.layers.1",

--- a/tests/sparseml/pytorch/modifiers/obcq/test_pytorch.py
+++ b/tests/sparseml/pytorch/modifiers/obcq/test_pytorch.py
@@ -57,7 +57,7 @@ def test_successful_layerwise_recipe():
     targets = ["seq.fc1", "seq.fc2"]
     kwargs = dict(sparsity=sparsities, block_size=128, quantize=False, targets=targets)
     modifier = SparseGPTModifierPyTorch(**kwargs)
-    modifier._validate_layerwise_sparisity()
+    modifier._validate_layerwise_sparsity()
     modifier.model = ModifiableModel(framework=Framework.pytorch, model=model)
     found_compressible_layers = modifier.compressible_layers()
 


### PR DESCRIPTION
Before this PR OBCQ recipes needed prunen/prunem to be specified individually. This PR makes a UX change such that now, a `mask_structure` of the form `N:M` can be defined; the where both N, M are integers (similar to prunen and prunem)

Test command:

```bash
python3 src/sparseml/transformers/sparsification/obcq/obcq.py faceb
ook/opt-350m c4 --recipe src/sparseml/transformers/sparsification/obcq/example.yaml --eval wikitext2 
```

Output:
```bash
.
.
.
2023-10-31 07:03:54 sparseml.modifiers.quantization.pytorch INFO     Running quantization calibration using calibration_dataloader
2023-10-31 07:04:02 sparseml.modifiers.obcq.utils.helpers INFO     Evaluating perplexity...
2023-10-31 07:04:03 sparseml.modifiers.obcq.utils.helpers INFO     tensor(34.7602, device='cuda:0')
2023-10-31 07:04:05 sparseml.modifiers.obcq.utils.helpers INFO     tensor(36.3635, device='cuda:0')
2023-10-31 07:04:06 sparseml.modifiers.obcq.utils.helpers INFO     tensor(37.2799, device='cuda:0')
2023-10-31 07:04:08 sparseml.modifiers.obcq.utils.helpers INFO     tensor(36.4086, device='cuda:0')
2023-10-31 07:04:09 sparseml.modifiers.obcq.utils.helpers INFO     tensor(33.7602, device='cuda:0')
2023-10-31 07:04:11 sparseml.modifiers.obcq.utils.helpers INFO     tensor(35.3937, device='cuda:0')
2023-10-31 07:04:12 sparseml.modifiers.obcq.utils.helpers INFO     tensor(33.7370, device='cuda:0')
2023-10-31 07:04:14 sparseml.modifiers.obcq.utils.helpers INFO     tensor(33.7335, device='cuda:0')
2023-10-31 07:04:16 sparseml.modifiers.obcq.utils.helpers INFO     tensor(33.4511, device='cuda:0')
2023-10-31 07:04:17 sparseml.modifiers.obcq.utils.helpers INFO     tensor(33.1673, device='cuda:0')
2023-10-31 07:04:19 sparseml.modifiers.obcq.utils.helpers INFO     tensor(33.1939, device='cuda:0')
2023-10-31 07:04:20 sparseml.modifiers.obcq.utils.helpers INFO     tensor(34.0454, device='cuda:0')
2023-10-31 07:04:22 sparseml.modifiers.obcq.utils.helpers INFO     tensor(34.4664, device='cuda:0')
2023-10-31 07:04:23 sparseml.modifiers.obcq.utils.helpers INFO     tensor(34.3553, device='cuda:0')
2023-10-31 07:04:25 sparseml.modifiers.obcq.utils.helpers INFO     tensor(34.0684, device='cuda:0')
2023-10-31 07:04:26 sparseml.modifiers.obcq.utils.helpers INFO     tensor(33.9638, device='cuda:0')
2023-10-31 07:04:28 sparseml.modifiers.obcq.utils.helpers INFO     tensor(33.9543, device='cuda:0')
2023-10-31 07:04:29 sparseml.modifiers.obcq.utils.helpers INFO     tensor(34.1352, device='cuda:0')
2023-10-31 07:04:29 sparseml.modifiers.obcq.utils.helpers INFO     Perplexity: 34.135204
```