### PR TITLE
Adding GSM8K support for OBCQ

### DIFF
--- a/src/sparseml/transformers/data/__init__.py
+++ b/src/sparseml/transformers/data/__init__.py
@@ -15,7 +15,7 @@
 # flake8: noqa
 from .base_llm import TransformersDataset
 from .c4 import *
+from .gsm8k import *
 from .open_platypus import *
 from .ptb import *
 from .wikitext import *
-from .gsm8k import *

--- a/src/sparseml/transformers/data/__init__.py
+++ b/src/sparseml/transformers/data/__init__.py
@@ -18,3 +18,4 @@ from .c4 import *
 from .open_platypus import *
 from .ptb import *
 from .wikitext import *
+from .gsm8k import *

--- a/src/sparseml/transformers/data/gsm8k.py
+++ b/src/sparseml/transformers/data/gsm8k.py
@@ -42,12 +42,12 @@ class GSM8K(TransformersDataset):
 
         processed_data = []
         for sample in self._data:
-            processed_sample = "Question: {{question}}.\nAnswer:".format(
-                    question=sample["question"]
-                )
+            processed_sample = "Question: {question}.\nAnswer:".format(
+                question=sample["question"]
+            )
 
             if "answer" in sample:
-                processed_sample += ' ' + sample["answer"]
+                processed_sample += " " + sample["answer"]
             processed_data.append(processed_sample)
 
         self.create_dataloader(processed_data)

--- a/src/sparseml/transformers/data/gsm8k.py
+++ b/src/sparseml/transformers/data/gsm8k.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torch.nn import Module
+
+from sparseml.transformers.data.base_llm import TransformersDataset
+
+
+@TransformersDataset.register(name="gsm8k")
+class GSM8K(TransformersDataset):
+    def __init__(
+        self,
+        model: Module,
+        seqlen: int,
+        nsamples: int,
+        seed: int = 0,
+        split: str = "train",
+        split_percent_to_use: float = 1.0,
+    ):
+        super().__init__(
+            model=model,
+            seqlen=seqlen,
+            nsamples=nsamples,
+            path="gsm8k",
+            name="main",
+            seed=seed,
+            split=split,
+            use_max_tokens=False,
+            split_percent_to_use=split_percent_to_use,
+        )
+
+        processed_data = []
+        for sample in self._data:
+            processed_sample = "Question: {{question}}.\nAnswer:".format(
+                    question=sample["question"]
+                )
+           
+
+            if "answer" in sample:
+                processed_sample += ' ' + sample["answer"]
+            processed_data.append(processed_sample)
+
+        self.create_dataloader(processed_data)

--- a/src/sparseml/transformers/data/gsm8k.py
+++ b/src/sparseml/transformers/data/gsm8k.py
@@ -45,7 +45,6 @@ class GSM8K(TransformersDataset):
             processed_sample = "Question: {{question}}.\nAnswer:".format(
                     question=sample["question"]
                 )
-           
 
             if "answer" in sample:
                 processed_sample += ' ' + sample["answer"]

--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -36,7 +36,7 @@ from sparseml.transformers.utils.model import SparseCasualLM
 __all__ = ["one_shot"]
 
 _LOGGER = logging.getLogger(__name__)
-SUPPORTED_DATASETS = ["wikitext2", "ptb", "c4", "open_platypus", "gsm8k"]
+SUPPORTED_DATASETS = TransformersDataset.registered_names()
 SUPPORTED_MODELS = ["opt", "llama", "mistral"]
 
 

--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "dataset",
         type=str,
-        choices=["wikitext2", "ptb", "c4", "open_platypus", "gsm8k"],
+        choices=SUPPORTED_DATASETS,
         help="Name of dataset to extract calibration data from",
     )
     parser.add_argument(

--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -36,7 +36,7 @@ from sparseml.transformers.utils.model import SparseCasualLM
 __all__ = ["one_shot"]
 
 _LOGGER = logging.getLogger(__name__)
-SUPPORTED_DATASETS = ["wikitext2", "ptb", "c4", "open_platypus"]
+SUPPORTED_DATASETS = ["wikitext2", "ptb", "c4", "open_platypus", "gsm8k"]
 SUPPORTED_MODELS = ["opt", "llama", "mistral"]
 
 
@@ -154,7 +154,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "dataset",
         type=str,
-        choices=["wikitext2", "ptb", "c4", "open_platypus"],
+        choices=["wikitext2", "ptb", "c4", "open_platypus", "gsm8k"],
         help="Name of dataset to extract calibration data from",
     )
     parser.add_argument(


### PR DESCRIPTION
With this PR, we enable to running OBCQ on GSM8K dataset.

Testing:
```python obcq.py models/Llama-2-7b-hf/ gsm8k --recipe example_llama.yaml```
runs perfectly.