### PR TITLE
Fix flaky Top-KAST test by imposing numerical stability (smaller lr, fewer epochs of training)

### DIFF
--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
@@ -179,7 +179,7 @@ class TestTopKASTPruningModifier(ScheduledModifierTest):
                 assert torch.allclose(
                     modifier._module_masks._params[i][backward_mask],
                     layer_weights_pre._params[i][backward_mask]
-                    * (1 - 0.0002 * 0.25 * 1 / modifier._forward_sparsity),
+                    * (1 - 0.0002 * 0.00025 * 1 / modifier._forward_sparsity),
                     atol=1e-5,
                     equal_nan=True,
                 )

--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
@@ -172,7 +172,7 @@ class TestTopKASTPruningModifier(ScheduledModifierTest):
                 )
                 assert torch.allclose(
                     modifier._module_masks._params[i][forward_mask],
-                    layer_weights_pre._params[i][forward_mask] * (1 - 0.0002 * 0.25),
+                    layer_weights_pre._params[i][forward_mask] * (1 - 0.0002 * 0.00025),
                     atol=1e-5,
                     equal_nan=True,
                 )

--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
@@ -125,7 +125,6 @@ class TestTopKASTPruningModifier(ScheduledModifierTest):
             assert not modifier.update_ready(epoch, test_steps_per_epoch)
             _test_compression_sparsity_applied()
 
-    # @pytest.mark.skip(reason="This test is flaky; fix is in progress")
     @flaky(max_runs=3, min_passes=2)
     def test_weight_decay(
         self,

--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
@@ -125,7 +125,7 @@ class TestTopKASTPruningModifier(ScheduledModifierTest):
             assert not modifier.update_ready(epoch, test_steps_per_epoch)
             _test_compression_sparsity_applied()
 
-    @pytest.mark.skip(reason="This test is flaky; fix is in progress")
+    # @pytest.mark.skip(reason="This test is flaky; fix is in progress")
     @flaky(max_runs=3, min_passes=2)
     def test_weight_decay(
         self,

--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_topkast.py
@@ -36,12 +36,12 @@ from tests.sparseml.pytorch.helpers import (  # noqa isort:skip
 
 
 def create_optim_sgd(
-    model: Module, lr: float = 0.25, momentum: float = 0.9, weight_decay: float = 0
+    model: Module, lr: float = 0.00025, momentum: float = 0.9, weight_decay: float = 0
 ) -> SGD:
     return SGD(model.parameters(), lr=lr, momentum=momentum, weight_decay=weight_decay)
 
 
-def create_optim_adam(model: Module, lr: float = 0.25) -> Adam:
+def create_optim_adam(model: Module, lr: float = 0.00025) -> Adam:
     return Adam(model.parameters(), lr=lr)
 
 
@@ -52,8 +52,8 @@ def create_optim_adam(model: Module, lr: float = 0.25) -> Adam:
             forward_sparsity=0.9,
             backward_sparsity=0.5,
             start_epoch=0,
-            end_epoch=20,
-            update_frequency=5,
+            end_epoch=5,
+            update_frequency=2,
             params=["re:.*weight"],
             leave_enabled=True,
             active_weight_decay=0.0002,
@@ -62,8 +62,8 @@ def create_optim_adam(model: Module, lr: float = 0.25) -> Adam:
             forward_sparsity=0.9,
             backward_sparsity=0.5,
             start_epoch=0,
-            end_epoch=20,
-            update_frequency=5,
+            end_epoch=7,
+            update_frequency=3,
             params=["re:.*weight"],
             active_weight_decay=0.0002,
         ),
@@ -71,7 +71,7 @@ def create_optim_adam(model: Module, lr: float = 0.25) -> Adam:
             forward_sparsity=0.8,
             backward_sparsity=0.7,
             start_epoch=6.0,
-            end_epoch=26.0,
+            end_epoch=9.0,
             update_frequency=1,
             params=["re:.*weight"],
             active_weight_decay=0.0002,


### PR DESCRIPTION
Fix flaky Top-Kast test by imposing numerical stability.