### PR TITLE
fix flaky topkast test

### DIFF
--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
@@ -173,14 +173,14 @@ class TestTopKASTPruningModifier(ScheduledModifierTest):
                     modifier._module_masks._params[i][forward_mask],
                     layer_weights_pre._params[i][forward_mask] * (1 - 0.0002 * 0.25),
                     atol=1e-5,
-                    equal_nan=True
+                    equal_nan=True,
                 )
                 assert torch.allclose(
                     modifier._module_masks._params[i][backward_mask],
                     layer_weights_pre._params[i][backward_mask]
                     * (1 - 0.0002 * 0.25 * 1 / modifier._forward_sparsity),
                     atol=1e-5,
-                    equal_nan=True
+                    equal_nan=True,
                 )
 
             optimizer.step()

--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
@@ -19,6 +19,7 @@ import torch
 from torch.nn import Module
 from torch.optim import SGD, Adam
 
+from flaky import flaky
 from sparseml.pytorch.sparsification.pruning import TopKASTPruningModifier
 from tests.sparseml.pytorch.helpers import LinearNet
 from tests.sparseml.pytorch.sparsification.pruning.helpers import (
@@ -124,6 +125,7 @@ class TestTopKASTPruningModifier(ScheduledModifierTest):
             assert not modifier.update_ready(epoch, test_steps_per_epoch)
             _test_compression_sparsity_applied()
 
+    @flaky(max_runs=3, min_passes=2)
     def test_weight_decay(
         self,
         modifier_lambda,
@@ -170,11 +172,15 @@ class TestTopKASTPruningModifier(ScheduledModifierTest):
                 assert torch.allclose(
                     modifier._module_masks._params[i][forward_mask],
                     layer_weights_pre._params[i][forward_mask] * (1 - 0.0002 * 0.25),
+                    atol=1e-5,
+                    equal_nan=True
                 )
                 assert torch.allclose(
                     modifier._module_masks._params[i][backward_mask],
                     layer_weights_pre._params[i][backward_mask]
                     * (1 - 0.0002 * 0.25 * 1 / modifier._forward_sparsity),
+                    atol=1e-5,
+                    equal_nan=True
                 )
 
             optimizer.step()


### PR DESCRIPTION
This one test fails a lot because of the randomly initialized matrices. So some ways to ease this:

- greater fault tolerance in computations
- make nan = nan
- mark test as flaky

Tested this a bunch locally, seems to consistently pass now.