### PR TITLE
Add Logarithmic Activation Equalization for one-shot quantization

### DIFF
--- a/src/sparseml/modifiers/__init__.py
+++ b/src/sparseml/modifiers/__init__.py
@@ -19,3 +19,4 @@ from .obcq import *
 from .pruning import *
 from .quantization import *
 from .smoothquant import *
+from .logarithmic_equalization import *

--- a/src/sparseml/modifiers/logarithmic_equalization/__init__.py
+++ b/src/sparseml/modifiers/logarithmic_equalization/__init__.py
@@ -1,0 +1,17 @@
+# flake8: noqa
+
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .base import *

--- a/src/sparseml/modifiers/logarithmic_equalization/base.py
+++ b/src/sparseml/modifiers/logarithmic_equalization/base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from sparseml.modifiers.smoothquant import SmoothQuantModifier
 
 __all__ = ["LogarithmicEqualizationModifier"]
@@ -31,12 +30,11 @@ class LogarithmicEqualizationModifier(SmoothQuantModifier):
      small set of calibration data through the model.
 
      This algorithm is very similar to SmoothQuant, changing only how the smoothing scales
-     are computed.
+     are computed. This modifier inherits most functionality from the SmoothQuantModifier.
 
     example recipe:
      ```yaml
      LogarithmicEqualizationModifier:
-       smoothing_strength: 0.5
        mappings: [
          [["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"], "re:.*self_attn_layer_norm"],
          [["re:.*fc1"], "re:.*final_layer_norm"]
@@ -50,6 +48,3 @@ class LogarithmicEqualizationModifier(SmoothQuantModifier):
      :param num_calibration_steps: number of samples to use for calibration, or None to
      use the whole dataset
     """
-
-    smoothing_strength: None # Not used in logarithmic equalization
-

--- a/src/sparseml/modifiers/logarithmic_equalization/base.py
+++ b/src/sparseml/modifiers/logarithmic_equalization/base.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from sparseml.modifiers.smoothquant import SmoothQuantModifier
+
+__all__ = ["LogarithmicEqualizationModifier"]
+
+
+class LogarithmicEqualizationModifier(SmoothQuantModifier):
+    """
+     Implements the Logarithmic Equalization Algorithm from https://arxiv.org/abs/2308.15987.
+     This modifier performs a channel-wise smoothing of outliers in activations, making them
+     easier to quantize by reducing the dynamic range. The smoothing is offset by
+     applying the inverse operation to the next layer of weights, making the weights
+     slightly more difficult to quantize.
+
+     Because this modifier manipulates the weights of the model, it can only be used
+     in one-shot and not during training. Activation ranges are determined by running a
+     small set of calibration data through the model.
+
+     This algorithm is very similar to SmoothQuant, changing only how the smoothing scales
+     are computed.
+
+    example recipe:
+     ```yaml
+     LogarithmicEqualizationModifier:
+       smoothing_strength: 0.5
+       mappings: [
+         [["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"], "re:.*self_attn_layer_norm"],
+         [["re:.*fc1"], "re:.*final_layer_norm"]
+       ]
+       ignore: ["model.decoder.final_layer_norm"]
+     ```
+
+     :param mappings: list activation layers to smooth, and the which layers to offset
+     the smoothing to for each activation
+     :param ignore: list of layers to ignore, even if they match a regex in mappings
+     :param num_calibration_steps: number of samples to use for calibration, or None to
+     use the whole dataset
+    """
+
+    smoothing_strength: None # Not used in logarithmic equalization
+

--- a/src/sparseml/modifiers/logarithmic_equalization/pytorch.py
+++ b/src/sparseml/modifiers/logarithmic_equalization/pytorch.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import List
+
+import torch
+from torch.nn import Module
+
+from sparseml.modifiers.logarithmic_equalization.base import LogarithmicEqualizationModifier
+from sparseml.modifiers.smoothquant.pytorch import SmoothQuantModifierPyTorch
+
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = ["LogarithmicEqualizationPyTorch"]
+
+
+class LogarithmicEqualizationPyTorch(SmoothQuantModifierPyTorch, LogarithmicEqualizationModifier):
+    """
+    PyTorch implementation of the SmoothQuant algorithm
+
+    :param calibration_function: optional function to use for the forward pass, or None
+    to use the default tensor_module_forward
+    """
+
+    smoothing_strength: None # Not used in logarithmic equalization
+
+    def _calculate_smoothing_scales(
+        self, balance_layers: List[Module], activation_scales: torch.Tensor
+    ) -> List[float]:
+        """
+        Calculate how much smoothing to apply to each channel based on the dynamic
+        range of the activation and the following weights
+
+        :param balance_layers: layers to offset activation smoothing to
+        :param activation_scales: channel-wise dynamic range of activation to smooth
+        :return: channel-wise scales to use for smoothing activation
+        """
+        # calculate the amount of smoothing to apply
+        # s_j = max(|X_j|) / log2( 2 + max(|X_j|) )
+        # where j is the input channel
+        scales = activation_scales / torch.log2(2 + activation_scales)
+        return scales

--- a/src/sparseml/modifiers/logarithmic_equalization/pytorch.py
+++ b/src/sparseml/modifiers/logarithmic_equalization/pytorch.py
@@ -18,7 +18,6 @@ from typing import List
 import torch
 from torch.nn import Module
 
-from sparseml.modifiers.logarithmic_equalization.base import LogarithmicEqualizationModifier
 from sparseml.modifiers.smoothquant.pytorch import SmoothQuantModifierPyTorch
 
 
@@ -27,15 +26,13 @@ _LOGGER = logging.getLogger(__name__)
 __all__ = ["LogarithmicEqualizationPyTorch"]
 
 
-class LogarithmicEqualizationPyTorch(SmoothQuantModifierPyTorch, LogarithmicEqualizationModifier):
+class LogarithmicEqualizationModifierPyTorch(SmoothQuantModifierPyTorch):
     """
-    PyTorch implementation of the SmoothQuant algorithm
+    PyTorch implementation of the Logarithmic Activation Equalization algorithm
 
     :param calibration_function: optional function to use for the forward pass, or None
     to use the default tensor_module_forward
     """
-
-    smoothing_strength: None # Not used in logarithmic equalization
 
     def _calculate_smoothing_scales(
         self, balance_layers: List[Module], activation_scales: torch.Tensor

--- a/src/sparseml/modifiers/smoothquant/base.py
+++ b/src/sparseml/modifiers/smoothquant/base.py
@@ -91,7 +91,7 @@ class SmoothQuantModifier(Modifier):
      use the whole dataset
     """
 
-    smoothing_strength: float = Field(validation_alias="alpha")
+    smoothing_strength: float = Field(validation_alias="alpha", default=0.5)
     mappings: List[Tuple]
     ignore: Optional[List[str]] = None
     num_calibration_steps: Optional[int] = None
@@ -111,12 +111,12 @@ class SmoothQuantModifier(Modifier):
         """
         if self.end and self.end != -1:
             raise ValueError(
-                "SmoothQuantModifier can only be applied during one-shot. Expected end"
+                f"{self.__class__.__name__} can only be applied during one-shot. Expected end"
                 " to be None or -1, got {}".format(self.end)
             )
         if self.start and self.start != -1:
             raise ValueError(
-                "SmoothQuantModifier can only be applied during one-shot. Expected "
+                f"{self.__class__.__name__} can only be applied during one-shot. Expected "
                 "start to be None or -1, got {}".format(self.start)
             )
 

--- a/src/sparseml/modifiers/smoothquant/pytorch.py
+++ b/src/sparseml/modifiers/smoothquant/pytorch.py
@@ -83,7 +83,7 @@ class SmoothQuantModifierPyTorch(SmoothQuantModifier):
                     out = out[0]
 
                 hidden_dim = out.shape[-1]
-                out = out.view(-1, hidden_dim).abs()
+                out = out.view(-1, hidden_dim)
                 latest_mins = torch.min(out, dim=0)[0]
                 latest_maxes = torch.max(out, dim=0)[0]
 
@@ -189,4 +189,5 @@ class SmoothQuantModifierPyTorch(SmoothQuantModifier):
         scales = activation_scales.pow(self.smoothing_strength) / weight_scales.pow(
             1 - self.smoothing_strength
         )
+        scales = torch.where(weight_scales > 0., scales, activation_scales)
         return scales

--- a/src/sparseml/modifiers/smoothquant/pytorch.py
+++ b/src/sparseml/modifiers/smoothquant/pytorch.py
@@ -112,7 +112,8 @@ class SmoothQuantModifierPyTorch(SmoothQuantModifier):
         Catch the output dynamic ranges of each layer that will be smoothed by running
         forward passes with calibration_dataloader
         """
-        _LOGGER.info("Running SmoothQuant scale calibration...")
+        class_name = self.__class__.__name__.replace("PyTorch", "")
+        _LOGGER.info(f"Running {class_name} scale calibration...")
         if not calibration_dataloader:
             raise ValueError(
                 "Calibration data loader not set, must populate the calib_data field of"
@@ -162,7 +163,7 @@ class SmoothQuantModifierPyTorch(SmoothQuantModifier):
                 smooth_layer.weight.div_(scales)
             else:
                 smooth_layer.weight.div_(scales.view(-1, 1))
-            if hasattr(smooth_layer, "bias"):
+            if hasattr(smooth_layer, "bias") and smooth_layer.bias is not None:
                 smooth_layer.bias.div_(scales)
 
     def _calculate_smoothing_scales(


### PR DESCRIPTION
This PR implements a modifier for the Logarithmic Activation Equalization algorithm, introduced in thie paper [FPTQ: Fine-grained Post-Training Quantization for Large Language Models](https://arxiv.org/abs/2308.15987).

The algorithm is a variant of SmoothQuant, with a different method for computation of the smoothing scales. So this implementation basically inherits from SmoothQuantModifier and modifies the _calculate_smoothing_scales method of the PyTorch version.

The PR also adds a couple of changes to SmoothQuantModifier:
- Fix how the min/max values are computed
- Add default value for the smoothing strength. The parameter is not needed in LAE, so by adding a default value we switch it from a required to an optional parameter from the user point of view. This simplifies the inheritance logic.
- Replaced "SmoothQuantModifier" from logging messages by self.__class__.__name__ so changes the modifier name for inherited classes