### PR TITLE
[transforms] change flattenqparams assertion to check

### DIFF
--- a/src/sparseml/exporters/transforms/flatten_qparams.py
+++ b/src/sparseml/exporters/transforms/flatten_qparams.py
@@ -50,7 +50,8 @@ class FlattenQParams(OnnxTransform):
                 continue
             self.log_match(init)
             a = numpy_helper.to_array(init)
-            assert a.shape == (1,)
+            if a.shape != (1,):
+                continue  # assume qparam is already flattened
             b = numpy.array(a[0])
             assert b.shape == ()
             assert b.dtype == a.dtype


### PR DESCRIPTION
the assertion removed in this PR is not needed since if the qparam is not (1,) we don't need to flatten it. this can lead to unwanted assertions if/when the export format changes