### PR TITLE
Remove changes to model config at finalization

### DIFF
--- a/src/sparseml/modifiers/obcq/pytorch.py
+++ b/src/sparseml/modifiers/obcq/pytorch.py
@@ -155,8 +155,6 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
 
         :param state: un-used, for matching spec of Modifier base class
         """
-        use_cache = self.finalization_kwargs_.get("use_cache", False)
-        self.model.config.use_cache = use_cache
 
         if self.quantization_modifier_:
             self.quantization_modifier_.finalize(state, **kwargs)


### PR DESCRIPTION
This PR removes changes made to the model config when finalizing the OBCQ modifier. Specifically, we change use_cache when running SparseGPT, but we don't want this change to be permanent. If we do make this change permanent, the use_cache is saved in the compressed checkpoint and inference may become slower.