### PR TITLE
OBCQ Test Fix

### DIFF
--- a/tests/sparseml/transformers/obcq/test_obcq.py
+++ b/tests/sparseml/transformers/obcq/test_obcq.py
@@ -75,7 +75,7 @@ def test_lm_head_target():
     if not torch.cuda.is_available():
         device = "cpu"
 
-    model = SparseCausalLM.llama_model_from_pretrained(tiny_model_path)
+    model = SparseCausalLM.auto_model_from_pretrained(tiny_model_path)
     modifiable_model = ModifiableModel(model=model, framework=Framework.pytorch)
 
     kwargs = {


### PR DESCRIPTION
A previous PR removed the llama-specific loading function, replacing it with an AutoModel load. This PR updates a unit test to reflect the change