### PR TITLE
[One Shot] Default to AutoModel loading in OBCQ script

### DIFF
--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -94,7 +94,13 @@ def one_shot(
         model_loader_fn = SparseCausalLM.auto_model_from_pretrained
         forward_fn = llama_forward
     else:
-        raise ValueError(f"model_path={model_path} should be one of {SUPPORTED_MODELS}")
+        _LOGGER.warning(
+            f"A supported model type({SUPPORTED_MODELS}) could not be "
+            f"parsed from model_path={model_path}. Defaulting to "
+            "AutoModelForCausalLM loading. "
+        )
+        model_loader_fn = SparseCausalLM.auto_model_from_pretrained
+        forward_fn = llama_forward
     torch_dtype = _parse_dtype(precision)
     model = model_loader_fn(
         model_path, sequence_length=sequence_length, torch_dtype=torch_dtype


### PR DESCRIPTION
Previously the OBCQ script would return with an error if one of the supported/tested model types wasn't found in the name of the `--model_path` argument. 

With this PR, instead of erroring out we just return a warning to the user and attempt to load the model with `AutoModelForCausalLM` anway.

### Testing
```
src/sparseml/transformers/sparsification/obcq/obcq.py model_path=sahil2801/replit-code-instruct-glaive open_platypus --recipe tests/sparseml/transformers/obcq/test_tiny.yaml --save True
```

The model successfully loads with a warning. One-Shot does fail for this model, will address that in another PR since its MPT-specific

Asana ticket: https://app.asana.com/0/1205229323407165/1206141086244198/f