### PR TITLE
[OBCQ][UX update] Make target ids optional

### DIFF
--- a/src/sparseml/modifiers/obcq/base.py
+++ b/src/sparseml/modifiers/obcq/base.py
@@ -50,6 +50,8 @@ class SparseGPTModifier(Modifier):
         shape. Defaults to 0:0 which represents an unstructured mask.
     :param targets: list of layer names to compress during OBCQ, or '__ALL__'
         to compress every layer in the model
+    :param target_ids: list of keys in model output to cache, NOTE: this argument
+        has been deprecated and will be removed in a future release
     """
 
     sparsity: Union[float, List[float]]
@@ -61,9 +63,17 @@ class SparseGPTModifier(Modifier):
     prunen_: Optional[int] = None
     prunem_: Optional[int] = None
     targets: Union[str, List[str], None] = ALL_TOKEN
+    target_ids: Optional[List[str]] = None
     layer_prefix: Optional[str] = None
-    compressible_layers_: List = None
+    compressible_layers_: Optional[List] = None
     quantization_modifier_: Any = None
+
+    def __post_init__(self):
+        if self.target_ids is not None:
+            _LOGGER.warning(
+                "`target_ids` param has been deprecated and will be "
+                "removed in a future release"
+            )
 
     def compressible_layers(self) -> List:
         """

--- a/src/sparseml/modifiers/obcq/pytorch.py
+++ b/src/sparseml/modifiers/obcq/pytorch.py
@@ -108,6 +108,7 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
         # decoder layer. Also return attention_mask as part of kwargs
         extras = self.compress_bottom(
             dev=self.device_,
+            target_ids=self.target_ids,
             layer_prefix=self.layer_prefix_,
             **accum_kwargs,
         )
@@ -165,6 +166,7 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
         dataloader: List = None,
         nsamples: int = None,
         dev: str = "cuda:0",
+        target_ids: List[str] = None,
         layer_prefix: Optional[str] = None,
     ) -> Dict:
         """
@@ -174,6 +176,8 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
         :param dataloader: calibration data to pass through the model
         :param nsamples: number of samples to use for calibration, or None to use it all
         :param dev: device to use
+        :param target_ids: list of keys in model output to cache, NOTE: this argument
+            has been deprecated and will be removed in a future release
         :param layer_prefix: name of model attribute that contains the list of layers,
             i.e. model.decoder for OPT or just model for Llama
         :return: outputs from bottom part of network, attention mask, and kv-cache state
@@ -184,6 +188,7 @@ class SparseGPTModifierPyTorch(SparseGPTModifier):
             dataloader=dataloader,
             device=dev,
             nsamples=nsamples,
+            target_ids=target_ids,
             layer_prefix=layer_prefix,
         )
 

--- a/src/sparseml/modifiers/obcq/utils/helpers.py
+++ b/src/sparseml/modifiers/obcq/utils/helpers.py
@@ -136,11 +136,11 @@ def cache_attention_inputs(
     embed_tokens.to(device)
     first_layer.to(device)
     cached_inputs = catch(
-        model,
-        first_layer,
-        target_ids,  # ["attention_mask"],
-        dataloader,
-        nsamples,
+        model=model,
+        attention_layer=first_layer,
+        target_keys=target_ids,
+        data_loader=dataloader,
+        nsamples=nsamples,
     )
     embed_tokens.cpu()
     first_layer.cpu()

--- a/src/sparseml/transformers/sparsification/obcq/utils/helpers.py
+++ b/src/sparseml/transformers/sparsification/obcq/utils/helpers.py
@@ -38,7 +38,11 @@ def opt_forward(model: Module, data_loader: List, device: str, nsamples: int = N
     :return: logits output of the model
     """
     cached_inputs = cache_attention_inputs(
-        model, data_loader, device, nsamples, "decoder"
+        model=model,
+        dataloader=data_loader,
+        device=device,
+        nsamples=nsamples,
+        layer_prefix="decoder",
     )
     buffer = [b[0] for b in cached_inputs.pop("inputs")]
     for layer in model.model.decoder.layers:
@@ -86,7 +90,13 @@ def llama_forward(model: Module, data_loader: List, device: str, nsamples: int =
 
     :return: logits output of the model
     """
-    cached_inputs = cache_attention_inputs(model, data_loader, device, nsamples, None)
+    cached_inputs = cache_attention_inputs(
+        model=model,
+        dataloader=data_loader,
+        device=device,
+        nsamples=nsamples,
+        layer_prefix=None,
+    )
     buffer = [b[0] for b in cached_inputs.pop("inputs")]
     for layer in model.model.layers:
         buffer = execute_offloaded_module(


### PR DESCRIPTION
`target_ids` was deprecated in a previous PR #1804 ; in hindsight it would be nicer to make it optional to allow easier transition for users(credits to @anmarques). This PR does that. With this change older recipes (with target_ids specified) would also work and log a warning saying this param is deprecated and would be removed completely in a future release. 

The same test was run as in #1804 and same results were observed