### PR TITLE
Fix Circular Import in Old Trainer

### DIFF
--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -39,7 +39,6 @@ from transformers.trainer_callback import TrainerState
 from transformers.trainer_pt_utils import reissue_pt_warnings
 from transformers.trainer_utils import ShardedDDPOption, get_last_checkpoint
 
-from sparseml.pytorch.model_load.helpers import RECIPE_FILE_NAME
 from sparseml.pytorch.optim import ScheduledModifierManager, ScheduledOptimizer
 from sparseml.pytorch.sparsification.quantization.helpers import (
     initialize_channel_wise_scale_zp,
@@ -51,6 +50,7 @@ from sparseml.pytorch.utils import (
     WANDBLogger,
 )
 from sparseml.transformers.utils import SparseAutoModel
+from sparseml.transformers.utils.helpers import RECIPE_NAME
 
 
 __all__ = [
@@ -464,7 +464,7 @@ class RecipeManagerTrainerInterface:
         if output_dir is None:
             output_dir = self.args.output_dir
 
-        recipe_path = os.path.join(output_dir, RECIPE_FILE_NAME)
+        recipe_path = os.path.join(output_dir, RECIPE_NAME)
         if self.arch_manager:
             composed_manager = ScheduledModifierManager.compose_staged(
                 base_recipe=str(self.arch_manager),
@@ -634,7 +634,7 @@ class RecipeManagerTrainerInterface:
                 f"and metadata {self.metadata}"
             )
 
-        arch_recipe = os.path.join(self.model_state_path, RECIPE_FILE_NAME)
+        arch_recipe = os.path.join(self.model_state_path, RECIPE_NAME)
         if os.path.isfile(arch_recipe):
             arch_manager = ScheduledModifierManager.from_yaml(arch_recipe)
             _LOGGER.info(

--- a/src/sparseml/transformers/utils/helpers.py
+++ b/src/sparseml/transformers/utils/helpers.py
@@ -28,7 +28,10 @@ from sparsezoo import setup_model
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-__all__ = ["save_zoo_directory", "detect_last_checkpoint"]
+__all__ = ["RECIPE_NAME", "save_zoo_directory", "detect_last_checkpoint"]
+
+
+RECIPE_NAME = "recipe.yaml"
 
 
 def save_zoo_directory(


### PR DESCRIPTION
importing from `sparseml.pytorch.model_load.helpers` was causing a circular import when launching one-shot, this moves the default recipe definition to avoid the issue