### PR TITLE
[BugFix] `TypeError` with OBCQ

### DIFF
--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -116,7 +116,7 @@ def one_shot(
     dataset = TransformersDataset.load_from_registry(
         dataset_name,
         model=model_path,
-        seqlen=sequence_length,
+        seqlen=sequence_length or model.seqlen,
         nsamples=num_samples,
         seed=0,
         split="train",


### PR DESCRIPTION
A bug was found in obcq.py script where if sequence_length was not supplied, it would cause a TypeError down the line during datset loading.

The bug was potentially introduced in #1872

This PR brings back `model.seqlen` from #1872 and falls back to using that if `sequence_length` is not set:

Test command:
```bash
python src/sparseml/transformers/sparsification/obcq/obcq.py /home/rahul/llama/training c4 --recipe src/sparseml/transformers/sparsification/obcq/example_llama.yaml --eval wikitext2 --nsamples 128 --precision full
```

Error:
```bash
2023-12-13 10:30:23 __main__     INFO     Running one_shot on device cuda:0
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:01<00:00,  1.23it/s]
Repo card metadata block was not found. Setting CardData to empty.
/home/rahul/projects/.venv/lib/python3.11/site-packages/datasets/table.py:1421: FutureWarning: promote has been superseded by mode='default'.
  table = cls._concat_blocks(blocks, axis=0)
Traceback (most recent call last):
  File "/home/rahul/projects/sparseml/src/sparseml/transformers/sparsification/obcq/obcq.py", line 240, in <module>
    one_shot(
  File "/home/rahul/projects/sparseml/src/sparseml/transformers/sparsification/obcq/obcq.py", line 116, in one_shot
    dataset = TransformersDataset.load_from_registry(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/projects/.venv/lib/python3.11/site-packages/sparsezoo/utils/registry.py", line 130, in load_from_registry
    return constructor(**constructor_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/projects/sparseml/src/sparseml/transformers/data/c4.py", line 47, in __init__
    self.create_dataloader(processed_data, join_on=" ")
  File "/home/rahul/projects/sparseml/src/sparseml/transformers/data/base_llm.py", line 70, in create_dataloader
    start_idx = data_idx * self._seqlen
                ~~~~~~~~~^~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```

The error is resolved with this PR