### PR TITLE
Misc Finetuning Checkpointing Fixes

### DIFF
--- a/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
+++ b/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
@@ -8,7 +8,7 @@ fsdp_config:
   fsdp_cpu_ram_efficient_loading: false
   fsdp_forward_prefetch: false
   fsdp_offload_params: false
-  fsdp_sharding_strategy: 2
+  fsdp_sharding_strategy: 1
   fsdp_state_dict_type: SHARDED_STATE_DICT
   fsdp_sync_module_states: true
   fsdp_transformer_layer_cls_to_wrap: LlamaDecoderLayer

--- a/src/sparseml/modifiers/distillation/output/pytorch.py
+++ b/src/sparseml/modifiers/distillation/output/pytorch.py
@@ -16,7 +16,7 @@ from typing import Any, Dict
 
 import torch
 from torch.nn import Module
-
+from torch.distributed.fsdp import FullyShardedDataParallel
 from sparseml.core import Event, EventType, State
 from sparseml.modifiers.distillation.output.base import OutputDistillationModifier
 from sparseml.modifiers.distillation.utils.pytorch import KDFactory, KDModuleWrapper
@@ -27,6 +27,7 @@ __all__ = ["OutputDistillationModifierPyTorch"]
 
 class OutputDistillationModifierPyTorch(OutputDistillationModifier):
     wrappers_: Dict[str, Any] = None
+    fsdp_active_: bool = False
 
     def on_initialize(self, state: State, **kwargs) -> bool:
         if (
@@ -37,6 +38,8 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
             return False
 
         self.wrappers_ = {}
+        if kwargs.get("fsdp_active"):
+            self.fsdp_active_ = True
 
         for target in (
             self.targets if isinstance(self.targets, list) else [self.targets]
@@ -165,4 +168,5 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
             projections=projections,
             transforms=transforms,
             comparison=comparison,
+            fsdp_active=self.fsdp_active_
         )

--- a/src/sparseml/modifiers/distillation/output/pytorch.py
+++ b/src/sparseml/modifiers/distillation/output/pytorch.py
@@ -16,7 +16,7 @@ from typing import Any, Dict
 
 import torch
 from torch.nn import Module
-from torch.distributed.fsdp import FullyShardedDataParallel
+
 from sparseml.core import Event, EventType, State
 from sparseml.modifiers.distillation.output.base import OutputDistillationModifier
 from sparseml.modifiers.distillation.utils.pytorch import KDFactory, KDModuleWrapper
@@ -94,7 +94,7 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
 
     def on_start(self, state: State, event: Event, **kwargs):
         for wrapper in self.wrappers_.values():
-            wrapper.kdenabled_ = True
+            wrapper.kdenabled = True
 
     def on_update(self, state: State, event: Event, **kwargs):
         if event.type_ == EventType.LOSS_CALCULATED and event.should_update(
@@ -110,7 +110,7 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
 
     def on_end(self, state: State, event: Event, **kwargs):
         for wrapper in self.wrappers_.values():
-            wrapper.kdenabled_ = False
+            wrapper.kdenabled = False
 
     def _create_wrapper(
         self, student_layer: Module, teacher_layer: Module, state: State
@@ -168,5 +168,5 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
             projections=projections,
             transforms=transforms,
             comparison=comparison,
-            fsdp_active=self.fsdp_active_
+            fsdp_active=self.fsdp_active_,
         )

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -141,7 +141,7 @@ class SessionManagerMixIn:
             train_data=train_data,
             start=epoch,
             copy_data=False,
-            fsdp_active = self.is_fsdp_enabled
+            fsdp_active=self.is_fsdp_enabled,
         )
         self.accelerator.wait_for_everyone()
 
@@ -402,6 +402,9 @@ class SessionManagerMixIn:
                 save_function=self.accelerator.save,
                 state_dict=state_dict,
             )
