### PR TITLE
[Logger refactor] match wandb signature

### DIFF
--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -1323,6 +1323,23 @@ class MetricLoggingWrapper(LoggingWrapperBase):
             tag=tag, values=values, step=step, wall_time=wall_time, **kwargs
         )
 
+    def log(
+        self,
+        data: Dict[str, Any],
+        step: Optional[int] = None,
+        tag: Optional[str] = DEFAULT_TAG,
+        **kwargs,
+    ) -> None:
+        """
+        :param data:  A dict of serializable python objects i.e `str`,
+                `ints`, `floats`, `Tensors`, `dicts`, etc
+        :param step: global step for when the values were taken
+        :param tag: identifying tag to log the values with, defaults to DEFAULT_TAG
+        :param kwargs: additional logging arguments to support
+            Python and custom loggers
+        """
+        self.log_scalars(tag=tag, values=data, step=step, **kwargs)
+
 
 def _create_dirs(path: str):
     path = Path(path).expanduser().absolute()


### PR DESCRIPTION
This PR adds a log method  with similar signature to https://github.com/wandb/wandb/blob/722f9737ce1a77b8970fef275047e8a0f4a1a68e/wandb/sdk/wandb_run.py#L1622 to our `LoggerManager`


Test:
```python
from logging import INFO
from sparseml.core import LoggerManager

def check_wandb_type_logging_functions():
    logger_manager = LoggerManager()
    logger_manager.metric.log(data="Hello World!", level=INFO)


if __name__ == "__main__":
    check_wandb_type_logging_functions()
```

Output:
```bash
$ python local/scripts/dummy.py                                                                                                                (add-wandb-like-logging-function|✚1⚑8)
Logging all SparseML modifier-level logs to sparse_logs/02-01-2024_09.16.29.log
2024-01-02 09:16:29 sparseml.core.logger.logger INFO     Logging all SparseML modifier-level logs to sparse_logs/02-01-2024_09.16.29.log
python defaul_tag step None: Hello World!
```
Based off of #1919 