### PR TITLE
[OBCQ Bug Fix] Fallback to CPU if no CUDA

### DIFF
--- a/src/sparseml/modifiers/obcq/utils/sparsegpt.py
+++ b/src/sparseml/modifiers/obcq/utils/sparsegpt.py
@@ -199,7 +199,8 @@ class SparseGPT:
                 _LOGGER.debug(torch.sum((self.layer(self._inp1) - self.out1) ** 2))
                 _LOGGER.debug(torch.sum(Losses))
 
-        torch.cuda.synchronize()
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
         _LOGGER.info("time %.2f" % (time.time() - tick))
         _LOGGER.info("error %.2f" % torch.sum(Losses).item())
 

--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -74,6 +74,7 @@ def one_shot(
 
     # fallback to cpu if cuda not available
     device = _fallback_to_cpu(device)
+    _LOGGER.info(f"Running one_shot on device {device}")
 
     # Load the configuration from the model path
     config = AutoConfig.from_pretrained(model_path)

--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -153,7 +153,7 @@ def _save(model, tokenizer, save_path, recipe_path):
 
 def _fallback_to_cpu(device):
     if "cuda" in device and not torch.cuda.is_available():
-        _LOGGER.info(
+        _LOGGER.warning(
             f"Requested {device} but CUDA is not available, falling back to CPU"
         )
         return "cpu"

--- a/src/sparseml/transformers/sparsification/obcq/utils/helpers.py
+++ b/src/sparseml/transformers/sparsification/obcq/utils/helpers.py
@@ -42,6 +42,7 @@ def opt_forward(model: Module, data_loader: List, device: str, nsamples: int = N
         dataloader=data_loader,
         device=device,
         nsamples=nsamples,
+        target_ids=["attention_mask"],
         layer_prefix="decoder",
     )
     buffer = [b[0] for b in cached_inputs.pop("inputs")]
@@ -95,6 +96,7 @@ def llama_forward(model: Module, data_loader: List, device: str, nsamples: int =
         dataloader=data_loader,
         device=device,
         nsamples=nsamples,
+        target_ids=["attention_mask", "position_ids"],
         layer_prefix=None,
     )
     buffer = [b[0] for b in cached_inputs.pop("inputs")]

--- a/tests/sparseml/transformers/obcq/test_obcq.py
+++ b/tests/sparseml/transformers/obcq/test_obcq.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+import torch
 
 from sparseml.modifiers.obcq.utils.helpers import ppl_eval_general
 from sparseml.transformers.data import TransformersDataset
@@ -30,6 +31,8 @@ from sparseml.transformers.sparsification.obcq.utils.helpers import llama_forwar
 def test_obcq_tinystories(recipe_file_path):
     tiny_model_path = "Xenova/llama2.c-stories15M"
     device = "cuda:0"
+    if not torch.cuda.is_available():
+        device = "cpu"
 
     # test recipe with 50% sparsity, quantization and smoothquant
     tiny_model = one_shot(


### PR DESCRIPTION
`tests.sparseml.transformers.obcq.test_obcq` was failing on Jenkins due to CUDA not being available, this PR updates the OBCQ script to fall back to CPU if CUDA is unavailable. The model used in this test is very small, so it still runs quickly enough on CPU.

Also fixes a small bug in the perplexity calculations in the OBCQ script caused by the recent `target_ids` change

### Testing 
```
export CUDA_VISIBLE_DEVICES=[]
pytest tests/sparseml/transformers/obcq/test_obcq.py
```
Output:
```
WARNING    sparseml.transformers.sparsification.obcq.obcq:obcq.py:156 Requested cuda:0 but CUDA is not available, falling back to CPU
.....
tests/sparseml/transformers/obcq/test_obcq.py::test_obcq_tinystories[tests/sparseml/transformers/obcq/test_tiny.yaml] PASSED                                                                     [ 50%]
tests/sparseml/transformers/obcq/test_obcq.py::test_obcq_tinystories[tests/sparseml/transformers/obcq/test_tiny2.yaml] PASSED                                                                    [100%]
```