+
+        self.save_state()
+        self.save_optimizer_and_scheduler(output_dir)
 
         # save recipe, will contain modifiers from the model's original recipe as well
         # as those added from self.recipe

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -275,9 +275,8 @@ def train(checkpoint: str, output_dir: str, train_dataset: Dataset, trainer: Tra
     trainer.log_metrics("train", metrics)
     trainer.save_metrics("train", metrics)
 
+    # this includes saving the state, optimizer and scheduler
     trainer.save_model()
-    trainer.save_state()
-    trainer.save_optimizer_and_scheduler(output_dir)
 
 
 def evaluate(eval_dataset: Dataset, trainer: Trainer):

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -143,7 +143,7 @@ def main(
 
     # Detecting last checkpoint.
     last_checkpoint = detect_last_checkpoint(training_args)
-    model_path = model_args.model_name_or_path
+    model_path = last_checkpoint or model_args.model_name_or_path
 
     # Set seed before initializing model.
     set_seed(training_args.seed)
@@ -170,7 +170,7 @@ def main(
     }
     # this calls from_pretrained under the hood so should be FSDP safe
     model, teacher = SparseAutoModel.text_generation_from_pretrained_distil(
-        model_name_or_path=model_args.model_name_or_path,
+        model_name_or_path=model_path,
         teacher_name_or_path=training_args.distill_teacher,
         model_kwargs=model_kwargs,
         teacher_kwargs=teacher_kwargs,
@@ -178,11 +178,14 @@ def main(
 
     # initialize structure of input model from recipe if needed
     recipe_path = os.path.join(model_path, "recipe.yaml")
-    if not os.path.exists(recipe_path):
-        _LOGGER.warning(f"No recipes were applied for {model_path}.")
+    if last_checkpoint is not None and training_args.recipe is None:
+        training_args.recipe = recipe_path  # continue from checkpoint recipe
     else:
-        _LOGGER.warning(f"Applying recipe {recipe_path} to {model_path}")
-        apply_recipe_structure_to_model(model, recipe_path, model_path)
+        if not os.path.exists(recipe_path):
+            _LOGGER.warning(f"No recipes were applied for {model_path}.")
+        else:
+            _LOGGER.warning(f"Applying recipe {recipe_path} to {model_path}")
+            apply_recipe_structure_to_model(model, recipe_path, model_path)
 
     # Load tokenizer
     # distill TODO: support for different tokenizer for teacher?

--- a/src/sparseml/transformers/finetune/trainer.py
+++ b/src/sparseml/transformers/finetune/trainer.py
@@ -108,20 +108,6 @@ class Trainer(SessionManagerMixIn, HFTransformersTrainer):
             self.state.best_metric = None
             self.state.best_model_checkpoint = None
 
-    def _load_optimizer_and_scheduler(self, checkpoint):
-        """
-        Override the Transformers Trainer so that optimizer, scheduler and scaler could
-        be loaded also from the input model folder, which is our use case (instead of
-        only from a separate checkpoint folder).
-        """
-        # We include the model path as where the optimizer and scheduler could be loaded
-        # (in addition to checkpoint folders)
-        model_folder = checkpoint if checkpoint is not None else self.model_state_path
-        if not os.path.isfile(os.path.join(model_folder, OPTIMIZER_NAME)):
-            return
-
-        super()._load_optimizer_and_scheduler(model_folder)
-
     def _dummy_lr_scheduler(self):
         return torch.optim.lr_scheduler.MultiplicativeLR(
             self.optimizer,


### PR DESCRIPTION
### Summary of Changes
This PR contains a few bug fixes for finetuning, mostly related to checkpoints
* Adding logic to `kd_wrapper.py` to determine if `named_modules` should return the full module or just the student. This varys based on when it is called (see comments)
* Expand the `SessionMixIn.save_model` function to export the resulting model as a single bin, this allows it to be reloaded outside of FSDP. 
* Cleaning up checkpoint logic to use the input recipe if we're resuming from a checkpoint
* Only update the loss if a modifier returns a non-None loss value (the previous distillation merge had broken non-distillation loss calculation)

### Testing
Tested saving and reloading checkpoints works with and without FSDP

### Remaining Issues
Resuming an FSDP checkpoint outside of FSDP still doesn't work out of the box. You need to treat the checkpoint directory as a new input directory rather than a checkpoint (which throws off the epoch start)