### PR TITLE
Fix for NaNs in Smooth Quant

### DIFF
--- a/src/sparseml/modifiers/smoothquant/pytorch.py
+++ b/src/sparseml/modifiers/smoothquant/pytorch.py
@@ -26,6 +26,8 @@ from sparseml.modifiers.utils.pytorch_helpers import run_calibration_forward
 
 _LOGGER = logging.getLogger(__name__)
 
+MINIMUM_ACTIVATION_SCALE = 1e-5
+
 __all__ = ["SmoothQuantModifierPyTorch"]
 
 
@@ -156,6 +158,9 @@ class SmoothQuantModifierPyTorch(SmoothQuantModifier):
             balance_layers = mapping.balance_layers
 
             scales = self._calculate_smoothing_scales(balance_layers, activation_scales)
+            scales = torch.maximum(
+                scales, torch.Tensor([MINIMUM_ACTIVATION_SCALE]).to(scales.device)
+            )
 
             # invert the smoothing in the following layers
             for layer in balance_layers:

--- a/src/sparseml/transformers/utils/model.py
+++ b/src/sparseml/transformers/utils/model.py
@@ -430,12 +430,15 @@ class SparseCausalLM:
 
     @staticmethod
     def opt_model_from_pretrained(
-        model_path: str, torch_dtype: Union[str, torch.dtype] = "auto"
+        model_path: str,
+        sequence_length: Optional[int] = None,
+        torch_dtype: Union[str, torch.dtype] = "auto",
     ) -> torch.nn.Module:
         """
         Load a pretrained OPT model from the specified hugging face path
 
         :param model_path: hugging face or local path to model
+        :param sequence_length: maximum allowable tokens in input sequence
         :param torch_dtype: precision to load model weights in as
         :return: loaded pretrained model
         """
@@ -449,33 +452,22 @@ class SparseCausalLM:
 
         model = OPTForCausalLM.from_pretrained(model_path, torch_dtype=torch_dtype)
         model.eval()
-        model.seqlen = model.config.max_position_embeddings
-        return model
-
-    @staticmethod
-    def llama_model_from_pretrained(
-        model_path: str, torch_dtype: Union[str, torch.dtype] = "auto"
-    ) -> torch.nn.Module:
-        """
-        Load a pretrained Llama model from the specified hugging face path
-
-        :param model_path: hugging face path to model
-        :param torch_dtype: precision to load model weights in as
-        :return: loaded pretrained model
-        """
-        model = LlamaForCausalLM.from_pretrained(model_path, torch_dtype=torch_dtype)
-        model.eval()
-        model.seqlen = model.config.max_position_embeddings
+        model.seqlen = (
+            sequence_length if sequence_length else model.config.max_position_embeddings
+        )
         return model
 
     @staticmethod
     def auto_model_from_pretrained(
-        model_path: str, torch_dtype: Union[str, torch.dtype] = "auto"
+        model_path: str,
+        sequence_length: Optional[int] = None,
+        torch_dtype: Union[str, torch.dtype] = "auto",
     ) -> torch.nn.Module:
         """
         Load a pretrained model using auto from the specified hugging face path
 
         :param model_path: hugging face path to model
+        :param sequence_length: maximum allowable tokens in input sequence
         :param torch_dtype: precision to load model weights in as
         :return: loaded pretrained model
         """
@@ -483,7 +475,9 @@ class SparseCausalLM:
             model_path, torch_dtype=torch_dtype
         )
         model.eval()
-        model.seqlen = model.config.max_position_embeddings
+        model.seqlen = (
+            sequence_length if sequence_length else model.config.max_position_embeddings
+        )
         return model
 
 


### PR DESCRIPTION
Issue first noticed on `teknium/OpenHermes-2.5-Mistral-7B`. When calculating the activation scales, its possible to get a scale of 0, which causes a NaN when trying to apply quantization after smoothing.

The fix is to set a minimum scale to avoid a divide by 0

See slack thread for more info on bug: https://neuralmagic.slack.com/archives/C04SRPGT5MW/p1700515011493959

### Testing
