### PR TITLE
Change Transformers export default sequence length to max_position_embeddings

### DIFF
--- a/src/sparseml/transformers/export.py
+++ b/src/sparseml/transformers/export.py
@@ -297,7 +297,9 @@ def export_transformer_to_onnx(
     )
 
     if sequence_length is None:
-        _LOGGER.info(f"Using default sequence length of {config.max_position_embeddings}")
+        _LOGGER.info(
+            f"Using default sequence length of {config.max_position_embeddings}"
+        )
         sequence_length = config.max_position_embeddings
 
     tokenizer = AutoTokenizer.from_pretrained(

--- a/src/sparseml/transformers/export.py
+++ b/src/sparseml/transformers/export.py
@@ -40,8 +40,9 @@ optional arguments:
                         Path to directory where model files for weights,
                         config, and tokenizer are stored
   --sequence_length SEQUENCE_LENGTH
-                        Sequence length to use. Default is 384. Can be
-                        overwritten later
+                        Sequence length to use. Default is
+                        `config.max_position_embeddings`. Can be overwritten
+                        later
   --no_convert_qat      Set flag to not perform QAT to fully quantized
                         conversion after export
   --finetuning_task FINETUNING_TASK
@@ -238,7 +239,7 @@ def load_task_dataset(
 def export_transformer_to_onnx(
     task: str,
     model_path: str,
-    sequence_length: int = 384,
+    sequence_length: Optional[int] = None,
     convert_qat: bool = True,
     finetuning_task: Optional[str] = None,
     onnx_file_name: str = MODEL_ONNX_NAME,
@@ -294,6 +295,11 @@ def export_transformer_to_onnx(
         trust_remote_code=trust_remote_code,
         **config_args,
     )
+
+    if sequence_length is None:
+        _LOGGER.info(f"Using default sequence length of {config.max_position_embeddings}")
+        sequence_length = config.max_position_embeddings
+
     tokenizer = AutoTokenizer.from_pretrained(
         model_path, model_max_length=sequence_length
     )
@@ -514,8 +520,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--sequence_length",
         type=int,
-        default=384,
-        help="Sequence length to use. Default is 384. Can be overwritten later",
+        default=None,
+        help=(
+            "Sequence length to use. Default is `config.max_position_embeddings`. "
+            "Can be overwritten later"
+        ),
     )
     parser.add_argument(
         "--no_convert_qat",
@@ -579,7 +588,7 @@ def _parse_args() -> argparse.Namespace:
 def export(
     task: str,
     model_path: str,
-    sequence_length: int,
+    sequence_length: Optional[int],
     no_convert_qat: bool,
     finetuning_task: str,
     onnx_file_name: str,

--- a/src/sparseml/transformers/sparsification/obcq/export.py
+++ b/src/sparseml/transformers/sparsification/obcq/export.py
@@ -40,8 +40,9 @@ optional arguments:
                         Path to directory where model files for weights,
                         config, and tokenizer are stored
   --sequence_length SEQUENCE_LENGTH
-                        Sequence length to use. Default is 384. Can be
-                        overwritten later
+                        Sequence length to use. Default is
+                        `config.max_position_embeddings`. Can be overwritten
+                        later
   --no_convert_qat      Set flag to not perform QAT to fully quantized
                         conversion after export
   --onnx_file_name ONNX_FILE_NAME
@@ -304,7 +305,7 @@ def load_task_dataset(
 def export_transformer_to_onnx(
     task: str,
     model_path: str,
-    sequence_length: int = 384,
+    sequence_length: Optional[int] = None,
     convert_qat: bool = True,
     onnx_file_name: str = MODEL_ONNX_NAME,
     num_export_samples: int = 0,
@@ -353,6 +354,10 @@ def export_transformer_to_onnx(
         trust_remote_code=trust_remote_code,
         **config_args,
     )
+
+    if sequence_length is None:
+        sequence_length = config.max_position_embeddings
+
     tokenizer = AutoTokenizer.from_pretrained(
         model_path, model_max_length=sequence_length
     )
@@ -543,8 +548,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--sequence_length",
         type=int,
-        default=384,
-        help="Sequence length to use. Default is 384. Can be overwritten later",
+        default=None,
+        help=(
+            "Sequence length to use. Default is `config.max_position_embeddings`. "
+            "Can be overwritten later"
+        ),
     )
     parser.add_argument(
         "--no_convert_qat",
@@ -586,7 +594,7 @@ def _parse_args() -> argparse.Namespace:
 def export(
     task: str,
     model_path: str,
-    sequence_length: int,
+    sequence_length: Optional[int],
     no_convert_qat: bool,
     onnx_file_name: str,
     num_export_samples: int = 0,


### PR DESCRIPTION
## Usage

```
sparseml.transformers.export_onnx --model_path ./TinyLlama-1.1B-Chat-v0.3 --task text-generation --trust_remote_code 
2023-11-13 18:56:23 sparseml.transformers.export INFO     Attempting onnx export for model at /home/mgoin/models/TinyLlama-1.1B-Chat-v0.3 for task text-generation
2023-11-13 18:56:23 sparseml.transformers.export INFO     Using default sequence length of 2048
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
```


## Reason

Unfortunately I think it is very important to export LLMs with the largest sequence length possible.

For instance I was exporting llama models with a sequence length of 512 for convenience
`sparseml.transformers.export_onnx --model_path ./llama2.c-stories15M --task text-generation --sequence_length 512 `
However due to the PyTorch export and constant folding it seems to produce a cached, fixed rotary embedding of the sequence length used. See it as 512 in this screenshot. The ONNX can still run and compile with a sequence length larger than 512, but the output is unstable and quickly starts to repeat

![Screenshot 2023-11-08 at 7 09 36 PM](https://github.com/neuralmagic/sparseml/assets/3195154/d3ef99cb-709a-4439-9ff6-cd534beb1cc6)