### PR TITLE
[Use] frequency manager in logger

### DIFF
--- a/src/sparseml/core/helpers.py
+++ b/src/sparseml/core/helpers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Any, Generator, Optional, Tuple
+from typing import Any, Generator, Tuple
 
 from sparseml.core.logger import LoggerManager
 from sparseml.core.model.base import ModifiableModel
@@ -30,7 +30,6 @@ def should_log_model_info(
     model: ModifiableModel,
     loggers: LoggerManager,
     epoch: float,
-    last_log_epoch: Optional[float] = None,
 ) -> bool:
     """
     Check if we should log model level info
@@ -42,13 +41,12 @@ def should_log_model_info(
     :param model: The model whose info we want to log
     :param loggers: The logger manager to log to
     :param epoch: The current epoch
-    :param last_log_epoch: The last epoch we logged model info at
     :return: True if we should log model level info, False otherwise
     """
     return (
         hasattr(model, "loggable_items")
         and isinstance(loggers, LoggerManager)
-        and loggers.log_ready(epoch=epoch, last_log_epoch=last_log_epoch)
+        and loggers.log_ready(current_log_step=epoch)
     )
 
 

--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -29,9 +29,9 @@ from typing import Callable, Dict, List, Optional, Union
 
 from sparseml.core.logger.utils import (
     FrequencyManager,
+    FrequencyType,
+    LoggingModeType,
     LogStepType,
-    PossibleFrequencyType,
-    PossibleLoggingMode,
 )
 
 
@@ -814,8 +814,8 @@ class LoggerManager(ABC):
         log_frequency: Union[float, None] = 0.1,
         log_python: bool = True,
         name: str = "manager",
-        mode: PossibleLoggingMode = "on_change",
-        frequency_type: PossibleFrequencyType = "epoch",
+        mode: LoggingModeType = "on_change",
+        frequency_type: FrequencyType = "epoch",
     ):
         self._loggers = loggers or []
         self._name = name

--- a/src/sparseml/core/logger/utils/frequency_manager.py
+++ b/src/sparseml/core/logger/utils/frequency_manager.py
@@ -18,14 +18,14 @@ from typing import Literal, Union
 
 __all__ = [
     "FrequencyManager",
-    "PossibleLoggingMode",
-    "PossibleFrequencyType",
+    "LoggingModeType",
+    "FrequencyType",
     "LogStepType",
 ]
 
 LogStepType = Union[int, float, None]
-PossibleLoggingMode = Literal["on_change", "exact"]
-PossibleFrequencyType = Literal["epoch", "step", "batch"]
+LoggingModeType = Literal["on_change", "exact"]
+FrequencyType = Literal["epoch", "step", "batch"]
 
 
 class FrequencyManager:
@@ -46,8 +46,8 @@ class FrequencyManager:
     def __init__(
         self,
         log_frequency: LogStepType = None,
-        mode: PossibleLoggingMode = "exact",
-        frequency_type: PossibleFrequencyType = "epoch",
+        mode: LoggingModeType = "exact",
+        frequency_type: FrequencyType = "epoch",
     ):
         # sets self._logging_mode and self._check_model_update
         self._logging_mode = self._set_logging_mode(mode=mode)
@@ -196,7 +196,7 @@ class FrequencyManager:
                 f"log step must be greater than or equal to 0, given {log_step}"
             )
 
-    def _set_logging_mode(self, mode: PossibleLoggingMode) -> PossibleLoggingMode:
+    def _set_logging_mode(self, mode: LoggingModeType) -> LoggingModeType:
         """
         Set the logging mode for the frequency manager.
         The logging mode determines how the frequency manager determines
@@ -222,9 +222,7 @@ class FrequencyManager:
             )
         return self._logging_mode
 
-    def _set_frequency_type(
-        self, frequency_type: PossibleFrequencyType
-    ) -> PossibleFrequencyType:
+    def _set_frequency_type(self, frequency_type: FrequencyType) -> FrequencyType:
         """
         Set the frequency type for the frequency manager.
         The frequency type determines what the frequency manager is tracking.

--- a/src/sparseml/core/logger/utils/frequency_manager.py
+++ b/src/sparseml/core/logger/utils/frequency_manager.py
@@ -16,7 +16,12 @@
 from typing import Literal, Union
 
 
-__all__ = ["FrequencyManager"]
+__all__ = [
+    "FrequencyManager",
+    "PossibleLoggingMode",
+    "PossibleFrequencyType",
+    "LogStepType",
+]
 
 LogStepType = Union[int, float, None]
 PossibleLoggingMode = Literal["on_change", "exact"]
