### PR TITLE
[Logger Framework][Add] mode and frequency type to FrequencyManager

### DIFF
--- a/tests/sparseml/core/logger/utils/test_frequency_manager.py
+++ b/tests/sparseml/core/logger/utils/test_frequency_manager.py
@@ -139,10 +139,9 @@ def test_log_ready(
     assert actual == expected
 
 
-def _test_cases__validate_log_frequency():
-    # "log_frequency, frequency_type, expectation"
-
-    return [
+@pytest.mark.parametrize(
+    "log_frequency, frequency_type, expectation",
+    [
         # epoch frequency type accepts floats
         (0.1, "epoch", does_not_raise()),
         # batch and step frequency types need
@@ -153,12 +152,7 @@ def _test_cases__validate_log_frequency():
         (-1, "epoch", pytest.raises(ValueError)),
         (-1, "batch", pytest.raises(ValueError)),
         (-1, "step", pytest.raises(ValueError)),
-    ]
-
-
-@pytest.mark.parametrize(
-    "log_frequency, frequency_type, expectation",
-    _test_cases__validate_log_frequency(),
+    ],
 )
 def test__validate_log_frequency(log_frequency, frequency_type, expectation):
     with expectation:

--- a/tests/sparseml/core/logger/utils/test_frequency_manager.py
+++ b/tests/sparseml/core/logger/utils/test_frequency_manager.py
@@ -137,3 +137,29 @@ def test_log_ready(
     )
 
     assert actual == expected
+
+
+def _test_cases__validate_log_frequency():
+    # "log_frequency, frequency_type, expectation"
+
+    return [
+        # epoch frequency type accepts floats
+        (0.1, "epoch", does_not_raise()),
+        # batch and step frequency types need
+        # log_frequency to be an integer
+        (0.1, "batch", pytest.raises(TypeError)),
+        (0.1, "step", pytest.raises(TypeError)),
+        # negative log_frequency is invalid
+        (-1, "epoch", pytest.raises(ValueError)),
+        (-1, "batch", pytest.raises(ValueError)),
+        (-1, "step", pytest.raises(ValueError)),
+    ]
+
+
+@pytest.mark.parametrize(
+    "log_frequency, frequency_type, expectation",
+    _test_cases__validate_log_frequency(),
+)
+def test__validate_log_frequency(log_frequency, frequency_type, expectation):
+    with expectation:
+        FrequencyManager(log_frequency=log_frequency, frequency_type=frequency_type)


### PR DESCRIPTION
This PR adds `frequency_type` ("epoch", "step", "batch") and `mode` ("exact", "on_change") to frequency manager:

```
The frequency type attribute controls what the frequency manager is tracking, e.g. if the frequency type
is "epoch", then the frequency manager will track the number of epochs that
have passed since the last log, if the frequency type is "step", then the
frequency manager will track the number of optimizer steps
```

```
 The logging mode to use, either "on_change" or "exact",
"on_change" will log when the model has been updated since the last log,
 "exact" will log at the given frequency regardless of model updates.
```

The frequency manager, now also keeps track of the last step when model 
was updated. Whenever updated the it is the responsibility of users to 
call `model_updated(step)` function.

These two arguments will provide more fine-grained control over the logs, and how to filter them to avoid over-logging

based off of #1860