### PR TITLE
[Fix]"ValueError: scheme_overrides contains submodule names or module types that do not match to any submodules in the model" when using mpt model in sparseml.transformers.export_onnx

### DIFF
--- a/src/sparseml/transformers/export.py
+++ b/src/sparseml/transformers/export.py
@@ -340,7 +340,7 @@ def export_transformer_to_onnx(
         applied = trainer.apply_manager(epoch=math.inf, checkpoint=None)
     except ValueError as e:
         raise ValueError(
-            f"Failed to applied the recipy to the "
+            f"Failed to apply the recipe to the "
             f"model with the exception message:\n{e}\n"
             "It is possible, that there are missing modules "
             "specific to the model, that were not properly loaded. "

--- a/src/sparseml/transformers/export.py
+++ b/src/sparseml/transformers/export.py
@@ -328,8 +328,16 @@ def export_transformer_to_onnx(
         recipe_args=None,
         teacher=None,
     )
-
-    applied = trainer.apply_manager(epoch=math.inf, checkpoint=None)
+    try:
+        applied = trainer.apply_manager(epoch=math.inf, checkpoint=None)
+    except ValueError as e:
+        raise ValueError(
+            f"Failed to applied the recipy to the "
+            f"model with the exception message:\n{e}\n"
+            "It is possible, that there are missing modules "
+            "specific to the model, that were not properly loaded. "
+            "A possible solution would be setting the --trust_remote_code flag"
+        )
 
     if not applied:
         _LOGGER.warning(


### PR DESCRIPTION
Fix for: https://app.asana.com/0/1205724081986514/1205917069172910

The possible solution was either to catch the error or set --trust_remote_code flag True by default. I like the first solution much better. It is verbose, indicates where the error has occurred, and most importantly, does not work against the user's assumptions (HF has gotten us used to having this flag set to False by default).

When I get the buy-in from the stakeholders, I will also cherry-pick this to 1.6.