### PR TITLE
ONNX export for weights-only quantization

### DIFF
--- a/src/sparseml/exporters/onnx_to_deepsparse.py
+++ b/src/sparseml/exporters/onnx_to_deepsparse.py
@@ -94,6 +94,7 @@ class ONNXToDeepsparse(BaseExporter):
                 else sparseml_transforms.ConvToConvIntegerAddCastMul(),
                 sparseml_transforms.GemmToQLinearMatMul(),
                 sparseml_transforms.GemmToMatMulIntegerAddCastMul(),
+                sparseml_transforms.WeightsOnly(),
                 sparseml_transforms.QuantizeResiduals(),
                 sparseml_transforms.RemoveDuplicateQConvWeights(),
                 sparseml_transforms.RemoveDuplicateQuantizeOps(),

--- a/src/sparseml/exporters/transforms/__init__.py
+++ b/src/sparseml/exporters/transforms/__init__.py
@@ -48,3 +48,4 @@ from .remove_duplicate_qconv_weights import RemoveDuplicateQConvWeights
 from .remove_duplicate_quantize_ops import RemoveDuplicateQuantizeOps
 from .skip_input_quantize import SkipInputQuantize
 from .kv_cache import *
+from .weightsonly import WeightsOnly

--- a/src/sparseml/exporters/transforms/weightsonly.py
+++ b/src/sparseml/exporters/transforms/weightsonly.py
@@ -1,0 +1,88 @@
+from onnx import ModelProto, numpy_helper
+
+from sparseml.exporters.transforms import OnnxTransform
+from sparseml.onnx.utils import ONNXGraph
+from sparseml.exporters.transforms.utils import (
+    INITIALIZER_MATCH,
+    get_structural_matches,
+    get_quantization_params,
+    optional_node,
+)
+from sparseml.exporters.transforms.utils.helpers import quantize_array
+
+__all__ = ["WeightsOnly"]
+
+
+class WeightsOnly(OnnxTransform):
+    """
+    A transform that converts floating point weights to INT8.
+
+    Transforms
+    ```
+    |   weights (initializer)
+    |     |
+    |     Q
+    |     |
+    |     Dq
+    |     |
+    |  Transpose (optional)
+    ```
+    (where `Q` is QuantizeLinear, and `Dq` is DequantizeLinear)
+
+    into
+
+    ```
+    |   weights (INT8 initializer)
+    |      |
+    |      Dq
+    ```
+    """
+
+    def transform(self, model: ModelProto) -> ModelProto:
+        graph = ONNXGraph(model)
+        matches = get_structural_matches(
+            graph,
+            parent_ops=[
+                [INITIALIZER_MATCH, "QuantizeLinear"]
+            ],
+            op_type="DequantizeLinear",
+            children_ops=[[optional_node("Transpose")]],
+        )
+
+        for match in matches:
+            self.log_match(match)
+
+            initializer, qnode = match.parents[0]
+            dqnode = match.node
+            transpose_node = match.children[0][0]
+
+            quantize_params = get_quantization_params(
+                model, qnode, include_target=True
+            )
+
+            quantized_array = quantize_array(
+                quantize_params.target,
+                quantize_params.scale,
+                quantize_params.zero_point,
+                quantize_params.zero_point.dtype,
+            )
+
+            if transpose_node is not None:
+                quantized_array = quantized_array.transpose()
+                dqnode.output[0] = transpose_node.output[0]
+
+            quantized_initializer_name = initializer.name + "_quantized"
+            quantized_initializer = numpy_helper.from_array(
+                quantized_array, name=quantized_initializer_name
+            )
+            model.graph.initializer.append(quantized_initializer)
+
+            dqnode.input[0] = quantized_initializer_name
+
+            # Clean up
+            self.delete_node_deferred(qnode)
+
+            if transpose_node is not None:
+                self.delete_node_deferred(transpose_node)
+
+        return model

--- a/src/sparseml/exporters/transforms/weightsonly.py
+++ b/src/sparseml/exporters/transforms/weightsonly.py
@@ -1,14 +1,29 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from onnx import ModelProto, numpy_helper
 
 from sparseml.exporters.transforms import OnnxTransform
-from sparseml.onnx.utils import ONNXGraph
 from sparseml.exporters.transforms.utils import (
     INITIALIZER_MATCH,
-    get_structural_matches,
     get_quantization_params,
+    get_structural_matches,
     optional_node,
 )
 from sparseml.exporters.transforms.utils.helpers import quantize_array
+from sparseml.onnx.utils import ONNXGraph
+
 
 __all__ = ["WeightsOnly"]
 
@@ -42,9 +57,7 @@ class WeightsOnly(OnnxTransform):
         graph = ONNXGraph(model)
         matches = get_structural_matches(
             graph,
-            parent_ops=[
-                [INITIALIZER_MATCH, "QuantizeLinear"]
-            ],
+            parent_ops=[[INITIALIZER_MATCH, "QuantizeLinear"]],
             op_type="DequantizeLinear",
             children_ops=[[optional_node("Transpose")]],
         )
@@ -56,9 +69,7 @@ class WeightsOnly(OnnxTransform):
             dqnode = match.node
             transpose_node = match.children[0][0]
 
-            quantize_params = get_quantization_params(
-                model, qnode, include_target=True
-            )
+            quantize_params = get_quantization_params(model, qnode, include_target=True)
 
             quantized_array = quantize_array(
                 quantize_params.target,


### PR DESCRIPTION
This PR adds a transformation that quantizes weights for weights-only quantization. It was tested on a Llama2 model.