### PR TITLE
[Logger Refactor] Add tb summary writer like functions

### DIFF
--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -25,7 +25,7 @@ from datetime import datetime
 from logging import CRITICAL, DEBUG, ERROR, INFO, WARN, Logger
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from sparseml.core.logger.utils import (
     FrequencyManager,
@@ -73,6 +73,7 @@ LOGGING_LEVELS = {
     "error": ERROR,
     "critical": CRITICAL,
 }
+DEFAULT_TAG = "defaul_tag"
 
 
 class BaseLogger(ABC):
@@ -1278,6 +1279,49 @@ class MetricLoggingWrapper(LoggingWrapperBase):
                     wall_time=wall_time,
                     level=level,
                 )
+
+    def add_scalar(
+        self,
+        value,
+        tag: str = DEFAULT_TAG,
+        step: Optional[int] = None,
+        wall_time: Union[int, float, None] = None,
+        **kwargs,
+    ):
+        """
+        Add a scalar value to the logger
+
+        :param value: value to log
+        :param tag: tag to log the value with, defaults to DEFAULT_TAG
+        :param step: global step for when the value was taken
+        :param wall_time: global wall time for when the value was taken
+        :param kwargs: additional logging arguments to to pass through to the
+            logger
+        """
+        self.log_scalar(tag=tag, value=value, step=step, wall_time=wall_time, **kwargs)
+
+    def add_scalars(
+        self,
+        values: Dict[str, Any],
+        tag: str = DEFAULT_TAG,
+        step: Optional[int] = None,
+        wall_time: Union[int, float, None] = None,
+        **kwargs,
+    ):
+        """
+        Adds multiple scalar values to the logger
+
+        :param values: values to log, must be A dict of serializable
+            python objects i.e `str`, `ints`, `floats`, `Tensors`, `dicts`, etc
+        :param tag: tag to log the value with, defaults to DEFAULT_TAG
+        :param step: global step for when the value was taken
+        :param wall_time: global wall time for when the value was taken
+        :param kwargs: additional logging arguments to to pass through to the
+            logger
+        """
+        self.log_scalars(
+            tag=tag, values=values, step=step, wall_time=wall_time, **kwargs
+        )
 
 
 def _create_dirs(path: str):


### PR DESCRIPTION
This PR adds a log method  with similar signature to https://github.com/pytorch/pytorch/blob/92998693a9455af6259cae468265f01cfff8810e/torch/utils/tensorboard/writer.py#L353 to our `LoggerManager`


Test:
```python
#local.py
from logging import INFO
from sparseml.core import LoggerManager

def check_tb_type_logging_functions():
    logger_manager = LoggerManager()
    logger_manager.metric.add_scalar(value="Hello World!", level=INFO)
    logger_manager.metric.add_scalars(values={1: "Hello World!"}, level=INFO, tag="my_scalar")

if __name__ == "__main__":
    check_tb_type_logging_functions()
```

Output:
```bash
$ python local.py                                                                                                         (add-tb-like-logging-function|✚1…2⚑7)
2024-01-02 09:09:47 sparseml.core.logger.logger INFO     Logging all SparseML modifier-level logs to sparse_logs/02-01-2024_09.09.47.log
python defaul_tag step None: Hello World!
python my_scalar step None: {1: 'Hello World!'}

```

Based off of #1932

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205848553025320