### PR TITLE
[Fix] Failing `test_save_zoo_directory` tests

### DIFF
--- a/tests/sparseml/transformers/utils/test_helpers.py
+++ b/tests/sparseml/transformers/utils/test_helpers.py
@@ -32,6 +32,7 @@ def test_save_zoo_directory(stub, tmp_path_factory):
     zoo_model = Model(stub, path_to_training_outputs)
     zoo_model.download()
 
+    zoo_model.deployment_tar.unzip()
     zoo_model.sample_inputs.unzip()
     zoo_model.sample_outputs["framework"].unzip()
 


### PR DESCRIPTION
In the recent SparseZoo changes we have altered the behavior of `Model.download()`. Now it only downloads the `deployment.tar`, but does not unzip it. So we have to manually call the `.unzip()` method to get the expected result.