### PR TITLE
[Bugfix] ModuleNotFoundError when importing `one_shot` from`obcq`

### DIFF
--- a/src/sparseml/transformers/sparsification/obcq/__init__.py
+++ b/src/sparseml/transformers/sparsification/obcq/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
Python build command ignores packaging `sparseml.transformers.sparsification.obcq` in wheel due to missing init files in transformers/obcq folder. That causes a `ModuleNotFoundError`; this bug oly reveals itself when installing from the wheel, and actually passes when doing an `--editable` install

Fix includes: Adding missing init file in the respective folder

Steps to reproduce:
```bash
pip3 install --default-timeout=200 --index-url http://10.10.60.107:8080/ --trusted-host 10.10.60.107 "sparseml-nightly[torchvision, transformers]"
```

```python
>>> from sparseml.transformers.sparsification.obcq.obcq import one_shot
/home/domenic/testing/testfail-1019/venv/lib/python3.10/site-packages/torch/cuda/__init__.py:546: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'sparseml.transformers.sparsification.obcq'
>>>
```


Adding init file fixes the issue; tested manually with building a wheel off of this Branch, and trying the same import again:


```bash
python3 -m pip install --upgrade build && python3 -m build && \
pip install "dist/sparseml_nightly-1.6.0.20231109-py3-none-any.whl[transformers, torchvision]" 
```

```python
>>> import  sparseml.transformers.sparsification.obcq
>>> from sparseml.transformers.sparsification.obcq.obcq import one_shot
>>> 
KeyboardInterrupt
```