### PR TITLE
Increase obcq nsamples to 512

### DIFF
--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -158,7 +158,7 @@ if __name__ == "__main__":
         help="Name of dataset to extract calibration data from",
     )
     parser.add_argument(
-        "--nsamples", type=int, default=128, help="Number of calibration data samples"
+        "--nsamples", type=int, default=512, help="Number of calibration data samples"
     )
     parser.add_argument("--device", type=str, default="cuda:0")
     parser.add_argument("--deploy-dir", type=str, default=".")


### PR DESCRIPTION
From @eldarkurtic 's early experiments on the small GSM8k dataset, just increasing num samples can provide up to 8 points accuracy improvement over 128. `nsamples=2048` gave the best results but 512 got most of the way there, so I consider this a safe default