### PR TITLE
[KV Cache Injection] Pathway to handle GQA models

### DIFF
--- a/src/sparseml/exporters/transforms/kv_cache/configs.py
+++ b/src/sparseml/exporters/transforms/kv_cache/configs.py
@@ -262,7 +262,7 @@ def adapt_cache_structure_for_gqa(
             kv_cache_config.transpose_value_input = None
 
             _LOGGER.info(
-                f"Adapted the model {transformers_config['model_type']} "
+                f"Adapted the model: {transformers_config['model_type']} "
                 f"to work with GQA."
             )
     return kv_cache_config

--- a/src/sparseml/exporters/transforms/kv_cache/configs.py
+++ b/src/sparseml/exporters/transforms/kv_cache/configs.py
@@ -250,8 +250,7 @@ def adapt_cache_structure_for_gqa(
     :param transformers_config: The transformers config for
         the model. If contains the key:`num_key_value_heads`,
         the model may be potentially using GQA instead of
-        Multi Query Attention (MQA) and thus the kv_cache_config
-        needs to be adapted.
+        MHA and thus the kv_cache_config needs to be adapted.
     :param model_names: The list of model names that may use
         GQA instead of MQA.
     :return: Potentially adapted kv cache config for the model.

--- a/src/sparseml/exporters/transforms/kv_cache/configs.py
+++ b/src/sparseml/exporters/transforms/kv_cache/configs.py
@@ -241,9 +241,10 @@ def adapt_cache_structure_for_gqa(
     properly works with Grouped Query Attention (GQA).
 
     For now, this function only supports the llama model.
-    LLama uses QA instead of Multi Query Attention (MQA)
-    if the `num_key_value_heads` is higher than 1, but
-    not equal to the `num_attention_heads`.
+    Llama uses:
+    Multi Head Attention (MHA) if `num_key_value_heads==num_attention_heads` (default),
+    Grouped Query Attention (GQA) if `num_key_value_heads<num_attention_heads`,
+    Multi Query Attention (MQA) if `num_key_value_heads==1`,
 
     :param kv_cache_config: The kv cache config for the model.
     :param transformers_config: The transformers config for

--- a/src/sparseml/exporters/transforms/kv_cache/configs.py
+++ b/src/sparseml/exporters/transforms/kv_cache/configs.py
@@ -237,7 +237,7 @@ def adapt_cache_structure_for_gqa(
     model_names: List[str] = ["llama"],
 ) -> KeyValueCacheConfig:
     """
-    Potentially adapts the kv_cache_config,so that it
+    Potentially adapts the kv_cache_config, so that it
     properly works with Grouped Query Attention (GQA).
 
     :param kv_cache_config: The kv cache config for the model.

--- a/src/sparseml/exporters/transforms/kv_cache/configs.py
+++ b/src/sparseml/exporters/transforms/kv_cache/configs.py
@@ -223,7 +223,48 @@ def get_kv_cache_config(
     kv_cache_config.num_attention_heads = num_attention_heads
     kv_cache_config.hidden_size_kv_cache = hidden_size_kv_cache
 
+    kv_cache_config = adapt_cache_structure_for_gqa(
+        kv_cache_config, transformers_config
+    )
+
     _LOGGER.info("Properly configured arguments for KV Cache Transformation")
+    return kv_cache_config
+
+
+def adapt_cache_structure_for_gqa(
+    kv_cache_config: KeyValueCacheConfig,
+    transformers_config: Dict[str, Any],
+    model_names: List[str] = ["llama"],
+) -> KeyValueCacheConfig:
+    """
+    Potentially adapts the kv_cache_config,so that it
+    properly works with Grouped Query Attention (GQA).
+
+    :param kv_cache_config: The kv cache config for the model.
+    :param transformers_config: The transformers config for
+        the model. If contains the key:`num_key_value_heads`,
+        the model may be potentially using GQA instead of
+        Multi Query Attention (MQA) and thus the kv_cache_config
+        needs to be adapted.
+    :param model_names: The list of model names that may use
+        GQA instead of MQA.
+    :return: Potentially adapted kv cache config for the model.
+        If the model does not use GQA, the kv_cache_config is
+        returned unchanged.
+    """
+    num_key_value_heads = transformers_config.get("num_key_value_heads")
+
+    if num_key_value_heads is not None:
+        # If num_key_value_heads=1 the model will use
+        # Multi Query Attention (MQA) otherwise GQA is used.
+        if kv_cache_config.model_name in model_names and num_key_value_heads > 1:
+            # For now, we only support GQA for LLAMA.
+            kv_cache_config.transpose_value_input = None
+
+            _LOGGER.info(
+                f"Adapted the model {transformers_config['model_type']} "
+                f"to work with GQA."
+            )
     return kv_cache_config
 
 


### PR DESCRIPTION
## Feature Description

A polished version of @mgoin 's PR: https://github.com/neuralmagic/sparseml/pull/1731

As discussed internally, until we potentially figure out the new UI for the KV Cache Injection, we should have an appropriate pathway to handle GQA models.

## Manual Testing

```python
from huggingface_hub import snapshot_download
import os
from src.sparseml.exporters.kv_cache_injector import KeyValueCacheInjector
import onnx
import onnxruntime
import numpy as np
from deepsparse.transformers.utils.helpers import create_causal_mask

directory = snapshot_download("mgoin/TinyLlama-1.1B-step-50K-105b-ONNX")
model = onnx.load(os.path.join(directory, "model-orig.onnx"), load_external_data=False)
model = KeyValueCacheInjector(model_path=directory).apply(model)
onnx.save(model, os.path.join(directory, "model.onnx"))

input_ids = np.ones((1,16), dtype = np.int64)
attention_mask = np.ones((1,16), dtype = np.int64)
kv_cache_key = {name.name: np.zeros((1,32,0,64), dtype=np.float32) for name in model.graph.input if name.name.endswith('key')}
kv_cache_value = {name.name: np.zeros((1,32,0,64), dtype=np.float32) for name in model.graph.input if name.name.endswith('value')}
kv_cache = {**kv_cache_key, **kv_cache_value}
causal_mask = create_causal_mask(input_ids, attention_mask)
positions = attention_mask.cumsum(1) * attention_mask


session = onnxruntime.InferenceSession(os.path.join(directory, "model.onnx"))
session.run(None, {"input_ids": input_ids,
                   "attention_mask": attention_mask,
                   "causal_mask": causal_mask,
                   "positions": positions,
                    **kv_cache})
```

Output:

```bash
Fetching 10 files: 100%|██████████| 10/10 [00:00<00:00, 56679.78it/s]
2023-11-09 12:52:02 sparseml.exporters.transforms.kv_cache.configs INFO     Loaded config file /home/ubuntu/.cache/huggingface/hub/models--mgoin--TinyLlama-1.1B-step-50K-105b-ONNX/snapshots/af990acf6d9e76cc2d7758ac3eabcb44eafe039c/config.json for model: llama
2023-11-09 12:52:02 sparseml.exporters.transforms.kv_cache.configs INFO     Adapted the model: llama to work with GQA.
2023-11-09 12:52:02 sparseml.exporters.transforms.kv_cache.configs INFO     Properly configured arguments for KV Cache Transformation
Attempting to validate an in-memory ONNX model that has been loaded without external data. This is currently not supported by the ONNX checker. The validation will be skipped.
2023-11-09 12:52:03 sparseml.exporters.transforms.onnx_transform INFO     [CacheKeysAndValues] Transformed 44 matches
Attempting to validate an in-memory ONNX model that has been loaded without external data. This is currently not supported by the ONNX checker. The validation will be skipped.
/home/ubuntu/damian/sparseml/src/sparseml/exporters/transforms/kv_cache/transforms_llama.py:125: UserWarning: Number of Slice nodes updated 44 does not match the expected values [64, 80] for the 7 billion or 13 billion parameter models.
  warnings.warn(
2023-11-09 12:52:08 sparseml.exporters.transforms.kv_cache.transforms_llama INFO     Found 44 Slice nodes to update
2023-11-09 12:52:09 sparseml.exporters.transforms.kv_cache.transforms_base INFO     Inserted positions input to the ONNX model
2023-11-09 12:52:09 sparseml.exporters.transforms.kv_cache.transforms_base INFO     Inserted causal_mask input to the ONNX model
2023-11-09 12:52:09 sparseml.exporters.transforms.kv_cache.transforms_base INFO     Successfully swapped 1 nodes for input 'positions'
2023-11-09 12:52:09 sparseml.exporters.transforms.kv_cache.transforms_base INFO     Successfully swapped 1 nodes for input 'causal_mask'
2023-11-09 12:52:10 sparseml.exporters.transforms.kv_cache.transforms_llama INFO     Successfully adjusted the causal_mask input
2023-11-09 12:52:10 sparseml.exporters.transforms.onnx_transform INFO     [AdditionalTransformsLLAMA] Transformed 49 matches
Attempting to validate an in-memory ONNX model that has been loaded without external data. This is currently not supported by the ONNX checker. The validation will be skipped.
2023-11-09 12:52:12.216736227 [W:onnxruntime:, graph.cc:108 MergeShapeInfo] Error merging shape info for output. 'logits' source:{1,16,32000} target:{1,512,32000}. Falling back to lenient merge.
2023-11-09 12:52:12.237340563 [W:onnxruntime:, graph.cc:3553 CleanUnusedInitializersAndNodeArgs] Removing initializer '1110'. It is not used by any node and should be removed from the model.
2023-11-09 12:52:12.237367603 [W:onnxruntime:, graph.cc:3553 CleanUnusedInitializersAndNodeArgs] Removing initializer '1121'. It is not used by any node and should be removed from the model.
...
2023-11-09 12:52:12.237692294 [W:onnxruntime:, graph.cc:3553 CleanUnusedInitializersAndNodeArgs] Removing initializer '776'. It is not used by any node and should be removed from the model.
2023-11-09 12:52:12.237701644 [W:onnxruntime:, graph.cc:3553 CleanUnusedInitializersAndNodeArgs] Removing initializer '787'. It is not used by any node and should be removed from the model.

Process finished with exit code 0
```

The model runs a single forward pass in onnxruntime successfully. Note: I have not investigated the correctness of the result nor have I an explanation why initializers are being discarded by the onnxruntime during initialization.
