### PR TITLE
[Export Refactor][Transformers] Enable loading SparseModels

### DIFF
--- a/src/sparseml/export/export.py
+++ b/src/sparseml/export/export.py
@@ -113,8 +113,15 @@ def export(
     :param task: Optional task to use for exporting the model.
         Defaults to None.
     """
+    # TODO: Remove with the followin once sparsezoo: #404 lands
+    """
+    from sparsezoo.utils.registry import standardize_lookup_name
+    task = standardize_lookup_name(task)
+    """
     if task is not None:
         task = task.replace("_", "-").replace(" ", "-")
+
+    # TODO: Remove once sparsezoo: #404 lands
     if integration is not None:
         integration = integration.replace("_", "-").replace(" ", "-")
 

--- a/src/sparseml/export/export.py
+++ b/src/sparseml/export/export.py
@@ -27,7 +27,7 @@ from sparseml.export.helpers import (
 from sparseml.export.validators import validate_correctness as validate_correctness_
 from sparseml.export.validators import validate_structure as validate_structure_
 from sparseml.pytorch.opset import TORCH_DEFAULT_ONNX_OPSET
-from sparseml.pytorch.utils.helpers import default_device, use_single_gpu
+from sparseml.pytorch.utils.helpers import default_device
 from src.sparseml.integration_helper_functions import (
     IntegrationHelperFunctions,
     resolve_integration,
@@ -46,8 +46,9 @@ def export(
     single_graph_file: bool = True,
     num_export_samples: int = 0,
     batch_size: int = 1,
+    recipe: Optional[Union[Path, str]] = None,
     deployment_directory_name: str = "deployment",
-    device: str = "auto",
+    device: str = "cpu",
     graph_optimizations: Union[str, List[str], None] = "all",
     validate_correctness: bool = False,
     validate_structure: bool = True,
@@ -82,6 +83,9 @@ def export(
         the model to. Defaults to 'deepsparse'.
     :param opset: The ONNX opset to use for exporting the model.
         Defaults to the latest supported opset.
+    :param recipe: The path to the recipe to use for exporting the model.
+        Defaults to None. If a recipe is found in the source_path, it will
+        be automatically used for export.
     :param single_graph_file: Whether to save the model as a single
         file. Defaults to True.
     :param num_export_samples: The number of samples to create for
@@ -109,6 +113,10 @@ def export(
     :param task: Optional task to use for exporting the model.
         Defaults to None.
     """
+    if task is not None:
+        task = task.replace("_", "-").replace(" ", "-")
+    if integration is not None:
+        integration = integration.replace("_", "-").replace(" ", "-")
 
     # create the target path if it doesn't exist
     if not Path(target_path).exists():
@@ -116,7 +124,6 @@ def export(
 
     # choose the appropriate device
     device = default_device() if device == "auto" else device
-    device = use_single_gpu(device) if "cuda" in device else device
 
     # assert the valid deployment target
     if deployment_target not in AVAILABLE_DEPLOYMENT_TARGETS:
@@ -140,8 +147,14 @@ def export(
     # that were created along with the model and are needed
     # for the export
     model, loaded_model_kwargs = helper_functions.create_model(
-        source_path, device=device, task=task, batch_size=batch_size, **kwargs
+        source_path,
+        device=device,
+        task=task,
+        batch_size=batch_size,
+        recipe=recipe,
+        **kwargs,
     )
+    model.eval()
 
     if loaded_model_kwargs:
         _LOGGER.info(

--- a/src/sparseml/integration_helper_functions.py
+++ b/src/sparseml/integration_helper_functions.py
@@ -51,10 +51,6 @@ def resolve_integration(
         will attempt to infer it from the source_path.
     :return: The name of the integration to use for exporting the model.
     """
-
-    if integration is not None:
-        integration = integration.replace("_", "-")
-
     from sparseml.pytorch.image_classification.utils.helpers import (
         is_image_classification_model,
     )

--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -137,15 +137,6 @@ def default_device() -> str:
     return "cuda:{}".format(",".join(device_ids))
 
 
-def use_single_gpu(device: str) -> str:
-    """
-    return: the first gpu in the device string if multiple are available
-    """
-    if "cuda" not in device:
-        raise ValueError("use_single_gpu should only be called on cuda devices")
-    return device.split(",")[0]
-
-
 def device_of(inputs: Any):
     if isinstance(inputs, Tensor):
         return inputs.device

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -169,11 +169,20 @@ def main(
         "use_auth_token": True if model_args.use_auth_token else None,
     }
     # this calls from_pretrained under the hood so should be FSDP safe
-    model, teacher = SparseAutoModel.text_generation_from_pretrained_distil(
+    model = SparseAutoModel.text_classification_from_pretrained(
         model_name_or_path=model_path,
-        teacher_name_or_path=training_args.distill_teacher,
-        model_kwargs=model_kwargs,
-        teacher_kwargs=teacher_kwargs,
+        model_type="student" if training_args.distill_teacher else "model",
+        **model_kwargs,
+    )
+    teacher = (
+        SparseAutoModel.text_classification_from_pretrained(
+            model_name_or_path=training_args.distill_teacher,
+            model_type="teacher",
+            **teacher_kwargs,
+        )
+        if training_args.distill_teacher
+        and training_args.distill_teacher not in ["self", "disable"]
+        else training_args.distill_teacher
     )
 
     # initialize structure of input model from recipe if needed

--- a/src/sparseml/transformers/integration_helper_functions.py
+++ b/src/sparseml/transformers/integration_helper_functions.py
@@ -26,7 +26,6 @@ from sparseml.transformers.utils.helpers import (
     MANDATORY_DEPLOYMENT_FILES,
     NLG_TOKENIZER_FILES,
     OPTIONAL_DEPLOYMENT_FILES,
-    RECIPE_NAME,
     TaskNames,
     resolve_sequence_length,
 )
@@ -78,10 +77,6 @@ def create_model(
 
     if task is None:
         raise ValueError("To create a transformer model, a task must be specified")
-    if recipe is None:
-        _LOGGER.info(f"Attempting to apply default recipe: {RECIPE_NAME}")
-    else:
-        _LOGGER.info(f"Attempting to apply user-specified recipe: {recipe}")
 
     if not trust_remote_code:
         _LOGGER.warning(

--- a/src/sparseml/transformers/integration_helper_functions.py
+++ b/src/sparseml/transformers/integration_helper_functions.py
@@ -26,7 +26,9 @@ from sparseml.transformers.utils.helpers import (
     MANDATORY_DEPLOYMENT_FILES,
     NLG_TOKENIZER_FILES,
     OPTIONAL_DEPLOYMENT_FILES,
+    RECIPE_NAME,
     TaskNames,
+    resolve_sequence_length,
 )
 from sparseml.transformers.utils.load_task_dataset import load_task_dataset
 from sparseml.transformers.utils.optimizations import apply_kv_cache_injection
@@ -38,10 +40,9 @@ from src.sparseml.integration_helper_functions import (
 from src.sparseml.transformers.utils.initializers import (
     _parse_data_args,
     initialize_config,
-    initialize_model,
+    initialize_sparse_model,
     initialize_tokenizer,
     initialize_trainer,
-    resolve_sequence_length,
 )
 
 
@@ -52,6 +53,7 @@ def create_model(
     source_path: Union[Path, str],
     device: Optional[str] = None,
     task: Optional[str] = None,
+    recipe: Optional[str] = None,
     **kwargs,
 ) -> Tuple[torch.nn.Module, Dict[str, Any]]:
     """
@@ -61,6 +63,8 @@ def create_model(
     :param source_path: The path to the model
     :param device: The device to use for the model and dataloader instantiation
     :param task: The task to use for the model and dataloader instantiation
+    :param recipe: The recipe to use for the model and dataloader instantiation.
+        If None, attempt to use the default recipe
 
     :return: A tuple of the
         - torch model
@@ -74,7 +78,10 @@ def create_model(
 
     if task is None:
         raise ValueError("To create a transformer model, a task must be specified")
-    task = task.replace("_", "-")
+    if recipe is None:
+        _LOGGER.info(f"Attempting to apply default recipe: {RECIPE_NAME}")
+    else:
+        _LOGGER.info(f"Attempting to apply user-specified recipe: {recipe}")
 
     if not trust_remote_code:
         _LOGGER.warning(
@@ -85,11 +92,13 @@ def create_model(
     config = initialize_config(source_path, trust_remote_code, **config_args)
     sequence_length = sequence_length or resolve_sequence_length(config)
     tokenizer = initialize_tokenizer(source_path, sequence_length, task)
-    model = initialize_model(
+    model = initialize_sparse_model(
         model_path=source_path,
         task=task,
         config=config,
         trust_remote_code=trust_remote_code,
+        recipe=recipe,
+        sequence_length=sequence_length,
         device=device,
     )
 
@@ -108,9 +117,8 @@ def create_model(
     else:
         validation_dataset = None
 
-    model.train()
     trainer = initialize_trainer(model, source_path, validation_dataset)
-    model.eval()
+    # TODO: Parse out dataloader from the trainer
 
     return model, dict(
         trainer=trainer,

--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -34,7 +34,7 @@ from sparseml.transformers.sparsification.obcq.utils.helpers import (
     llama_forward,
     opt_forward,
 )
-from sparseml.transformers.utils.sparse_model import SparseCausalLM
+from sparseml.transformers.utils.sparse_model import SparseAutoModel
 
 
 __all__ = ["one_shot"]
@@ -91,18 +91,18 @@ def one_shot(
     model_loader_fn = None
     forward_fn = None
     if "opt" in model_type:
-        model_loader_fn = SparseCausalLM.opt_model_from_pretrained
+        model_loader_fn = SparseAutoModel.text_classification_from_pretrained
         forward_fn = opt_forward
     elif "llama" in model_type or "mistral" in model_type:
-        model_loader_fn = SparseCausalLM.auto_model_from_pretrained
+        model_loader_fn = SparseAutoModel.text_classification_from_pretrained
         forward_fn = llama_forward
     else:
         _LOGGER.warning(
             f"A supported model type({SUPPORTED_MODELS}) could not be "
             f"parsed from model_path={model_path}. Defaulting to "
-            "AutoModelForCausalLM loading. "
+            "SparseAutoModel loading. "
         )
-        model_loader_fn = SparseCausalLM.auto_model_from_pretrained
+        model_loader_fn = SparseAutoModel.text_classification_from_pretrained
         forward_fn = llama_forward
     torch_dtype = _parse_dtype(precision)
     model = model_loader_fn(

--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -34,7 +34,7 @@ from sparseml.transformers.sparsification.obcq.utils.helpers import (
     llama_forward,
     opt_forward,
 )
-from sparseml.transformers.utils.model import SparseCausalLM
+from sparseml.transformers.utils.sparse_model import SparseCausalLM
 
 
 __all__ = ["one_shot"]

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -37,6 +37,7 @@ from transformers.trainer_callback import TrainerState
 from transformers.trainer_pt_utils import reissue_pt_warnings
 from transformers.trainer_utils import ShardedDDPOption, get_last_checkpoint
 
+from sparseml.pytorch.model_load.helpers import log_model_load
 from sparseml.pytorch.optim import ScheduledModifierManager, ScheduledOptimizer
 from sparseml.pytorch.sparsification.quantization.helpers import (
     initialize_channel_wise_scale_zp,
@@ -47,7 +48,6 @@ from sparseml.pytorch.utils import (
     TensorBoardLogger,
     WANDBLogger,
 )
-from sparseml.transformers.utils import SparseAutoModel
 from sparseml.transformers.utils.helpers import RECIPE_NAME
 
 
@@ -638,7 +638,7 @@ class RecipeManagerTrainerInterface:
         _LOGGER.info(
             f"Reloaded {total_loaded} model params for SparseML Recipe from {load_path}"
         )
-        SparseAutoModel.log_model_load(
+        log_model_load(
             self.model,
             self.model_state_path,
             model_type="student" if self.teacher else "model",

--- a/src/sparseml/transformers/utils/__init__.py
+++ b/src/sparseml/transformers/utils/__init__.py
@@ -19,4 +19,4 @@ Utilities for applying sparsification algorithms to Hugging Face transformers fl
 # flake8: noqa
 from .helpers import *
 from .metrics import *
-from .model import *
+from .sparse_model import *

--- a/src/sparseml/transformers/utils/helpers.py
+++ b/src/sparseml/transformers/utils/helpers.py
@@ -70,30 +70,19 @@ OPTIONAL_DEPLOYMENT_FILES = {"tokenizer.json", "tokenizer.model"}
 
 
 def apply_structure_to_transformers(
-    model: AutoModel, model_directory: Union[str, Path], recipe: Union[Path, str]
+    model: AutoModel, model_directory: Union[str, Path], recipe_path: Union[Path, str]
 ) -> None:
     """
     Apply the structure (dictated by the recipe) to the model.
     If no recipe is found, the model is returned as is (a warning is logged).
     :param model: the model to apply the structure to
     :param model_directory: the directory where the model is stored
-    :param recipe: the recipe to apply. It may be a path to a recipe file
-        or a recipe name (this assumes that the recipe is stored in the model_directory)
+    :param recipe_path: a valid path to the recipe to apply
     """
-    if Path(recipe).is_dir():
-        recipe_path = recipe
-    else:
-        recipe_path = os.path.join(model_directory, recipe)
-
-    if os.path.exists(recipe_path):
-        session_manager.create_session()
-        apply_recipe_structure_to_model(
-            model=model, recipe_path=recipe_path, model_path=model_directory
-        )
-    else:
-        _LOGGER.warning(
-            f"Recipe path: {recipe_path} found. Recipe will not be applied."
-        )
+    session_manager.create_session()
+    apply_recipe_structure_to_model(
+        model=model, recipe_path=recipe_path, model_path=model_directory
+    )
 
 
 def is_transformer_model(source_path: Union[Path, str]) -> bool:
@@ -202,7 +191,7 @@ def resolve_sequence_length(config: AutoConfig) -> int:
             "from the HF transformers config. Please specify "
             "the sequence length with --sequence_length"
         )
-    _LOGGER.info(
+    _LOGGER.debug(
         f"Using default sequence length of {sequence_length} "
         "(inferred from HF transformers config) "
     )

--- a/src/sparseml/transformers/utils/load_task_model.py
+++ b/src/sparseml/transformers/utils/load_task_model.py
@@ -12,19 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from pathlib import Path
+from typing import Any, Optional, Union
 
 from torch.nn import Module
 
-from sparseml.transformers.utils.helpers import TaskNames
-from sparseml.transformers.utils.model import SparseAutoModel
+from sparseml.transformers.utils.helpers import TaskNames, resolve_sequence_length
+from sparseml.transformers.utils.sparse_model import SparseAutoModel
 
 
 __all__ = ["load_task_model"]
 
 
 def load_task_model(
-    task: str, model_path: str, config: Any, trust_remote_code: bool = False
+    task: str,
+    model_path: str,
+    config: Any,
+    recipe: Optional[Union[str, Path]] = None,
+    trust_remote_code: bool = False,
+    **kwargs,
 ) -> Module:
     if task in TaskNames.mlm.value:
         return SparseAutoModel.masked_language_modeling_from_pretrained(
@@ -59,10 +65,15 @@ def load_task_model(
         )
 
     if task in TaskNames.text_generation.value:
+        sequence_length = kwargs.get("sequence_length")
+        if sequence_length is None:
+            sequence_length = resolve_sequence_length(config)
         return SparseAutoModel.text_generation_from_pretrained(
             model_name_or_path=model_path,
+            sequence_length=sequence_length,
             config=config,
             model_type="model",
+            recipe=recipe,
             trust_remote_code=trust_remote_code,
         )
 

--- a/src/sparseml/transformers/utils/sparse_model.py
+++ b/src/sparseml/transformers/utils/sparse_model.py
@@ -404,68 +404,6 @@ class SparseAutoModel:
             )
 
 
-class SparseCausalLM:
-    """
-    Factory class for loading LLMs from the transformers library. Currently OPT and
-    Llama are supported
-    """
-
-    @staticmethod
-    def opt_model_from_pretrained(
-        model_path: str,
-        sequence_length: Optional[int] = None,
-        torch_dtype: Union[str, torch.dtype] = "auto",
-    ) -> torch.nn.Module:
-        """
-        Load a pretrained OPT model from the specified hugging face path
-
-        :param model_path: hugging face or local path to model
-        :param sequence_length: maximum allowable tokens in input sequence
-        :param torch_dtype: precision to load model weights in as
-        :return: loaded pretrained model
-        """
-
-        def skip(*args, **kwargs):
-            pass
-
-        torch.nn.init.kaiming_uniform_ = skip
-        torch.nn.init.uniform_ = skip
-        torch.nn.init.normal_ = skip
-
-        model = OPTForCausalLM.from_pretrained(model_path, torch_dtype=torch_dtype)
-        model.eval()
-        model.seqlen = (
-            sequence_length if sequence_length else model.config.max_position_embeddings
-        )
-        return model
-
-    @staticmethod
-    def auto_model_from_pretrained(
-        model_path: str,
-        sequence_length: Optional[int] = None,
-        torch_dtype: Union[str, torch.dtype] = "auto",
-    ) -> torch.nn.Module:
-        """
-        Load a pretrained model using auto from the specified hugging face path
-
-        :param model_path: hugging face path to model
-        :param sequence_length: maximum allowable tokens in input sequence
-        :param torch_dtype: precision to load model weights in as
-        :return: loaded pretrained model
-        """
-        model = AutoModelForCausalLM.from_pretrained(
-            model_path, torch_dtype=torch_dtype
-        )
-        model.eval()
-        max_seq_len = None
-        if hasattr(model.config, "max_position_embeddings"):
-            max_seq_len = model.config.max_position_embeddings
-        elif hasattr(model.config, "max_seq_len"):
-            max_seq_len = model.config.max_seq_len
-        model.seqlen = sequence_length if sequence_length else max_seq_len
-        return model
-
-
 def get_shared_tokenizer_src(student: Module, teacher: Optional[Module]) -> str:
     """
     Get a tokenizer source used for both student and teacher, assuming

--- a/src/sparseml/transformers/utils/sparse_model.py
+++ b/src/sparseml/transformers/utils/sparse_model.py
@@ -15,11 +15,13 @@
 import inspect
 import logging
 import os
+from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 from torch.nn import Module
 from transformers import (
+    AutoConfig,
     AutoModelForCausalLM,
     AutoModelForMaskedLM,
     AutoModelForQuestionAnswering,
@@ -29,7 +31,8 @@ from transformers import (
 )
 from transformers.file_utils import WEIGHTS_NAME
 
-from sparseml.pytorch.utils import ModuleSparsificationInfo
+from sparseml.pytorch.model_load.helpers import log_model_load
+from sparseml.transformers.utils.helpers import apply_structure_to_transformers
 
 
 __all__ = ["SparseAutoModel", "get_shared_tokenizer_src"]
@@ -75,7 +78,7 @@ class SparseAutoModel:
                 **kwargs,
             )
 
-        SparseAutoModel.log_model_load(model, model_name_or_path, model_type, delayed)
+        log_model_load(model, model_name_or_path, model_type, delayed)
 
         return model
 
@@ -139,7 +142,7 @@ class SparseAutoModel:
             model_name_or_path,
             **kwargs,
         )
-        SparseAutoModel.log_model_load(model, model_name_or_path, model_type, delayed)
+        log_model_load(model, model_name_or_path, model_type, delayed)
 
         return model
 
@@ -201,7 +204,7 @@ class SparseAutoModel:
             model_name_or_path,
             **kwargs,
         )
-        SparseAutoModel.log_model_load(model, model_name_or_path, model_type, delayed)
+        log_model_load(model, model_name_or_path, model_type, delayed)
 
         return model
 
@@ -241,6 +244,11 @@ class SparseAutoModel:
     def text_generation_from_pretrained(
         model_name_or_path: str,
         model_type: str,
+        sequence_length: int,
+        config: AutoConfig,
+        recipe: Optional[Union[str, Path]] = None,
+        trust_remote_code: bool = False,
+        torch_dtype: Union[str, torch.dtype] = "auto",
         **kwargs,
     ) -> Module:
         """
@@ -250,58 +258,43 @@ class SparseAutoModel:
         :param kwargs: keyword arguments to pass through to the AutoModel call
         :return: the created model for text generation
         """
-        SparseAutoModel._check_tf(model_name_or_path)
-        if not kwargs:
-            kwargs = {}
-        kwargs["from_tf"] = False
-        delayed = False
-        if "state_dict" not in kwargs:
-            kwargs["state_dict"], delayed = SparseAutoModel._loadable_state_dict(
-                model_name_or_path
+        if config.model_type == "opt":
+            # TODO: Talk to Alex whether this pathway needs to be maintained
+            def skip(*args, **kwargs):
+                pass
+
+            torch.nn.init.kaiming_uniform_ = skip
+            torch.nn.init.uniform_ = skip
+            torch.nn.init.normal_ = skip
+
+            model = OPTForCausalLM.from_pretrained(
+                model_name_or_path,
+                torch_dtype=torch_dtype,
+                config=config,
+                trust_remote_code=trust_remote_code,
+                **kwargs,
+            )
+        else:
+            model = AutoModelForCausalLM.from_pretrained(
+                model_name_or_path,
+                torch_dtype=torch_dtype,
+                config=config,
+                trust_remote_code=trust_remote_code,
+                **kwargs,
             )
 
-        kwargs["config"].is_decoder = True
-        kwargs["config"].use_past = False
+        # TODO: Do we need to call eval() here? Why?
+        model.eval()
+        model.seqlen = sequence_length
 
-        model = AutoModelForCausalLM.from_pretrained(
-            model_name_or_path,
-            **kwargs,
-        )
-        SparseAutoModel.log_model_load(model, model_name_or_path, model_type, delayed)
+        if recipe:
+            apply_structure_to_transformers(
+                model=model, model_directory=model_name_or_path, recipe=recipe
+            )
+
+        log_model_load(model, model_name_or_path, model_type, delayed_load=False)
 
         return model
-
-    @staticmethod
-    def text_generation_from_pretrained_distil(
-        model_name_or_path: str,
-        teacher_name_or_path: Optional[str],
-        model_kwargs: Dict[str, Any],
-        teacher_kwargs: Dict[str, Any],
-    ) -> Tuple[Module, Optional[Module]]:
-        """
-        :param model_name_or_path: the name of or path to the model to load
-        :param teacher_name_or_path: the name of or path to the teacher to load,
-            None or one of ['self', 'disable'] will not create a teacher and
-            instead return the value passed in
-        :param model_kwargs: the keyword args to pass into the AutoModel for model
-        :param teacher_kwargs: the keyword args to pass into the AutoModel for teacher
-        :return: a tuple containing the model and distillation teacher (optional)
-            for text generation
-        """
-        model = SparseAutoModel.text_generation_from_pretrained(
-            model_name_or_path,
-            model_type="student" if teacher_name_or_path else "model",
-            **model_kwargs,
-        )
-        teacher = (
-            SparseAutoModel.text_generation_from_pretrained(
-                teacher_name_or_path, model_type="teacher", **teacher_kwargs
-            )
-            if teacher_name_or_path and teacher_name_or_path not in ["self", "disable"]
-            else teacher_name_or_path
-        )
-
-        return model, teacher
 
     @staticmethod
     def token_classification_from_pretrained(
@@ -329,7 +322,7 @@ class SparseAutoModel:
             model_name_or_path,
             **kwargs,
         )
-        SparseAutoModel.log_model_load(model, model_name_or_path, model_type, delayed)
+        log_model_load(model, model_name_or_path, model_type, delayed)
 
         return model
 
@@ -364,47 +357,6 @@ class SparseAutoModel:
         )
 
         return model, teacher
-
-    @staticmethod
-    def log_model_load(
-        model: Module, model_name_or_path: str, model_type: str, delayed_load: bool
-    ):
-        """
-        Log the state of a loaded model including sparsity and
-        prunable params information.
-
-        :param model: the loaded model
-        :param model_name_or_path: the original name of or path to the model that loaded
-        :param model_type: specify the type of model loaded for logging;
-            ex one of [model, student, teacher]
-        :param delayed_load: True if this model load was delayed until after
-            recipe instantiation due to QAT or other architectural state changes
-        """
-        if delayed_load:
-            _LOGGER.info(
-                f"Delayed load of model {model_name_or_path} detected. "
-                f"Will print out model information once SparseML recipes have loaded"
-            )
-            return
-
-        sparsification_info = ModuleSparsificationInfo(model)
-
-        _LOGGER.info(
-            f"Loaded {model_type} from {model_name_or_path} "
-            f"with {sparsification_info.params_total} total params. "
-            f"Of those there are {sparsification_info.params_prunable_total} prunable "
-            f"params which have {sparsification_info.params_prunable_sparse_percent} "
-            "avg sparsity."
-        )
-        model_type = (
-            "sparse"
-            if sparsification_info.params_prunable_sparse_percent > 5
-            else "dense"
-        )
-        _LOGGER.info(
-            f"{model_type} model detected, "
-            f"all sparsification info: {sparsification_info}"
-        )
 
     @staticmethod
     def _loadable_state_dict(

--- a/tests/sparseml/transformers/obcq/test_obcq.py
+++ b/tests/sparseml/transformers/obcq/test_obcq.py
@@ -25,7 +25,7 @@ from sparseml.pytorch.utils.helpers import tensor_sparsity
 from sparseml.transformers.data import TransformersDataset
 from sparseml.transformers.sparsification.obcq.obcq import one_shot
 from sparseml.transformers.sparsification.obcq.utils.helpers import llama_forward
-from sparseml.transformers.utils.sparse_model import SparseCausalLM
+from sparseml.transformers.utils.sparse_model import SparseAutoModel
 
 
 @pytest.mark.parametrize(
@@ -75,7 +75,7 @@ def test_lm_head_target():
     if not torch.cuda.is_available():
         device = "cpu"
 
-    model = SparseCausalLM.auto_model_from_pretrained(tiny_model_path)
+    model = SparseAutoModel.text_classification_from_pretrained(tiny_model_path)
     modifiable_model = ModifiableModel(model=model, framework=Framework.pytorch)
 
     kwargs = {

--- a/tests/sparseml/transformers/obcq/test_obcq.py
+++ b/tests/sparseml/transformers/obcq/test_obcq.py
@@ -25,7 +25,7 @@ from sparseml.pytorch.utils.helpers import tensor_sparsity
 from sparseml.transformers.data import TransformersDataset
 from sparseml.transformers.sparsification.obcq.obcq import one_shot
 from sparseml.transformers.sparsification.obcq.utils.helpers import llama_forward
-from sparseml.transformers.utils.model import SparseCausalLM
+from sparseml.transformers.utils.sparse_model import SparseCausalLM
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Feature Description

The main functionality introduced by this PR enables loading and applying the recipe in the new format to the `text-generation` models. 

The notable changes are:

`src/sparseml/export/export.py` -> allowing the user to provide recipe explicitely to the exporter. If the recipe is not provided, but the `recipe.yaml` is located side-by-side with the model, there will be an attempt to load it automatically

`src/sparseml/pytorch/model_load/helpers.py` -> moving the `log_model_load` out of the `transformers.SparseModel`, otherwise we would get nasty import dependencies. Plus, it just make sense for it to be more general function.

`src/sparseml/transformers/integration_helper_functions.py` -> simplifying the `create_model` function and adapting it to the new changes

`src/sparseml/transformers/utils/helpers.py` -> just adding an extra transformer-specific wrapper around the general `apply_recipe_structure_to_model` method. Just in case we need some transformer-specific functionalities.

`src/sparseml/transformers/utils/initializers.py` -> refactoring `initialize_model`, so now it becomes a comprehensive, main entry point for loading a `SparseModel`.

`src/sparseml/transformers/utils/load_task_model.py` -> look above, this function is an extension of `initialize_model` (now `initialize_sparse_model`)

## Testing

Tests in `tests/sparseml/export/transformers/test_generative_transformers.py` demonstrate the current capabilities of the new `export` module in the context of LLMs.