### PR TITLE
[Logger Refactor] Frequency Support

### DIFF
--- a/src/sparseml/core/helpers.py
+++ b/src/sparseml/core/helpers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Any, Generator, Optional, Tuple
+from typing import Any, Generator, Optional, Tuple, Union
 
 from sparseml.core.logger import LoggerManager
 from sparseml.core.model.base import ModifiableModel
@@ -54,7 +54,7 @@ def should_log_model_info(
     )
 
 
-def log_model_info(state: State, epoch):
+def log_model_info(state: State, current_log_step):
     """
     Log model level info to the logger
     Relies on `state.model` having a `loggable_items` method
@@ -63,25 +63,28 @@ def log_model_info(state: State, epoch):
     `LoggerManager` instance.
 
     :param state: The current state of sparsification
-    :param epoch: The epoch number to log model info
-        at
+    :param current_log_step: The current log step to log
+        model info at
     """
-    _log_epoch(logger_manager=state.loggers, epoch=epoch)
+    _log_current_step(logger_manager=state.loggers, current_log_step=current_log_step)
     _log_model_loggable_items(
         logger_manager=state.loggers,
         loggable_items=state.model.loggable_items(),
-        epoch=epoch,
+        epoch=current_log_step,
     )
 
 
-def _log_epoch(logger_manager: LoggerManager, epoch: int):
+def _log_current_step(
+    logger_manager: LoggerManager, current_log_step: Union[float, int]
+):
     """
     Log the epoch to the logger_manager
 
     :param logger_manager: The logger manager to log to
-    :param epoch: The epoch to log
+    :param current_log_step: The logging step
     """
