### PR TITLE
Pass Device to SmoothQuant

### DIFF
--- a/src/sparseml/modifiers/smoothquant/pytorch.py
+++ b/src/sparseml/modifiers/smoothquant/pytorch.py
@@ -127,6 +127,7 @@ class SmoothQuantModifierPyTorch(SmoothQuantModifier):
             calibration_dataloader,
             self.num_calibration_steps,
             self.calibration_function,
+            self.device_,
         )
 
         # remove the hooks now that we are done calibrating


### PR DESCRIPTION
Fix for a bug that caused smoothquant the run on the CPU, the device was not being passed to the calibration function properly