### PR TITLE
[BugFix] magnitude pruning fail

### DIFF
--- a/src/sparseml/modifiers/pruning/utils/pytorch/layer_mask.py
+++ b/src/sparseml/modifiers/pruning/utils/pytorch/layer_mask.py
@@ -157,7 +157,7 @@ class LayerParamMasking(BaseModel):
             return
 
         parameterized_layer = self._masked_layer_params[layer_param_name]
-        mask_name = param_mask_name(parameterized_layer.param_name)
+        mask_name = param_mask_name()
         mask = parameterized_layer.layer.get_buffer(mask_name)
         parameterized_layer.param.data = parameterized_layer.param.data * mask
 
@@ -166,7 +166,7 @@ class LayerParamMasking(BaseModel):
             return
 
         parameterized_layer = self._masked_layer_params[layer_param_name]
-        mask_name = param_mask_name(parameterized_layer.param_name)
+        mask_name = param_mask_name()
         mask = parameterized_layer.layer.get_buffer(mask_name)
 
         if parameterized_layer.param.grad is not None:


### PR DESCRIPTION
Bug:
Magnitude Pruning fails with the following message

```bash
Logging all SparseML modifier-level logs to sparse_logs/18-12-2023_14.52.42.log
2023-12-18 14:52:42 sparseml.core.logger INFO     Logging all SparseML modifier-level logs to sparse_logs/18-12-2023_14.52.42.log
2023-12-18 14:52:42 sparseml.core.recipe.recipe INFO     Loading recipe from file /home/rahul/projects/sparseml/local/recipe.yaml
Traceback (most recent call last):
  File "/home/rahul/projects/sparseml/local/e2e.py", line 101, in <module>
    session.event(event_type=EventType.OPTIM_POST_STEP)
  File "/home/rahul/projects/sparseml/src/sparseml/core/session.py", line 261, in event
    mod_data = self._lifecycle.event(
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/projects/sparseml/src/sparseml/core/lifecycle/session.py", line 146, in event
    data = mod.update_event(state=self.state, event=event, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/projects/sparseml/src/sparseml/core/modifier/stage.py", line 147, in update_event
    modifier.update_event(state, event, **kwargs)
  File "/home/rahul/projects/sparseml/src/sparseml/core/modifier/modifier.py", line 218, in update_event
    self.on_update(state, event, **kwargs)
  File "/home/rahul/projects/sparseml/src/sparseml/modifiers/pruning/magnitude/pytorch.py", line 121, in on_update
    self._update_masks(event)
  File "/home/rahul/projects/sparseml/src/sparseml/modifiers/pruning/magnitude/pytorch.py", line 137, in _update_masks
    self.apply_mask_weight(layer_param_name)
  File "/home/rahul/projects/sparseml/src/sparseml/modifiers/pruning/utils/pytorch/layer_mask.py", line 160, in apply_mask_weight
    mask_name = param_mask_name(parameterized_layer.param_name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: param_mask_name() takes 0 positional arguments but 1 was given
```

This happens because ` param_mask_name()` was updated to take in 0 positional arguments; but some usages in MagnitudePruningModifier were missed

This PR propagates the change to MagnitudePruning

After the change, the script executes withoput errors:

Test script:
```python
from sparseml.core.logger import LoggerManager
import sparseml.core.session as sml
from sparseml.core.framework import Framework
import torchvision
from torchvision import transforms
import torch
from torch.utils.data import DataLoader
import datasets
import os
from torch.optim import Adam
from torch.nn import CrossEntropyLoss
from sparseml.core.event import EventType
from sparseml.core import PythonLogger
import logging

NUM_LABELS = 3
BATCH_SIZE = 32
NUM_EPOCHS = 2
recipe = "/home/rahul/projects/sparseml/local/recipe.yaml"
device = "cuda:0"

# set up SparseML session
sml.create_session()
session = sml.active_session()


# download model
model = torchvision.models.mobilenet_v2(weights=torchvision.models.MobileNet_V2_Weights.DEFAULT)
model.classifier[1] = torch.nn.Linear(model.classifier[1].in_features, NUM_LABELS)
model.to(device)


# download data
beans_dataset = datasets.load_dataset("beans")
train_folder, _ = os.path.split(beans_dataset["train"][0]["image_file_path"])
train_path, _ = os.path.split(train_folder)
val_folder, _ = os.path.split(beans_dataset["validation"][0]["image_file_path"])
val_path, _ = os.path.split(train_folder)


# dataloaders
imagenet_transform = transforms.Compose([
   transforms.Resize(size=256, interpolation=transforms.InterpolationMode.BILINEAR, max_size=None, antialias=None),
   transforms.CenterCrop(size=(224, 224)),
   transforms.ToTensor(),
   transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
])

train_dataset = torchvision.datasets.ImageFolder(
    root=train_path,
    transform=imagenet_transform
)
train_loader = DataLoader(train_dataset, BATCH_SIZE, shuffle=True, pin_memory=True, num_workers=16)

val_dataset = torchvision.datasets.ImageFolder(
    root=val_path,
    transform=imagenet_transform
)
val_loader = DataLoader(val_dataset, BATCH_SIZE, shuffle=False, pin_memory=True, num_workers=16)


# loss and optimizer
criterion = CrossEntropyLoss()
optimizer = Adam(model.parameters(), lr=8e-3)


recipe_args = {}
session_data = session.initialize(
    framework=Framework.pytorch,
    recipe=recipe,
    recipe_args=recipe_args,
    model=model,
    teacher_model=None,
    optimizer=optimizer,
    train_data=train_loader,
    val_data=val_loader,
    start=0.0,
    steps_per_epoch=len(train_loader),
    loggers=LoggerManager(frequency_type="batch"),
)


# loop through batches
for epoch in range(NUM_EPOCHS):
    running_loss = 0.0
    total_correct = 0
    total_predictions = 0
    for step, (inputs, labels) in enumerate(session.state.data.train):
        inputs = inputs.to(device)
        labels = labels.to(device)
        session.state.optimizer.optimizer.zero_grad()
        session.event(event_type=EventType.BATCH_START, batch_data=(inputs, labels))

        outputs = session.state.model.model(inputs)
        loss = criterion(outputs, labels)
        loss.backward()
        session.event(event_type=EventType.LOSS_CALCULATED, loss=loss)

        session.event(event_type=EventType.OPTIM_PRE_STEP)
        session.state.optimizer.optimizer.step()
        session.event(event_type=EventType.OPTIM_POST_STEP)

        running_loss += loss.item()

        predictions = outputs.argmax(dim=1)
        total_correct += torch.sum(predictions == labels).item()
        total_predictions += inputs.size(0)

        session.event(event_type=EventType.BATCH_END)

    loss = running_loss / (step + 1.0)
    accuracy = total_correct / total_predictions
    print("Epoch: {} Loss: {} Accuracy: {}".format(epoch + 1, loss, accuracy))


# finalize session
session.finalize()
```  