### PR TITLE
[Fix] Adapt to the newest SparseZoo interface (and get GHA green again)

### DIFF
--- a/tests/sparseml/onnx/helpers.py
+++ b/tests/sparseml/onnx/helpers.py
@@ -67,8 +67,7 @@ def onnx_repo_models(request) -> OnnxRepoModelFixture:
             model.sample_inputs.unzip()
         input_paths = model.sample_inputs.path
     if model.sample_outputs is not None:
-        if not model.sample_outputs["framework"].files:
-            model.sample_outputs["framework"].unzip()
+
         output_paths = model.sample_outputs["framework"].path
 
     return OnnxRepoModelFixture(model_path, model_name, input_paths, output_paths)

--- a/tests/sparseml/pytorch/image_classification/utils/test_helpers.py
+++ b/tests/sparseml/pytorch/image_classification/utils/test_helpers.py
@@ -33,13 +33,6 @@ def test_save_zoo_directory(stub, tmp_path_factory):
     zoo_model = Model(stub, path_to_training_outputs)
     zoo_model.download()
 
-    zoo_model.sample_labels.unzip()
-    zoo_model.sample_inputs.unzip()
-    zoo_model.sample_outputs["framework"].unzip()
-
-    # download deployment directory
-    zoo_model.deployment_directory_path
-
     save_zoo_directory(
         output_dir=save_dir,
         training_outputs_dir=path_to_training_outputs,

--- a/tests/sparseml/transformers/utils/test_helpers.py
+++ b/tests/sparseml/transformers/utils/test_helpers.py
@@ -32,10 +32,6 @@ def test_save_zoo_directory(stub, tmp_path_factory):
     zoo_model = Model(stub, path_to_training_outputs)
     zoo_model.download()
 
-    zoo_model.deployment_tar.unzip()
-    zoo_model.sample_inputs.unzip()
-    zoo_model.sample_outputs["framework"].unzip()
-
     save_zoo_directory(
         output_dir=save_dir,
         training_outputs_dir=path_to_training_outputs,


### PR DESCRIPTION
Due to those changes: https://github.com/neuralmagic/sparsezoo/pull/389 we need to update the relevant pathways.