### PR TITLE
[OBCQ Recipe UX Change] Remove target_ids

### DIFF
--- a/src/sparseml/modifiers/obcq/base.py
+++ b/src/sparseml/modifiers/obcq/base.py
@@ -48,7 +48,6 @@ class SparseGPTModifier(Modifier):
     :param prunem: M for N:M pruning
     :param targets: list of layer names to compress during OBCQ, or '__ALL__'
         to compress every layer in the model
-    :param target_ids: list of keys in model output to cache
     """
 
     sparsity: Union[float, List[float]]
@@ -59,7 +58,6 @@ class SparseGPTModifier(Modifier):
     prunen: Optional[int] = 0
     prunem: Optional[int] = 0
     targets: Union[str, List[str], None] = ALL_TOKEN
-    target_ids: Optional[List[str]] = None
     layer_prefix: Optional[str] = None
     compressible_layers_: List = None
     quantization_modifier_: Any = None

--- a/src/sparseml/modifiers/obcq/pytorch.py
+++ b/src/sparseml/modifiers/obcq/pytorch.py
@@ -167,7 +167,6 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
         nsamples: int = None,
         dev: str = "cuda:0",
         layer_prefix: Optional[str] = None,
-        # target_ids: List[str] = None,
     ) -> Dict:
         """
         Runs calibration data through the bottom part of the network (everything up

--- a/src/sparseml/modifiers/obcq/pytorch.py
+++ b/src/sparseml/modifiers/obcq/pytorch.py
@@ -107,7 +107,6 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
         # decoder layer. Also return attention_mask as part of kwargs
         extras = self.compress_bottom(
             dev=self.device_,
-            target_ids=self.target_ids,
             layer_prefix=self.layer_prefix_,
             **accum_kwargs,
         )
@@ -167,8 +166,8 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
         dataloader: List = None,
         nsamples: int = None,
         dev: str = "cuda:0",
-        target_ids: List[str] = None,
         layer_prefix: Optional[str] = None,
+        # target_ids: List[str] = None,
     ) -> Dict:
         """
         Runs calibration data through the bottom part of the network (everything up
@@ -183,7 +182,7 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
         """
         layer_prefix = layer_prefix or self.layer_prefix_
         cached_inputs = cache_attention_inputs(
-            self.model, dataloader, dev, nsamples, target_ids, layer_prefix
+            self.model, dataloader, dev, nsamples, layer_prefix
         )
 
         outputs = cached_inputs.pop("inputs")

