### PR TITLE
[Bug Fix] Add missing module __init__.py

### DIFF
--- a/src/sparseml/modifiers/utils/__init__.py
+++ b/src/sparseml/modifiers/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
Fixing test error:
`ModuleNotFoundError: No module named 'sparseml.modifiers.utils'`