@@ -51,7 +56,7 @@ class FrequencyManager:
         self._frequency_type = self._set_frequency_type(frequency_type=frequency_type)
 
         self._validate_log_frequency(log_frequency=log_frequency)
-        self.log_frequency = log_frequency
+        self._log_frequency = log_frequency
 
         self.last_log_step: LogStepType = None
         self.last_model_update_step: LogStepType = None
@@ -90,11 +95,11 @@ class FrequencyManager:
         # e.g. 0.1 + 0.2 != 0.3
         # format(0.1 + 0.2, ".4f") == format(0.3, ".4f")
 
-        cadence_reached: bool = self.log_frequency is not None and (
+        cadence_reached: bool = self._log_frequency is not None and (
             current_log_step is None
             or self.last_log_step is None
             or current_log_step
-            >= float(format(self.last_log_step + self.log_frequency, ".4f"))
+            >= float(format(self.last_log_step + self._log_frequency, ".4f"))
         )
 
         if not cadence_reached or not check_model_update:
@@ -110,7 +115,7 @@ class FrequencyManager:
                 self.last_model_update_step >= self.last_log_step
                 and current_log_step
                 >= float(
-                    format(self.log_frequency + self.last_model_update_step, ".4f")
+                    format(self._log_frequency + self.last_model_update_step, ".4f")
                 )
             )
         )
@@ -136,6 +141,24 @@ class FrequencyManager:
         """
         self._validate_log_step(log_step=step)
         self.last_log_step = step
+
+    @property
+    def log_frequency(self) -> LogStepType:
+        """
+        :return: The log frequency
+        """
+        return self._log_frequency
+
+    @log_frequency.setter
+    def log_frequency(self, log_frequency: LogStepType) -> None:
+        """
+        Sets the log frequency to the given value
+
+        :param log_frequency: The log frequency to set
+        :post-cond: The log frequency is set to the given value
+        """
+        self._validate_log_frequency(log_frequency=log_frequency)
+        self._log_frequency = log_frequency
 
     def _validate_log_frequency(self, log_frequency):
         # checks that log frequency is a positive number or None

--- a/src/sparseml/pytorch/sparsification/modifier.py
+++ b/src/sparseml/pytorch/sparsification/modifier.py
@@ -438,7 +438,9 @@ class ScheduledModifier(Modifier, BaseScheduled):
             epoch = kwargs.get("epoch", None)
             steps_per_epoch = kwargs.get("steps_per_epoch", None)
             # Log call state
-            if self.loggers and self.loggers.log_ready(epoch, self._last_log_epoch):
+            if self.loggers and self.loggers.log_ready(
+                current_log_step=epoch, last_log_step=self._last_log_epoch
+            ):
                 self.log_string(
                     string=(
                         f"Calling {func.__name__} with:\n"
@@ -451,7 +453,9 @@ class ScheduledModifier(Modifier, BaseScheduled):
                 )
             out = func(*args, **kwargs)
             # Log return state
-            if self.loggers and self.loggers.log_ready(epoch, self._last_log_epoch):
+            if self.loggers and self.loggers.log_ready(
+                current_log_step=epoch, last_log_step=self._last_log_epoch
+            ):
                 out_print = out if isinstance(out, Tuple) else [out]
                 self.log_string(
                     string=(f"\nReturned: {format_args(out_print)}\n"),
@@ -671,7 +675,9 @@ class ScheduledModifier(Modifier, BaseScheduled):
         if not self._enabled:
             raise RuntimeError("modifier must be enabled")
 
-        if self.loggers and self.loggers.log_ready(epoch, self._last_log_epoch):
+        if self.loggers and self.loggers.log_ready(
+            current_log_step=epoch, last_log_step=self._last_log_epoch
+        ):
             self._last_log_epoch = epoch
             self._scheduled_log_called = True
             self.log_update(module, optimizer, epoch, steps_per_epoch)

--- a/src/sparseml/pytorch/sparsification/modifier.py
+++ b/src/sparseml/pytorch/sparsification/modifier.py
@@ -511,7 +511,7 @@ class ScheduledModifier(Modifier, BaseScheduled):
         self._ended = False
         self._schedule_called = False
         self._scheduled_log_called = False
-        self._last_log_epoch = -1
+        self._last_log_epoch = None
 
         self.validate_schedule()
 


### PR DESCRIPTION
This PR updates `LoggerManager` to use `FrequencyManager`

Few properties like `log_frequency` was moved
Add wrapper functions `model_updated` and `log_written` to `LoggerManager`

Based off of #1930 