### PR TITLE
 "AttributeError: 'torch._C.Value' object has no attribute 'float'" sparseml.transformers.export_onnx for zoo:bert-base_cased-squad_wikipedia_bookcorpus-pruned80.4block_quantized

### DIFF
--- a/src/sparseml/pytorch/utils/exporter.py
+++ b/src/sparseml/pytorch/utils/exporter.py
@@ -460,7 +460,7 @@ def export_onnx(
         https://pytorch.org/docs/stable/onnx.html
     """
     if _PARSED_TORCH_VERSION >= version.parse("1.10.0") and opset < 13 and convert_qat:
-        warnings.warn(
+        raise ValueError(
             "Exporting onnx with QAT and opset < 13 may result in errors. "
             "Please use opset>=13 with QAT. "
             "See https://github.com/pytorch/pytorch/issues/77455 for more info. "


### PR DESCRIPTION
Fix for: https://app.asana.com/0/1205724081986514/1205939749138533