### PR TITLE
[draft] proposed fix for incorrect mask application in FSDP

### DIFF
--- a/src/sparseml/modifiers/pruning/constant/pytorch.py
+++ b/src/sparseml/modifiers/pruning/constant/pytorch.py
@@ -76,6 +76,7 @@ class ConstantPruningModifierPyTorch(ConstantPruningModifier, LayerParamMasking)
             #     self.apply_mask_weight(layer_param_name, state.model.model)
             def mask_weights(module):
                 if hasattr(module, "mask"):
+                    # with FullyShardedDataParallel.summon_full_params(module):
                     module.weight *= module.mask
 
             state.model.model.apply(mask_weights)

--- a/src/sparseml/modifiers/pruning/utils/pytorch/layer_mask.py
+++ b/src/sparseml/modifiers/pruning/utils/pytorch/layer_mask.py
@@ -23,14 +23,10 @@ from torch.utils.hooks import RemovableHandle
 from sparseml.core import ModelParameterizedLayer
 
 
-__all__ = ["LayerParamMasking"]
+__all__ = ["LayerParamMasking", "param_mask_name"]
 
 
-def param_mask_name(param_name: str) -> str:
-    # valid_name = param_name.replace(".", "_")
-    # return f"{valid_name}_mask"
-
-    # for simplicity of quick fix
+def param_mask_name() -> str:
     return "mask"
 
 
@@ -73,7 +69,7 @@ class LayerParamMasking(BaseModel):
         if layer_param_name in self._masked_layer_params:
             raise ValueError(f"Layer param {layer_param_name} already has a mask")
 
-        mask_name = param_mask_name(parameterized_layer.param_name)
+        mask_name = param_mask_name()
 
         try:
             parameterized_layer.layer.get_buffer(mask_name)
@@ -129,7 +125,7 @@ class LayerParamMasking(BaseModel):
         mask: torch.Tensor,
     ):
         parameterized_layer = self._masked_layer_params[layer_param_name]
-        mask_name = param_mask_name(parameterized_layer.param_name)
+        mask_name = param_mask_name()
         mask_tensor = parameterized_layer.layer.get_buffer(mask_name)
         mask_tensor[:] = mask
 
@@ -140,7 +136,7 @@ class LayerParamMasking(BaseModel):
         if not mask_settings.persistent:
             delattr(
                 parameterized_layer.layer,
-                param_mask_name(parameterized_layer.param_name),
+                param_mask_name(),
             )
 
         del self._masked_layer_params[layer_param_name]
@@ -158,9 +154,6 @@ class LayerParamMasking(BaseModel):
             return
 
         parameterized_layer = self._masked_layer_params[layer_param_name]
-        if layer_param_name == "model.layers.5.mlp.down_proj.weight":
-            print(parameterized_layer.param.data)
-
         mask_name = param_mask_name(parameterized_layer.param_name)
         mask = parameterized_layer.layer.get_buffer(mask_name)
         parameterized_layer.param.data = parameterized_layer.param.data * mask

--- a/src/sparseml/modifiers/pruning/utils/pytorch/layer_mask.py
+++ b/src/sparseml/modifiers/pruning/utils/pytorch/layer_mask.py
@@ -27,8 +27,11 @@ __all__ = ["LayerParamMasking"]
 
 
 def param_mask_name(param_name: str) -> str:
-    valid_name = param_name.replace(".", "_")
-    return f"{valid_name}_mask"
+    # valid_name = param_name.replace(".", "_")
+    # return f"{valid_name}_mask"
+
+    # for simplicity of quick fix
+    return "mask"
 
 
 def setup_mask_for_param(param: Parameter, mask: torch.Tensor) -> torch.Tensor:

--- a/src/sparseml/transformers/finetune/callbacks.py
+++ b/src/sparseml/transformers/finetune/callbacks.py
@@ -48,12 +48,6 @@ class PostOptimCallback(TrainerCallback):
         """
         super().on_train_begin(args, state, control, **kwargs)
         session = sml.active_session()
-        print(
-            "TRAIN CALLBACK",
-            type(session.state.model.model),
-            type(self.trainer.model),
-            type(self.trainer.model_wrapped),
-        )
         session.state.model.model = self.trainer.model
 
     def on_step_end(

--- a/src/sparseml/transformers/finetune/callbacks.py
+++ b/src/sparseml/transformers/finetune/callbacks.py
@@ -32,6 +32,30 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class PostOptimCallback(TrainerCallback):
+    def __init__(self, trainer, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.trainer = trainer
+
+    def on_train_begin(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ):
+        """
+        Event called at the beginning of training.
+        """
+        super().on_train_begin(args, state, control, **kwargs)
+        session = sml.active_session()
+        print(
+            "TRAIN CALLBACK",
+            type(session.state.model.model),
+            type(self.trainer.model),
+            type(self.trainer.model_wrapped),
+        )
+        session.state.model.model = self.trainer.model
+
     def on_step_end(
         self,
         args: TrainingArguments,

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -257,11 +257,8 @@ class SessionManagerMixIn:
         self.accelerator.wait_for_everyone()
         from torch.distributed.fsdp import FullyShardedDataParallel
 
-        if self.accelerator.is_main_process:
-            print("logging sparsification")
-            print("MODEL BEFORE LOG: ", type(self.model))
-            with FullyShardedDataParallel.summon_full_params(self.model):
-                self.log_model_sparsification()
+        with FullyShardedDataParallel.summon_full_params(self.model):
+            self.log_model_sparsification()
 
         return output
 

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -58,7 +58,6 @@ def main(**kwargs):
     parser = HfArgumentParser(
         (ModelArguments, DataTrainingArguments, TrainingArguments)
     )
-    print(kwargs)
     model_args, data_args, training_args = parser.parse_dict(kwargs)
 
     # Setup logging

--- a/tests/sparseml/pytorch/modifiers/pruning/constant/test_pytorch.py
+++ b/tests/sparseml/pytorch/modifiers/pruning/constant/test_pytorch.py
@@ -104,7 +104,7 @@ def test_constant_pruning_modifier_e2e(model, optimizer):
     # check mask is added and has correct sparsity
 
     for _, parameterized_layer in modifier.parameterized_layers_.items():
-        mask_name = param_mask_name(parameterized_layer.param_name)
+        mask_name = param_mask_name()
         mask_tensor = parameterized_layer.layer.get_buffer(mask_name)
         data_tensor = parameterized_layer.param.data
         # check mask and data tensors have 0 in the same places
@@ -134,7 +134,7 @@ def test_constant_pruning_modifier_e2e(model, optimizer):
 
     # check mask is removed
     for layer_param_name, parameterized_layer in modifier.parameterized_layers_.items():
-        mask_name = param_mask_name(parameterized_layer.param_name)
+        mask_name = param_mask_name()
 
         if not old_mask_settings[layer_param_name].persistent:
             assert not hasattr(parameterized_layer.layer, mask_name)


### PR DESCRIPTION
in the current layer masking implementation, parameters are stored at initialization and references to them are used to apply masks on modifier update

in FSDP mode, it seems that masking on top of these references does update these parameter references, but these parameters no longer have an effect on the FSDP module. 

this fix just implements the simple flow @dsikka used in the sparsify MVP to apply the masks over a reference to the current FSDP module at update time. (ie instead of applying masks on the saved references to the layers, the masks are applied directly over fresh references from the model)

handing off to @Satrat


**confirmation of fix**
test command:
`accelerate launch --config_file fsdp_config.yaml test_trainer.py`

snippet of output with sparsity log (previously 0.0 for all sparsity values):
```python
2023-10-31 16:22:18 sparseml.transformers.finetune.session_mixin INFO     Finalized SparseML recipe argument applied to the model
2023-10-31 16:22:18 sparseml.transformers.finetune.session_mixin INFO     Sparsification info for ./obcq_deployment: 15191712 total params. Of those there are 15187968 prunable params which have 15.291973225121358 avg sparsity.
2023-10-31 16:22:18 sparseml.transformers.finetune.session_mixin INFO     sparse model detected, all sparsification info: {"params_summary": {"total": 15191712, "sparse": 2322540, "sparsity_percent": 15.288204515725418, "prunable": 15187968, "prunable_sparse": 2322540, "prunable_sparsity_percent": 15.291973225121358, "quantizable": 15187968, "quantized": 0, "quantized_percent": 0.0}, "params_info": {"_fsdp_wrapped_module.model.layers.0.self_attn.q_proj.weight": {"numel": 82944, "sparsity": 0.5000361800193787, "quantized": false}, "_fsdp_wrapped_module.model.layers.0.self_attn.k_proj.weight": {"numel": 82944, "sparsity": 0.5000361800193787, "quantized": false}, "_fsdp_wrapped_module.model.layers.0.self_attn.v_proj.weight": {"numel": 82944, "sparsity": 0.5000361800193787, "quantized": false}, "_fsdp_wrapped_module.model.layers.0.self_attn.o_proj.weight": {"numel": 82944, "sparsity": 0.5000361800193787, "quantized": false}, "_fsdp_wrapped_module.model.layers.0.mlp.gate_proj.weight": {"numel": 221184, "sparsity": 0.5000135898590088, "quantized": false}, "_fsdp_wrapped_module.model.layers.0.mlp.up_proj.weight": {"numel": 221184, "sparsity": 0.5000135898590088, "quantized": false}, "_fsdp_wrapped_module.model.layers.0.mlp.down_proj.weight": {"numel": 221184, "sparsity": 0.0, "quantized": false}, "_fsdp_wrapped_module.model.layers.1.self_attn.q_proj.weight": {"numel": 82944, "sparsity": 0.5000361800193787, "quantized": false}, "_fsdp_wrapped_module.model.layers.1.self_attn.k_proj.weight": {"numel": 82944, "sparsity": 0.5000361800193787, "quantized": false}, "_fsdp_wrapped_module.model.layers.1.self_attn.v_proj.weight": {"numel": 82944, "sparsity": 0.5000361800193787, "quantized": false}, "_fsdp_wrapped_module.model.layers.1.self_attn.o_proj.weight": {"numel": 82944, "sparsity": 0.5000361800193787, "quantized": false}, "_fsdp_wrapped_module.model.layers.1.mlp.gate_proj.weight": {"numel": 221184, "sparsity": 0.5000135898590088, "quantized": false}, "_fsdp_wrapped_module.model.layers.1.mlp.up_proj.weight": {"numel": 221184, "sparsity": 0.5000135898590088, "quantized": false},
```

### Update 11/1/23
The above fix works for n_gpu=1 but multi-gpu. The latest commit should fix the issue with multi-gpu. Essentially what was happening is we were initializing the model to our SparseSession before it was wrapped by FSDP. To fix this I added a new callback for `on_train_begin` that replaces the session's pytorch model with the FSDP wrapped one.

Using `model.apply` as implemented in the initial fix works because FSDP overrides the module `apply` function, see https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.apply. 

In order to access and update the underlying model outside of apply, we need to use the summon_full_params function, see https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.summon_full_params. This fixed the issue with reading out the sparsities after training
```
with FullyShardedDataParallel.summon_full_params(self.model):
    self.log_model_sparsification()
```
We may need to implement this idea in other areas of the codebase.

**Remaining things to wrap up:**
* currently this branch will only work with FSDP due to the summon_full_params call, update to check if we need this context before calling
* Having some issues with the script hanging when we try to save the model. Haven't had time to debug this, but https://huggingface.co/docs/accelerate/usage_guides/fsdp#saving-and-loading may be a good reference here. Might need to wrap this function so only one process is calling it?