### PR TITLE
[Fix] Inferring a default sequence length during transformers export

### DIFF
--- a/src/sparseml/transformers/export.py
+++ b/src/sparseml/transformers/export.py
@@ -297,10 +297,20 @@ def export_transformer_to_onnx(
     )
 
     if sequence_length is None:
+        if hasattr(config, "max_position_embeddings"):
+            sequence_length = config.max_position_embeddings
+        elif hasattr(config, "max_seq_len"):
+            sequence_length = config.max_seq_len
+        else:
+            raise ValueError(
+                "Could not infer a default sequence length "
+                "from the HF transformers config. Please specify "
+                "a sequence length with --sequence_length"
+            )
         _LOGGER.info(
-            f"Using default sequence length of {config.max_position_embeddings}"
+            f"Using default sequence length of {sequence_length} "
+            "(inferred from HF transformers config) "
         )
-        sequence_length = config.max_position_embeddings
 
     tokenizer = AutoTokenizer.from_pretrained(
         model_path, model_max_length=sequence_length


### PR DESCRIPTION
This PR: https://github.com/neuralmagic/sparseml/pull/1826 has added new functionality so that when no `sequence_length` is being specified, we are defaulting to a max sequence length from the config. Unfortunately, as pointed out in the PR comments, not only an HF config is not guaranteed to have `max_position_embeddings` attribute, but this information can be present under a different key value.
E.g
For the model `TinyLlama-1.1B-Chat-v0.3` we are looking at `config.max_position_embeddings`
For the model `zoo:mpt-7b-mpt_chat_mpt_pretrain-pruned80_quantized` we are looking at `config.max_seq_len`

This PR:
1) Adds `max_seq_len` to the set of config attributes that may be potentially used to infer the default sequence_length
2) Adds the behaviour that raises a ValueError if we are not able to infer the default sequence_length (the user should specify it manually then)