### PR TITLE
Allow buffers to set modifier's device

### DIFF
--- a/src/sparseml/modifiers/quantization/utils/quantize.py
+++ b/src/sparseml/modifiers/quantization/utils/quantize.py
@@ -234,11 +234,12 @@ def add_output_activation_observers(module: Module):
 
     def get_device(m):
         # infers device based on either paramteres or buffers
-        unique_devices = {p.device for p in m.parameters()} | \
-                            {p.device for p in m.buffers()}
+        unique_devices = {p.device for p in m.parameters()} | {
+            p.device for p in m.buffers()
+        }
 
         assert len(unique_devices) <= 1
-        return next(iter(unique_devices)) if len(unique_devices) > 0 else 'cpu'
+        return next(iter(unique_devices)) if len(unique_devices) > 0 else "cpu"
 
     def _needs_observer(target_module: Module):
         # combines logic from multiple places of original implementation which

--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -234,9 +234,14 @@ def add_output_activation_observers(module: Module):
     # adapted from torch/ao/quantization/quantize.py::_add_observer_
     # source: https://github.com/pytorch/pytorch/blob/v1.13.0/torch/ao/quantization/quantize.py#L135  # noqa: E501
     try:
-        device = next(module.parameters()).device
+        print("FROM INSIDE THE MAIN QUANTIZATION DIR")
+        if len(list(module.parameters())) > 0:
+            device = next(module.parameters()).device
+        elif len(list(module.buffers())) > 0:
+            device = next(module.buffers()).device
     except StopIteration:
         # default to CPU if module has no parameters
+        print("\n\n[WARNING]: Utilizing cpu for this module!!\n\n")
         device = "cpu"
 
     def _needs_observer(target_module: Module):

--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -233,16 +233,13 @@ def add_output_activation_observers(module: Module):
     """
     # adapted from torch/ao/quantization/quantize.py::_add_observer_
     # source: https://github.com/pytorch/pytorch/blob/v1.13.0/torch/ao/quantization/quantize.py#L135  # noqa: E501
-    try:
-        print("FROM INSIDE THE MAIN QUANTIZATION DIR")
-        if len(list(module.parameters())) > 0:
-            device = next(module.parameters()).device
-        elif len(list(module.buffers())) > 0:
-            device = next(module.buffers()).device
-    except StopIteration:
-        # default to CPU if module has no parameters
-        print("\n\n[WARNING]: Utilizing cpu for this module!!\n\n")
-        device = "cpu"
+    def get_device(m):
+        # infers device based on either paramteres or buffers
+        unique_devices = {p.device for p in m.parameters()} | \
+                            {p.device for p in m.buffers()}
+
+        assert len(unique_devices) <= 1
+        return next(iter(unique_devices)) if len(unique_devices) > 0 else 'cpu'
 
     def _needs_observer(target_module: Module):
         # combines logic from multiple places of original implementation which
@@ -280,6 +277,7 @@ def add_output_activation_observers(module: Module):
     def _add_activation_post_process(target_module: Module):
         # get output observer
         output_observer = submodule.qconfig.activation()
+        device = get_device(target_module)
         output_observer.to(device)
 
         # add an activation post process module

--- a/src/sparseml/pytorch/sparsification/quantization/quantize.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantize.py
@@ -235,11 +235,12 @@ def add_output_activation_observers(module: Module):
     # source: https://github.com/pytorch/pytorch/blob/v1.13.0/torch/ao/quantization/quantize.py#L135  # noqa: E501
     def get_device(m):
         # infers device based on either paramteres or buffers
-        unique_devices = {p.device for p in m.parameters()} | \
-                            {p.device for p in m.buffers()}
+        unique_devices = {p.device for p in m.parameters()} | {
+            p.device for p in m.buffers()
+        }
 
         assert len(unique_devices) <= 1
-        return next(iter(unique_devices)) if len(unique_devices) > 0 else 'cpu'
+        return next(iter(unique_devices)) if len(unique_devices) > 0 else "cpu"
 
     def _needs_observer(target_module: Module):
         # combines logic from multiple places of original implementation which


### PR DESCRIPTION
While applying modifiers, we utilize the module's device to set the correct device for the additional modules/buffers like fake quantization modules.
Presently, we default to cpu in case the module doesn't have any parameters. This PR adds the capability to utilize the buffer's device in case there are no parameters in the module. The change is based on PyTorch's latest implementation from which the `get_device` function is adapted from.