-    logger_manager.log_scalar(tag="Epoch", value=float(epoch), step=epoch)
+    tag = logger_manager.frequency_manager.frequency_type
+    logger_manager.log_scalar(tag=tag, value=current_log_step, step=current_log_step)
 
 
 def _log_model_loggable_items(

--- a/src/sparseml/core/helpers.py
+++ b/src/sparseml/core/helpers.py
@@ -29,8 +29,8 @@ __all__ = [
 def should_log_model_info(
     model: ModifiableModel,
     loggers: LoggerManager,
-    epoch: float,
-    last_log_epoch: Optional[float] = None,
+    current_log_step: float,
+    last_log_step: Optional[float] = None,
 ) -> bool:
     """
     Check if we should log model level info
@@ -41,14 +41,16 @@ def should_log_model_info(
 
     :param model: The model whose info we want to log
     :param loggers: The logger manager to log to
-    :param epoch: The current epoch
-    :param last_log_epoch: The last epoch we logged model info at
+    :param current_log_step: The current epoch
+    :param last_log_step: The last step we logged model info at
     :return: True if we should log model level info, False otherwise
     """
     return (
         hasattr(model, "loggable_items")
         and isinstance(loggers, LoggerManager)
-        and loggers.log_ready(epoch=epoch, last_log_epoch=last_log_epoch)
+        and loggers.log_ready(
+            current_log_step=current_log_step, last_log_step=last_log_step
+        )
     )
 
 

--- a/src/sparseml/core/lifecycle/session.py
+++ b/src/sparseml/core/lifecycle/session.py
@@ -143,7 +143,10 @@ class SparsificationLifecycle:
 
             def _model_forward_fn(*args, **kwargs):
                 output = forward_function(*args, **kwargs)
-                current_step = self.event_lifecycle.current_index
+                current_step = self.state.loggers.epoch_to_step(
+                    epoch=self.event_lifecycle.current_index,
+                    steps_per_epoch=len(self.state.data.train),
+                )
 
                 if should_log_model_info(
                     model=self.state.model,

--- a/src/sparseml/core/logger/__init__.py
+++ b/src/sparseml/core/logger/__init__.py
@@ -11,31 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# flake8: noqa
 
-
-# This file has been moved to src/sparseml/core/logger.py
-# and is kept here for backwards compatibility.
-# It will be removed in a future release.
-
-from sparseml.core.logger.logger import (
-    LOGGING_LEVELS,
-    BaseLogger,
-    LambdaLogger,
-    LoggerManager,
-    PythonLogger,
-    SparsificationGroupLogger,
-    TensorBoardLogger,
-    WANDBLogger,
-)
-
-
-__all__ = [
-    "BaseLogger",
-    "LambdaLogger",
-    "PythonLogger",
-    "TensorBoardLogger",
-    "WANDBLogger",
-    "SparsificationGroupLogger",
-    "LoggerManager",
-    "LOGGING_LEVELS",
-]
+from .logger import *

--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -59,8 +59,6 @@ __all__ = [
     "SparsificationGroupLogger",
     "LoggerManager",
     "LOGGING_LEVELS",
-    "VALID_FREQUENCY_TYPES",
-    "DEFAULT_FREQUENCY_TYPE",
 ]
 ALL_TOKEN = "__ALL__"
 LOGGING_LEVELS = {
@@ -70,7 +68,6 @@ LOGGING_LEVELS = {
     "error": ERROR,
     "critical": CRITICAL,
 }
-VALID_FREQUENCY_TYPES = ["epoch", "step", "batch"]
 DEFAULT_FREQUENCY_TYPE = "epoch"
 
 

--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -815,7 +815,9 @@ class LoggerManager(ABC):
         ):
             self._loggers.append(PythonLogger())
         self.frequency_manager: FrequencyManagerContract = (
-            FrequencyManagerFactory.from_frequency_type()
+            FrequencyManagerFactory.from_frequency_type(
+                frequency_type=frequency_type, log_frequency=log_frequency
+            )
         )
 
     def __len__(self):

--- a/src/sparseml/core/logger/utils/__init__.py
+++ b/src/sparseml/core/logger/utils/__init__.py
@@ -11,31 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# flake8: noqa
 
-
-# This file has been moved to src/sparseml/core/logger.py
-# and is kept here for backwards compatibility.
-# It will be removed in a future release.
-
-from sparseml.core.logger.logger import (
-    LOGGING_LEVELS,
-    BaseLogger,
-    LambdaLogger,
-    LoggerManager,
-    PythonLogger,
-    SparsificationGroupLogger,
-    TensorBoardLogger,
-    WANDBLogger,
-)
-
-
-__all__ = [
-    "BaseLogger",
-    "LambdaLogger",
-    "PythonLogger",
-    "TensorBoardLogger",
-    "WANDBLogger",
-    "SparsificationGroupLogger",
-    "LoggerManager",
-    "LOGGING_LEVELS",
-]
+from .frequency_managers import *

--- a/src/sparseml/core/logger/utils/frequency_managers.py
+++ b/src/sparseml/core/logger/utils/frequency_managers.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Optional, Union
+
+
+__all__ = [
+    "FrequencyManagerContract",
+    "EpochFrequencyManager",
+    "BatchFrequencyManager",
+    "OptimizerStepFrequencyManager",
+    "FrequencyManagerFactory",
+]
+
+
+class FrequencyManagerContract(ABC):
+    """
+    Contract for frequency managers
+    """
+
+    @abstractmethod
+    def validate_log_frequency(self, log_frequency):
+        """
+        Validates the log frequency, raising a ValueError if invalid
+        :param log_frequency: The log frequency to validate
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_ready(self, current_log_step, last_log_step) -> bool:
+        """
+        :param current_log_step: The current log step
+        :param last_log_step: The last step we logged at
+        :return: True if the frequency manager is ready to log, False otherwise
+        """
+        raise NotImplementedError
+
+
+class EpochFrequencyManager(FrequencyManagerContract):
+    """
+    Frequency manager that handles logging based on epochs.
+    Can accept a float or int for the frequency, where a float is a
+    fraction of an epoch
+
+    :param log_frequency: The frequency to log at, either a float or int or None
+    """
+
+    def __init__(self, log_frequency: Union[float, int, None] = None):
+        self.validate_log_frequency(log_frequency=log_frequency)
+        self._log_frequency = log_frequency
+
+    def log_ready(
+        self,
+        current_log_step: Union[int, float, None],
+        last_log_step: Union[int, float, None],
+    ):
+        """
+        :param current_log_step: The current log step
+        :param last_log_step: The last step we logged at
+        :return: True if the frequency manager is ready to log,
+            False otherwise
+        """
+        return self._log_frequency is not None and (
+            current_log_step is None
+            or last_log_step is None
+            or current_log_step >= last_log_step + self._log_frequency
+        )
+
+    def validate_log_frequency(self, log_frequency: Union[float, int, None]):
+        """
+        Validates the log frequency is a float or int or None, raising
+        a ValueError if invalid
+
+        :param log_frequency: _description_
+        :raises ValueError: _description_
+        """
+        if not isinstance(log_frequency, (float, int, type(None))):
+            raise ValueError(
+                f"frequency {log_frequency} must be a float or int or None"
+                f" But found {type(log_frequency)} instead"
+            )
+
+    @property
+    def log_frequency(self) -> Union[float, int, None]:
+        return self._log_frequency
+
+    @log_frequency.setter
+    def log_frequency(self, value: Union[float, int, None]):
+        self.validate_log_frequency(log_frequency=value)
+        self._log_frequency = value
+
+
+class IntegerFrequencyManager_(EpochFrequencyManager):
+    """
+    Frequency manager that handles logging based on integer steps only.
+    """
+
+    def validate_log_frequency(self, log_frequency: Optional[int]):
+        """
+        Validates the log frequency is an int or None, raising a ValueError if invalid
+
+        :param log_frequency: the log frequency to validate
+        :raises ValueError: if the log frequency is neither an int or None
+        """
+        if not isinstance(log_frequency, (int, type(None))):
+            raise ValueError(f"frequency {log_frequency} must be an int or None")
+        super().validate_log_frequency(log_frequency)
+
+
+class BatchFrequencyManager(IntegerFrequencyManager_):
+    """
+    Frequency manager that handles logging based on batches.
+    Accepts an int for the frequency, where the frequency is the number of batches
+    between logs, or None for to log on every batch. If not None, the frequency
+    must be >= 100
+    """
+
+    def validate_log_frequency(self, log_frequency: Optional[int]):
+        """
+        Validates the log frequency is an int or None, raising a ValueError if invalid
+        Also validates that the frequency is >= 100 (to avoid over-logging) if not None
+
+        :param log_frequency: the log frequency to validate
+        :raises ValueError: if the log frequency is neither an int or None
+        :raises ValueError: if the log frequency is < 100
+        """
+        super().validate_log_frequency(log_frequency)
+        if log_frequency is not None and log_frequency < 100:
+            raise ValueError(f"frequency {log_frequency} must be >= 100")
+
+
+class OptimizerStepFrequencyManager(IntegerFrequencyManager_):
+    """
+    Frequency manager that handles logging based on optimizer steps.
+    Accepts an int for the frequency, where the frequency is the number of optimizer
+    steps between logs, or None for to log on every optimizer step. If not None,
+    the frequency must be >=50
+    """
+
+    def validate_log_frequency(self, log_frequency: Optional[int]):
+        """
+        Validates the log frequency is an int or None, raising a ValueError if invalid
+        Also validates that the frequency is >= 50 (to avoid over-logging) if not None
+
+        :param log_frequency: the log frequency to validate
+        :raises ValueError: if the log frequency is neither an int or None
+        :raises ValueError: if the log frequency is < 50
+        """
+        super().validate_log_frequency(log_frequency)
+        if log_frequency is not None and log_frequency < 50:
+            raise ValueError(f"frequency {log_frequency} must be >= 50")
+
+
+_CONSTRUCTORS = defaultdict(
+    lambda: None,
+    {
+        "epoch": EpochFrequencyManager,
+        "batch": BatchFrequencyManager,
+        "optimizer_step": OptimizerStepFrequencyManager,
+    },
+)
+
+
+class FrequencyManagerFactory:
+    @staticmethod
+    def from_frequency_type(
+        frequency_type: str, log_frequency: Union[float, int, None] = None
+    ) -> FrequencyManagerContract:
+        """
+        Factory method for creating a frequency manager based on the frequency type
+
+        :param frequency_type: The frequency type to create, is case insensitive
+        :param log_frequency: The frequency to log at, either a float or int or None;
+            Default is None. If None, will log at every step
+        :return: The frequency manager
+        """
+
+        normalized_frequency_type = frequency_type.lower().replace("-", "_").strip()
+        if frequency_manager := _CONSTRUCTORS[normalized_frequency_type]:
+            return frequency_manager(log_frequency=log_frequency)
+
+        raise ValueError(
+            f"Invalid frequency type {frequency_type}, must be one "
+            f"of {list(_CONSTRUCTORS.keys())}"
+        )

--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -21,7 +21,7 @@ from sparseml.core.event import EventType
 from sparseml.core.framework import Framework
 from sparseml.core.helpers import log_model_info, should_log_model_info
 from sparseml.core.lifecycle import SparsificationLifecycle
-from sparseml.core.logger import BaseLogger, LoggerManager
+from sparseml.core.logger.logger import BaseLogger, LoggerManager
 from sparseml.core.recipe import Recipe
 from sparseml.core.state import ModifiedState, State
 
@@ -285,15 +285,15 @@ class SparseSession:
         if should_log_model_info(
             model=self.state.model,
             loggers=self.state.loggers,
-            epoch=epoch,
-            last_log_epoch=self.state._last_log_epoch,
+            current_log_step=epoch,
+            last_log_step=self.state._last_log_step,
         ):
             log_model_info(
                 state=self.state,
                 epoch=epoch,
             )
             # update last log epoch
-            self.state._last_log_epoch = epoch
+            self.state._last_log_step = epoch
 
     def get_serialized_recipe(self) -> str:
         """

--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -282,15 +282,18 @@ class SparseSession:
 
         # override logging cadence temporarily
 
-        if should_log_model_info(
-            model=self.state.model,
-            loggers=self.state.loggers,
-            current_log_step=epoch,
-            last_log_step=self.state._last_log_step,
+        if (
+            should_log_model_info(
+                model=self.state.model,
+                loggers=self.state.loggers,
+                current_log_step=epoch,
+                last_log_step=self.state._last_log_step,
+            )
+            and self.state.loggers.frequency_manager.frequency_type == "epoch"
         ):
             log_model_info(
                 state=self.state,
-                epoch=epoch,
+                current_log_step=epoch,
             )
             # update last log epoch
             self.state._last_log_step = epoch

--- a/src/sparseml/core/state.py
+++ b/src/sparseml/core/state.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Optional, Union
 from sparseml.core.data import ModifiableData
 from sparseml.core.event import Event
 from sparseml.core.framework import Framework
-from sparseml.core.logger import BaseLogger, LoggerManager
+from sparseml.core.logger.logger import BaseLogger, LoggerManager
 from sparseml.core.model import ModifiableModel
 from sparseml.core.optimizer import ModifiableOptimizer
 
@@ -113,7 +113,7 @@ class State:
     last_event: Event = None
     loggers: Optional[LoggerManager] = None
     model_log_cadence: Optional[float] = None
-    _last_log_epoch: Optional[float] = None
+    _last_log_step: Union[float, int, None] = None
 
     @property
     def sparsification_ready(self) -> bool:

--- a/tests/sparseml/core/test_helpers.py
+++ b/tests/sparseml/core/test_helpers.py
@@ -17,7 +17,11 @@ from collections import defaultdict
 import pytest
 
 from sparseml.core.event import EventType
-from sparseml.core.helpers import _log_epoch, _log_model_loggable_items, log_model_info
+from sparseml.core.helpers import (
+    _log_current_step,
+    _log_model_loggable_items,
+    log_model_info,
+)
 from sparseml.core.logger.logger import LoggerManager
 
 
@@ -74,9 +78,9 @@ def state_mock():
 
 def test__log_epoch_invokes_log_scalar():
     logger_manager = LoggerManagerMock()
-    _log_epoch(
+    _log_current_step(
         logger_manager=logger_manager,
-        epoch=1,
+        current_log_step=1,
     )
     # log epoch should invoke log_string
     assert logger_manager.hit_count["log_scalar"] == 1
@@ -85,7 +89,7 @@ def test__log_epoch_invokes_log_scalar():
 def test_log_model_info_logs_epoch_and_loggable_items():
     state = StateMock()
     epoch = 3
-    log_model_info(state, epoch=epoch)
+    log_model_info(state, current_log_step=epoch)
 
     # loggable items will invoke log_scalar for each
     # int/float value + 1 for the epoch

--- a/tests/sparseml/core/test_helpers.py
+++ b/tests/sparseml/core/test_helpers.py
@@ -18,7 +18,7 @@ import pytest
 
 from sparseml.core.event import EventType
 from sparseml.core.helpers import _log_epoch, _log_model_loggable_items, log_model_info
-from sparseml.core.logger import LoggerManager
+from sparseml.core.logger.logger import LoggerManager
 
 
 class ModelMock:

--- a/tests/sparseml/core/test_logger.py
+++ b/tests/sparseml/core/test_logger.py
@@ -19,7 +19,7 @@ from abc import ABC
 
 import pytest
 
-from sparseml.core.logger import (
+from sparseml.core.logger.logger import (
     LambdaLogger,
     LoggerManager,
     PythonLogger,


### PR DESCRIPTION
This PR adds, Frequency Type support to `LoggerManager`

Key Changes include:
* Introduce simple FrequencyManager to manage the frequency of logging
* Add `FrequencyManagerFactory` to create FrequencyManagers
* Attach callbacks to `optimizer.step()` or `model forward function` based on Frequency Type
* Moved `logger.py` into it's own folder
* Refactor some epoch specific logging helpers to be more general

Supported Frequency types are (NOT CASE SENSITIVE) :
- [X] `epoch`
- [X] `optimizer_step`
- [X] `batch`

By default, `epoch` frequency type is selected with a `log_freq` of `0.1`; if this works for users they can omit specifying loggers with session.initialize altogether

For more fine-grained control, A `LoggerManager` instance should be created, with the expected log_frequency and frequency type

Example script to log model info after 10 optimizer steps:
```python
from sparseml.core.logger.logger import LoggerManager
import sparseml.core.session as sml
from sparseml.core.framework import Framework
import torchvision
from torchvision import transforms
import torch
from torch.utils.data import DataLoader
import datasets
import os
from torch.optim import Adam
from torch.nn import CrossEntropyLoss
from sparseml.core.event import EventType
from sparseml.core import PythonLogger
import logging

NUM_LABELS = 3
BATCH_SIZE = 32
NUM_EPOCHS = 1
LOG_FREQUENCY = 10
FREQUENCY_TYPE = "optimizer_step" # or "epoch" # or "batch"
recipe = "/home/rahul/projects/sparseml/local/recipe.yaml"
device = "cuda:0"

# set up SparseML session
sml.create_session()
session = sml.active_session()


# download model
model = torchvision.models.mobilenet_v2(weights=torchvision.models.MobileNet_V2_Weights.DEFAULT)
model.classifier[1] = torch.nn.Linear(model.classifier[1].in_features, NUM_LABELS)
model.to(device)


# download data
beans_dataset = datasets.load_dataset("beans")
train_folder, _ = os.path.split(beans_dataset["train"][0]["image_file_path"])
train_path, _ = os.path.split(train_folder)
val_folder, _ = os.path.split(beans_dataset["validation"][0]["image_file_path"])
val_path, _ = os.path.split(train_folder)


# dataloaders
imagenet_transform = transforms.Compose([
   transforms.Resize(size=256, interpolation=transforms.InterpolationMode.BILINEAR, max_size=None, antialias=None),
   transforms.CenterCrop(size=(224, 224)),
   transforms.ToTensor(),
   transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
])

train_dataset = torchvision.datasets.ImageFolder(
    root=train_path,
    transform=imagenet_transform
)
train_loader = DataLoader(train_dataset, BATCH_SIZE, shuffle=True, pin_memory=True, num_workers=16)

val_dataset = torchvision.datasets.ImageFolder(
    root=val_path,
    transform=imagenet_transform
)
val_loader = DataLoader(val_dataset, BATCH_SIZE, shuffle=False, pin_memory=True, num_workers=16)


# loss and optimizer
criterion = CrossEntropyLoss()
optimizer = Adam(model.parameters(), lr=8e-3)


recipe_args = {}
session_data = session.initialize(
    framework=Framework.pytorch,
    recipe=recipe,
    recipe_args=recipe_args,
    model=model,
    teacher_model=None,
    optimizer=optimizer,
    train_data=train_loader,
    val_data=val_loader,
    start=0.0,
    steps_per_epoch=len(train_loader),
    loggers=LoggerManager(frequency_type=FREQUENCY_TYPE, log_frequency=LOG_FREQUENCY),
)


# loop through batches
for epoch in range(NUM_EPOCHS):
    running_loss = 0.0
    total_correct = 0
    total_predictions = 0
    for step, (inputs, labels) in enumerate(session.state.data.train):
        inputs = inputs.to(device)
        labels = labels.to(device)
        session.state.optimizer.optimizer.zero_grad()
        session.event(event_type=EventType.BATCH_START, batch_data=(inputs, labels))

        outputs = session.state.model.model(inputs)
        loss = criterion(outputs, labels)
        loss.backward()
        session.event(event_type=EventType.LOSS_CALCULATED, loss=loss)

        session.event(event_type=EventType.OPTIM_PRE_STEP)
        session.state.optimizer.optimizer.step()
        session.event(event_type=EventType.OPTIM_POST_STEP)

        running_loss += loss.item()

        predictions = outputs.argmax(dim=1)
        total_correct += torch.sum(predictions == labels).item()
        total_predictions += inputs.size(0)

        session.event(event_type=EventType.BATCH_END)

    loss = running_loss / (step + 1.0)
    accuracy = total_correct / total_predictions
    print("Epoch: {} Loss: {} Accuracy: {}".format(epoch + 1, loss, accuracy))


# finalize session
session.finalize()
``` 

The recipe used:
```yaml
test_stage:
  pruning_modifiers:
    MagnitudePruningModifier:
      init_sparsity: 0.0
      final_sparsity: 0.5
      start: 0
      end: 2
      update_frequency: 0.5
      targets:        
          - features.0.0.weight
          - features.1.conv.0.0.weight
          - features.1.conv.1.weight
          - features.2.conv.0.0.weight
          - features.2.conv.1.0.weight
          - features.2.conv.2.weight
          - features.3.conv.0.0.weight
          - features.3.conv.1.0.weight
          - features.3.conv.2.weight
          - features.4.conv.0.0.weight
          - features.4.conv.1.0.weight
          - features.4.conv.2.weight
          - features.5.conv.0.0.weight
          - features.5.conv.1.0.weight
          - features.5.conv.2.weight
          - features.6.conv.0.0.weight
          - features.6.conv.1.0.weight
          - features.6.conv.2.weight
          - features.7.conv.0.0.weight
          - features.7.conv.1.0.weight
          - features.7.conv.2.weight
          - features.8.conv.0.0.weight
          - features.8.conv.1.0.weight
          - features.8.conv.2.weight
          - features.9.conv.0.0.weight
          - features.9.conv.1.0.weight
          - features.9.conv.2.weight
          - features.10.conv.0.0.weight
          - features.10.conv.1.0.weight
          - features.10.conv.2.weight
          - features.11.conv.0.0.weight
          - features.11.conv.1.0.weight
          - features.11.conv.2.weight
          - features.12.conv.0.0.weight
          - features.12.conv.1.0.weight
          - features.12.conv.2.weight
          - features.13.conv.0.0.weight
          - features.13.conv.1.0.weight
          - features.13.conv.2.weight
          - features.14.conv.0.0.weight
          - features.14.conv.1.0.weight
          - features.14.conv.2.weight
          - features.15.conv.0.0.weight
          - features.15.conv.1.0.weight
          - features.15.conv.2.weight
          - features.16.conv.0.0.weight
          - features.16.conv.1.0.weight
          - features.16.conv.2.weight
          - features.17.conv.0.0.weight
          - features.17.conv.1.0.weight
          - features.17.conv.2.weight
          - features.18.0.weight
          - classifier.1.weight
      leave_enabled: True
```

Output with above script will log model info 4 times; (the dataset used has 33 batches, and we log once for every 10 optimizer steps, we also only run it for 1 epoch)

Output:
```bash
Logging all SparseML modifier-level logs to sparse_logs/18-12-2023_20.20.46.log
2023-12-18 20:20:46 sparseml.core.logger.logger INFO     Logging all SparseML modifier-level logs to sparse_logs/18-12-2023_20.20.46.log
2023-12-18 20:20:47 sparseml.core.recipe.recipe INFO     Loading recipe from file /home/rahul/projects/sparseml/local/recipe.yaml
Epoch: 1 Loss: 0.7876473863919576 Accuracy: 0.7108317214700194
```

Quick scan through the log file confirms correct logging:
![Screen Shot 2023-12-18 at 8 22 48 PM](https://github.com/neuralmagic/sparseml/assets/25380596/353d9858-8756-4ba7-a4a3-63f2a6bf183c)

The log file has been attached for reference:
[18-12-2023_20.20.46.log](https://github.com/neuralmagic/sparseml/files/13709991/18-12-2023_20.20.46.log)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206205545989441
  - https://app.asana.com/0/0/1205848553025323