--- a/src/sparseml/modifiers/obcq/pytorch.py
+++ b/src/sparseml/modifiers/obcq/pytorch.py
@@ -180,7 +180,11 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
         """
         layer_prefix = layer_prefix or self.layer_prefix_
         cached_inputs = cache_attention_inputs(
-            self.model, dataloader, dev, nsamples, layer_prefix
+            model=self.model,
+            dataloader=dataloader,
+            device=dev,
+            nsamples=nsamples,
+            layer_prefix=layer_prefix,
         )
 
         outputs = cached_inputs.pop("inputs")

--- a/src/sparseml/modifiers/obcq/utils/helpers.py
+++ b/src/sparseml/modifiers/obcq/utils/helpers.py
@@ -25,23 +25,29 @@ class Catcher(torch.nn.Module):
     def __init__(self, module):
         super().__init__()
         self.module = module
-        # default target keys
-
-        self.target_keys = [
-            "attention_mask",
-            # "input_id",
-        ]
+        self.target_keys = None
         self.cache = {key: [] for key in self.target_keys}
         self.cache["inputs"] = []
 
     def forward(self, *args, **kwargs):
         self.cache["inputs"].append(args)
+        if self.target_keys is None:
+            self.target_keys = self._get_target_keys(kwargs.keys())
+
         for key in self.target_keys:
             self.cache[key].append(kwargs[key])
         raise ValueError
 
     def get_cache(self):
         return self.cache
+
+    def _get_target_keys(self, input_keys):
+        target_keys = []
+        if "attention_mask" in input_keys:
+            target_keys.append("attention_mask")
+        if "position_ids" in input_keys:
+            target_keys.append("position_ids")
+        return target_keys
 
 
 def replace_module(model, old_module, new_module):

--- a/src/sparseml/modifiers/obcq/utils/helpers.py
+++ b/src/sparseml/modifiers/obcq/utils/helpers.py
@@ -20,6 +20,10 @@ import torch
 
 
 _LOGGER = logging.getLogger(__name__)
+_DEFAULT_TARGET_IDS = [
+    "attention_mask",
+    "position_ids",
+]
 
 
 class Catcher(torch.nn.Module):
@@ -44,10 +48,9 @@ class Catcher(torch.nn.Module):
 
     def _get_target_keys(self, input_keys):
         target_keys = []
-        if "attention_mask" in input_keys:
-            target_keys.append("attention_mask")
-        if "position_ids" in input_keys:
-            target_keys.append("position_ids")
+        for key in _DEFAULT_TARGET_IDS:
+            if key in input_keys:
+                target_keys.append(key)
         return target_keys
 
 

--- a/src/sparseml/modifiers/obcq/utils/helpers.py
+++ b/src/sparseml/modifiers/obcq/utils/helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from collections import defaultdict
 from math import ceil
 
 import torch
@@ -26,7 +27,7 @@ class Catcher(torch.nn.Module):
         super().__init__()
         self.module = module
         self.target_keys = None
-        self.cache = {key: [] for key in self.target_keys}
+        self.cache = defaultdict(list)
         self.cache["inputs"] = []
 
     def forward(self, *args, **kwargs):

--- a/src/sparseml/modifiers/obcq/utils/helpers.py
+++ b/src/sparseml/modifiers/obcq/utils/helpers.py
@@ -132,7 +132,6 @@ def cache_attention_inputs(model, dataloader, device, nsamples, layer_prefix):
     cached_inputs = catch(
         model,
         first_layer,
-        # target_ids,  # ["attention_mask"],
         dataloader,
         nsamples,
     )

--- a/src/sparseml/transformers/sparsification/obcq/example.yaml
+++ b/src/sparseml/transformers/sparsification/obcq/example.yaml
@@ -56,4 +56,3 @@ test_stage:
         "model.decoder.layers.22",
         "model.decoder.layers.23"
       ]
-      target_ids: ["attention_mask"]

--- a/src/sparseml/transformers/sparsification/obcq/example_llama.yaml
+++ b/src/sparseml/transformers/sparsification/obcq/example_llama.yaml
@@ -92,4 +92,3 @@ test_stage:
         "model.layers.30",
         "model.layers.31",
       ]
-      target_ids: ["attention_mask", "position_ids"]  

--- a/src/sparseml/transformers/sparsification/obcq/utils/helpers.py
+++ b/src/sparseml/transformers/sparsification/obcq/utils/helpers.py
@@ -38,7 +38,7 @@ def opt_forward(model: Module, data_loader: List, device: str, nsamples: int = N
     :return: logits output of the model
     """
     cached_inputs = cache_attention_inputs(
-        model, data_loader, device, nsamples, ["attention_mask"], "decoder"
+        model, data_loader, device, nsamples, "decoder"
     )
     buffer = [b[0] for b in cached_inputs.pop("inputs")]
     for layer in model.model.decoder.layers:
@@ -86,9 +86,7 @@ def llama_forward(model: Module, data_loader: List, device: str, nsamples: int =
 
     :return: logits output of the model
     """
-    cached_inputs = cache_attention_inputs(
-        model, data_loader, device, nsamples, ["attention_mask", "position_ids"], None
-    )
+    cached_inputs = cache_attention_inputs(model, data_loader, device, nsamples, None)
     buffer = [b[0] for b in cached_inputs.pop("inputs")]
     for layer in model.model.layers:
         buffer = execute_offloaded_module(

--- a/tests/sparseml/transformers/obcq/test_tiny.yaml
+++ b/tests/sparseml/transformers/obcq/test_tiny.yaml
@@ -40,4 +40,3 @@ test_stage:
         "model.layers.4",
         "model.layers.5"
       ]
-      target_ids: ["attention_mask", "position_ids"]  


### PR DESCRIPTION
This PR removes target_ids param from OBCQ modifier; now this param is not needed and will be inferred automatically

Test plan: Run obcq on both llama, and opt-1.3b; and assert we do not drop in perplexity

Expected perplexity: 
 -  opt - b/w 18-20
-  llama - b/w 7-8


Test commands:

- [X] OPT
```bash
python3 src/sparseml/transformers/sparsification/obcq/obcq.py faceb
ook/opt-1.3b c4 --recipe src/sparseml/transformers/sparsification/obcq/example.yaml --eval wikitext2 
```

Output: (Truncated)
```bash
2023-10-31 10:55:11 sparseml.modifiers.obcq.utils.helpers INFO     Perplexity: 18.037699
```

- [X] LLama-7B

```bash
python src/sparseml/transformers/sparsification/obcq/obcq.py /home/rahul/llama/training open_platypus --recipe src/sparseml/transformers/sparsification/obcq/example_llama.yaml --eval wikitext2
```

Output: (Truncated)
```bash
2023-11-01 09:12:28 sparseml.modifiers.obcq.utils.helpers INFO     Perplexity: 7.168426
```


Changes in existing recipes: Look at example.yaml/example_llama.yaml but TLDR; just remove target_ids field altogether