### PR TITLE
Enable One-Shot Launch from Finetuning Script

### DIFF
--- a/src/sparseml/pytorch/model_load/helpers.py
+++ b/src/sparseml/pytorch/model_load/helpers.py
@@ -215,3 +215,19 @@ def fallback_to_cpu(device: str) -> str:
         return "cpu"
 
     return device
+
+
+def parse_dtype(dtype_arg: str) -> torch.dtype:
+    """
+    :param dtype_arg: dtype string to parse
+    :return: torch.dtype parsed from input string
+    """
+    dtype = "auto"  # get precision from model by default
+    if dtype_arg == "half" or dtype_arg == "float16":
+        dtype = torch.float16
+    elif dtype_arg == "bfloat16":
+        dtype = torch.bfloat16
+    elif dtype_arg == "full" or dtype_arg == "float32":
+        dtype = torch.float32
+
+    return dtype

--- a/src/sparseml/pytorch/model_load/helpers.py
+++ b/src/sparseml/pytorch/model_load/helpers.py
@@ -33,6 +33,8 @@ __all__ = [
     "reload_model_state",
     "reload_model_from_checkpoint",
     "save_model_and_recipe",
+    "fallback_to_cpu",
+    "parse_dtype",
 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -182,11 +184,11 @@ def save_model_and_recipe(
     tokenizer: Optional[Any] = None,
 ):
     """
-    Save a model and the loaded recipe to file
+    Save a model, tokenizer and the currently loaded recipe to file
 
     :param model: pytorch model to save
-    :param tokenizer: model tokenizer to save
     :param save_path: path to save output to
+    :param tokenizer: model tokenizer to save
     """
     model.save_pretrained(save_path)
     if tokenizer is not None:
@@ -203,7 +205,7 @@ def save_model_and_recipe(
 
 def fallback_to_cpu(device: str) -> str:
     """
-    Changes device id if cuda is requested and not available by falling back to cpu
+    Takes in a device string and forces it to cpu if cuda is not available
 
     :param device: device id to check
     :return: device modified for CUDA status

--- a/src/sparseml/transformers/finetune/data/data_args.py
+++ b/src/sparseml/transformers/finetune/data/data_args.py
@@ -58,6 +58,10 @@ class DataTrainingArguments:
         default=None,
         metadata={"help": "Optional percentages of each split to download"},
     )
+    num_calibration_samples: Optional[int] = field(
+        default=512,
+        metadata={"help": "Number of samples to use for one-shot calibration"},
+    )
     overwrite_cache: bool = field(
         default=False,
         metadata={"help": "Overwrite the cached preprocessed datasets or not."},

--- a/src/sparseml/transformers/finetune/data/data_helpers.py
+++ b/src/sparseml/transformers/finetune/data/data_helpers.py
@@ -38,7 +38,11 @@ def get_raw_dataset(data_args, cache_dir: Optional[str] = None, **kwargs) -> Dat
 
 
 def make_dataset_splits(
-    tokenized_datasets: Dict[str, Any], do_train: bool, do_eval: bool, do_predict: bool
+    tokenized_datasets: Dict[str, Any],
+    do_train: bool = False,
+    do_eval: bool = False,
+    do_predict: bool = False,
+    do_oneshot: bool = False,
 ) -> Dict[str, Dataset]:
     """
     Restructures the datasets dictionary based on what tasks will be run
@@ -48,6 +52,7 @@ def make_dataset_splits(
     :param do_train: Whether to store the train dataset
     :param do_eval: Whether to store the validation dataset
     :param do_predict: Whether to store the test dataset
+    :param do_oneshot: Whether to store the calibration dataset
     :return: Datasets to be used by the requested tasks
     """
 
@@ -55,7 +60,7 @@ def make_dataset_splits(
     if "all" in tokenized_datasets and len(tokenized_datasets) == 1:
         tokenized_datasets = tokenized_datasets.get("all")
 
-    train_split = eval_split = predict_split = None
+    train_split = eval_split = predict_split = calib_split = None
     if do_train:
         if "train" not in tokenized_datasets:
             raise ValueError("--do_train requires a train dataset")
@@ -68,10 +73,15 @@ def make_dataset_splits(
         if "test" not in tokenized_datasets:
             raise ValueError("--do_predict requires a test dataset")
         predict_split = tokenized_datasets["test"]
+    if do_oneshot:
+        if "calibration" not in tokenized_datasets:
+            raise ValueError("--do_oneshot requires a calibration dataset")
+        calib_split = tokenized_datasets["calibration"]
 
     split_datasets = {
         "train": train_split,
         "validation": eval_split,
         "test": predict_split,
+        "calibration": calib_split,
     }
     return split_datasets

--- a/src/sparseml/transformers/finetune/model_args.py
+++ b/src/sparseml/transformers/finetune/model_args.py
@@ -64,3 +64,7 @@ class ModelArguments:
             "(necessary to use this script with private models)"
         },
     )
+    precision: str = field(
+        default="auto",
+        metadata={"help": "Precision to cast model weights to, default to auto"},
+    )

--- a/src/sparseml/transformers/finetune/runner.py
+++ b/src/sparseml/transformers/finetune/runner.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Optional
+
+from torch.nn import Module
+from transformers import AutoTokenizer
+
+from sparseml.transformers.finetune import Trainer, TrainingArguments
+from sparseml.transformers.finetune.data import TextGenerationDataset
+from sparseml.transformers.finetune.data.data_args import DataTrainingArguments
+from sparseml.transformers.finetune.data.data_helpers import make_dataset_splits
+from sparseml.transformers.finetune.model_args import ModelArguments
+
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+class StageRunner:
+    def __init__(
+        self,
+        data_args: "DataTrainingArguments",
+        model_args: "ModelArguments",
+        training_args: "TrainingArguments",
+        model: Module,
+        teacher: Optional[Module] = None,
+    ):
+        self._data_args = data_args
+        self._model_args = model_args
+        self._training_args = training_args
+
+        self.datasets = {}
+        self.model = model
+        self.teacher = teacher
+        self.trainer = None
+
+    def populate_datasets(self, tokenizer: "AutoTokenizer"):
+        splits = self._data_args.splits
+        tokenized_datasets = {}
+        if self._data_args.splits is None:
+            splits = {"all": None}
+        for split_name, split_str in splits.items():
+            dataset_manager = TextGenerationDataset.load_from_registry(
+                self._data_args.dataset_name,
+                data_args=self._data_args,
+                split=split_str,
+                tokenizer=tokenizer,
+            )
+            raw_dataset = dataset_manager.get_raw_dataset(self._model_args.cache_dir)
+            tokenized_dataset = dataset_manager.tokenize_and_process(raw_dataset)
+            tokenized_datasets[split_name] = tokenized_dataset
+
+        self.datasets = make_dataset_splits(
+            tokenized_datasets,
+            self._training_args.do_train,
+            self._training_args.do_eval,
+            self._training_args.do_predict,
+            self._training_args.do_oneshot,
+        )
+
+    def set_trainer(self, trainer: Trainer):
+        self.trainer = trainer
+
+    def one_shot(self):
+        pass
+
+    def train(self, checkpoint: str):
+        """
+        Run trainer's training loop on train_dataset, saving the resulting model to
+        output_dir
+
+        :param checkpoint: Optional checkpoint to resume from
+        """
+        train_result = self.trainer.train(resume_from_checkpoint=checkpoint)
+        metrics = train_result.metrics
+        metrics["train_samples"] = len(self.datasets["train"])
+        self.trainer.log_metrics("train", metrics)
+        self.trainer.save_metrics("train", metrics)
+
+        # this includes saving the state, optimizer and scheduler
+        self.trainer.save_model()
+
+    def evaluate(self):
+        """
+        Run trainer's evaluation loop on eval_dataset, logging the desired metrics
+        """
+        _LOGGER.info("*** Evaluate ***")
+        metrics = self.trainer.evaluate(self.datasets["validation"])
+
+        metrics["eval_samples"] = len(self.datasets["validation"])
+        self.trainer.log_metrics("eval", metrics)
+        self.trainer.save_metrics("eval", metrics)
+
+    def predict(self):
+        """
+        Run trainer's prediction loop on predict_dataset, logging the desired metrics
+        """
+        _LOGGER.info("*** Predict ***")
+        results = self.trainer.predict(self.dataset["test"])
+        metrics = results.metrics
+
+        metrics["predict_samples"] = len(self.dataset["test"])
+        self.trainer.log_metrics("predict", metrics)
+        self.trainer.save_metrics("predict", metrics)

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -247,7 +247,7 @@ def main(
 
     # One Shot
     if training_args.do_oneshot:
-        stage_runner.oneshot()
+        stage_runner.one_shot()
 
     # Evaluation
     if training_args.do_eval:

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -171,7 +171,7 @@ def main(
         "cache_dir": model_args.cache_dir,
         "revision": model_args.model_revision,
         "use_auth_token": True if model_args.use_auth_token else None,
-        "model_dtype": parse_dtype(model_args.precision),
+        "torch_dtype": parse_dtype(model_args.precision),
     }
     teacher_kwargs = {
         "cache_dir": model_args.cache_dir,

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -32,7 +32,10 @@ from transformers import (
     set_seed,
 )
 
-from sparseml.pytorch.model_load.helpers import apply_recipe_structure_to_model
+from sparseml.pytorch.model_load.helpers import (
+    apply_recipe_structure_to_model,
+    parse_dtype,
+)
 from sparseml.transformers.finetune import Trainer, TrainingArguments
 from sparseml.transformers.finetune.data.data_args import DataTrainingArguments
 from sparseml.transformers.finetune.model_args import ModelArguments
@@ -168,6 +171,7 @@ def main(
         "cache_dir": model_args.cache_dir,
         "revision": model_args.model_revision,
         "use_auth_token": True if model_args.use_auth_token else None,
+        "model_dtype": parse_dtype(model_args.precision),
     }
     teacher_kwargs = {
         "cache_dir": model_args.cache_dir,

--- a/src/sparseml/transformers/finetune/training_args.py
+++ b/src/sparseml/transformers/finetune/training_args.py
@@ -55,3 +55,7 @@ class TrainingArguments(HFTrainingArgs):
         default=None,
         metadata={"help": "Recipe arguments to be overwritten"},
     )
+    do_oneshot: Optional[bool] = field(
+        default=False,
+        metadata={"help": "Whether to run one-shot calibration"},
+    )

--- a/src/sparseml/transformers/finetune/training_args.py
+++ b/src/sparseml/transformers/finetune/training_args.py
@@ -59,3 +59,7 @@ class TrainingArguments(HFTrainingArgs):
         default=False,
         metadata={"help": "Whether to run one-shot calibration"},
     )
+    oneshot_device: Optional[str] = field(
+        default="cuda:0",
+        metadata={"help": "Device to run oneshot calibration on"},
+    )

--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -18,7 +18,6 @@ import os
 from pathlib import Path
 from typing import Optional
 
-import torch
 from torch.nn import Module
 from transformers import AutoConfig
 
@@ -29,6 +28,7 @@ from sparseml.pytorch.model_load.helpers import (
     RECIPE_FILE_NAME,
     apply_recipe_structure_to_model,
     fallback_to_cpu,
+    parse_dtype,
     save_model_and_recipe,
 )
 from sparseml.transformers.data import TransformersDataset
@@ -106,7 +106,7 @@ def one_shot(
         )
         model_loader_fn = SparseCausalLM.auto_model_from_pretrained
         forward_fn = llama_forward
-    torch_dtype = _parse_dtype(precision)
+    torch_dtype = parse_dtype(precision)
     model = model_loader_fn(
         model_path, sequence_length=sequence_length, torch_dtype=torch_dtype
     )
@@ -164,18 +164,6 @@ def one_shot(
         )
 
     return model
-
-
-def _parse_dtype(dtype_arg):
-    dtype = "auto"  # get precision from model by default
-    if dtype_arg == "half" or dtype_arg == "float16":
-        dtype = torch.float16
-    elif dtype_arg == "bfloat16":
-        dtype = torch.bfloat16
-    elif dtype_arg == "full" or dtype_arg == "float32":
-        dtype = torch.float32
-
-    return dtype
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR sets up the finetuning script to be able to launch a one-shot flow. The change log for alternating finetuning was starting to pile up, so wanted to open this as a preliminary PR before adding in the alternating logic.

### Summary of Changes
* Add oneshot path to `text_generation.py` (originally the finetuning script)
* Added `StageRunner` class for managing the different flows (train, eval, oneshot), rather than doing everything inside the entrypoint `text_generation.py` script
* Moved a bunch of helper functions that are now shared between `text_generation.py` and `obcq.py` (Eventually we can probably get rid of the OBCQ script)

### Testing

test_oneshot_recipe.yaml
```
test_stage:
  obcq_modifiers:
    SparseGPTModifier:
      sparsity: 0.5
      block_size: 128
      sequential_update: False
      quantize: False
      percdamp: 0.01
      prunen: 0
      prunem: 0
      targets: [
        "re:model.layers.\\d+$"
      ]
      target_ids: ["attention_mask", "position_ids"]  
```

Test script:
```
def run():
    from sparseml.transformers.finetune.text_generation import run_general
    
    model = "Xenova/llama2.c-stories15M"
    dataset_name = "open_platypus"
    concatenate_data = False
    do_oneshot = True
    output_dir = "./output_oneshot"
    overwrite_output_dir = True
    recipe = "test_oneshot_recipe.yaml"
    splits = {
        "calibration": "train[:90%]",
    }

    run_general(
        model_name_or_path=model,
        dataset_name=dataset_name,
        do_oneshot=do_oneshot,
        output_dir=output_dir,
        overwrite_output_dir=overwrite_output_dir,
        recipe=recipe,
        concatenate_data = concatenate_data,
        splits = splits
    )

if __name__ == "__main__":
    run()
```
