### PR TITLE
[Add] Wrap System and Metric Logging into it's own classes

### DIFF
--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -108,6 +108,9 @@ class BaseLogger(ABC):
         """
         self._enabled = value
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(name={self._name}, enabled={self._enabled})"
+
     def log_hyperparams(self, params: Dict[str, float]) -> bool:
         """
         :param params: Each key-value pair in the dictionary is the name of the
@@ -830,6 +833,13 @@ class LoggerManager(ABC):
             log_frequency=log_frequency,
         )
 
+        self.system = SystemLoggingWraper(
+            loggers=self._loggers, frequency_manager=self.frequency_manager
+        )
+        self.metric = MetricLoggingWrapper(
+            loggers=self._loggers, frequency_manager=self.frequency_manager
+        )
+
     def __len__(self):
         return len(self.loggers)
 
@@ -948,6 +958,9 @@ class LoggerManager(ABC):
         level: Optional[int] = None,
     ):
         """
+        (Note: this method is deprecated and will be removed in a future version,
+        use LoggerManager().metric.log_scalar instead)
+
         :param tag: identifying tag to log the value with
         :param value: value to save
         :param step: global step for when the value was taken
@@ -955,15 +968,20 @@ class LoggerManager(ABC):
         :param kwargs: additional logging arguments to support Python and custom loggers
         :return: True if logged, False otherwise.
         """
-        for log in self.loggers:
-            if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
-                log.log_scalar(
-                    tag=tag,
-                    value=value,
-                    step=step,
-                    wall_time=wall_time,
-                    level=level,
-                )
+        warnings.warn(
+            message="LoggerManager().log_scalar is deprecated and will be removed in a "
+            "future version, use LoggerManager().metric.log_scalar instead",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.metric.log_scalar(
+            tag=tag,
+            value=value,
+            step=step,
+            wall_time=wall_time,
+            log_types=log_types,
+            level=level,
+        )
 
     def log_scalars(
         self,
@@ -975,6 +993,9 @@ class LoggerManager(ABC):
         level: Optional[int] = None,
     ):
         """
+        (Note: this method is deprecated and will be removed in a future version,
+        use LoggerManager().metric.log_scalars instead)
+
         :param tag: identifying tag to log the values with
         :param values: values to save
         :param step: global step for when the values were taken
@@ -982,15 +1003,117 @@ class LoggerManager(ABC):
         :param kwargs: additional logging arguments to support Python and custom loggers
         :return: True if logged, False otherwise.
         """
-        for log in self.loggers:
-            if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
-                log.log_scalars(
-                    tag=tag,
-                    values=values,
-                    step=step,
-                    wall_time=wall_time,
-                    level=level,
-                )
+        warnings.warn(
+            message="LoggerManager().log_scalars is deprecated and will be removed"
+            " in a future version, use LoggerManager().metric.log_scalars instead",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.metric.log_scalars(
+            tag=tag,
+            values=values,
+            step=step,
+            wall_time=wall_time,
+            log_types=log_types,
+            level=level,
+        )
+
+    def log_hyperparams(
+        self,
+        params: Dict,
+        log_types: Union[str, List[str]] = ALL_TOKEN,
+        level: Optional[int] = None,
+    ):
+        """
+        (Note: this method is deprecated and will be removed in a future version,
+        use LoggerManager().metric.log_hyperparams instead)
+
+        :param params: Each key-value pair in the dictionary is the name of the
+            hyper parameter and it's corresponding value.
+        """
+        warnings.warn(
+            message="LoggerManager().log_hyperparams is deprecated and will be "
+            "removed in a future version, use "
+            "LoggerManager().metric.log_hyperparams instead",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.metric.log_hyperparams(
+            params=params,
+            log_types=log_types,
+            level=level,
+        )
+
+    def log_string(
+        self,
+        tag: str,
+        string: str,
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        log_types: Union[str, List[str]] = ALL_TOKEN,
+        level: Optional[int] = None,
+    ):
+        """
+        (Note: this method is deprecated and will be removed in a future version,
+        use LoggerManager().system.log_string instead)
+
+        :param tag: identifying tag to log the values with
+        :param values: values to save
+        :param step: global step for when the values were taken
+        :param wall_time: global wall time for when the values were taken
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        warnings.warn(
+            message="LoggerManager().log_string is deprecated and will be "
+            "removed in a future version, use "
+            "LoggerManager().system.log_string instead",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        self.system.log_string(
+            tag=tag,
+            string=string,
+            step=step,
+            wall_time=wall_time,
+            log_types=log_types,
+            level=level,
+        )
+
+    def save(
+        self,
+        file_path: str,
+        **kwargs,
+    ):
+        """
+        :param file_path: path to a file to be saved
+        :param kwargs: additional arguments that a specific logger might use
+        """
+        for log in self._loggers:
+            if log.enabled:
+                log.save(file_path, **kwargs)
+
+
+class LoggingWrapperBase:
+    """
+    Base class that holds a reference to the loggers and frequency manager
+    """
+
+    def __init__(self, loggers: List[BaseLogger], frequency_manager: FrequencyManager):
+        self._loggers = loggers
+        self._frequency_manager = frequency_manager
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"loggers={self._loggers}, frequency_manager={self._frequency_manager})"
+        )
+
+
+class SystemLoggingWraper(LoggingWrapperBase):
+    """
+    Wraps utilities and convenience methods for logging strings to the system
+    """
 
     def log_string(
         self,
@@ -1018,20 +1141,6 @@ class LoggerManager(ABC):
                     wall_time=wall_time,
                     level=level,
                 )
-
-    def log_hyperparams(
-        self,
-        params: Dict,
-        log_types: Union[str, List[str]] = ALL_TOKEN,
-        level: Optional[int] = None,
-    ):
-        """
-        :param params: Each key-value pair in the dictionary is the name of the
-            hyper parameter and it's corresponding value.
-        """
-        for log in self._loggers:
-            if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
-                log.log_hyperparams(params, level)
 
     def debug(self, tag, string, *args, **kwargs):
         """
@@ -1116,18 +1225,79 @@ class LoggerManager(ABC):
         kwargs["level"] = logging.CRITICAL
         self.log_string(tag=tag, string=string, *args, **kwargs)
 
-    def save(
+
+class MetricLoggingWrapper(LoggingWrapperBase):
+    """
+    Wraps utilities and convenience methods for logging metrics to the system
+    """
+
+    def log_hyperparams(
         self,
-        file_path: str,
-        **kwargs,
+        params: Dict,
+        log_types: Union[str, List[str]] = ALL_TOKEN,
+        level: Optional[int] = None,
     ):
         """
-        :param file_path: path to a file to be saved
-        :param kwargs: additional arguments that a specific logger might use
+        :param params: Each key-value pair in the dictionary is the name of the
+            hyper parameter and it's corresponding value.
         """
         for log in self._loggers:
-            if log.enabled:
-                log.save(file_path, **kwargs)
+            if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
+                log.log_hyperparams(params, level)
+
+    def log_scalar(
+        self,
+        tag: str,
+        value: float,
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        log_types: Union[str, List[str]] = ALL_TOKEN,
+        level: Optional[int] = None,
+    ):
+        """
+        :param tag: identifying tag to log the value with
+        :param value: value to save
+        :param step: global step for when the value was taken
+        :param wall_time: global wall time for when the value was taken
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        for log in self.loggers:
+            if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
+                log.log_scalar(
+                    tag=tag,
+                    value=value,
+                    step=step,
+                    wall_time=wall_time,
+                    level=level,
+                )
+
+    def log_scalars(
+        self,
+        tag: str,
+        values: float,
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        log_types: Union[str, List[str]] = ALL_TOKEN,
+        level: Optional[int] = None,
+    ):
+        """
+        :param tag: identifying tag to log the values with
+        :param values: values to save
+        :param step: global step for when the values were taken
+        :param wall_time: global wall time for when the values were taken
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        for log in self.loggers:
+            if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
+                log.log_scalars(
+                    tag=tag,
+                    values=values,
+                    step=step,
+                    wall_time=wall_time,
+                    level=level,
+                )
 
 
 def _create_dirs(path: str):

--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -870,11 +870,12 @@ class LoggerManager(ABC):
         """
         log_enabled = any(logger.enabled for logger in self.loggers)
         if last_log_step is not None:
-            self.warning(
-                tag="warning",
-                string="specifying `last_log_step` is now deprecated "
+            warnings.warn(
+                message="specifying `last_log_step` is now deprecated "
                 "and will be removed in a future release. Update to use"
                 " `log_written(step)` to track the last log step",
+                category=DeprecationWarning,
+                stacklevel=2,
             )
             self.frequency_manager.log_written(step=last_log_step)
 
@@ -986,7 +987,7 @@ class LoggerManager(ABC):
     def log_scalars(
         self,
         tag: str,
-        values: float,
+        values: Dict[str, float],
         step: Optional[int] = None,
         wall_time: Optional[float] = None,
         log_types: Union[str, List[str]] = ALL_TOKEN,
@@ -1100,13 +1101,13 @@ class LoggingWrapperBase:
     """
 
     def __init__(self, loggers: List[BaseLogger], frequency_manager: FrequencyManager):
-        self._loggers = loggers
+        self.loggers = loggers
         self._frequency_manager = frequency_manager
 
     def __repr__(self):
         return (
             f"{self.__class__.__name__}("
-            f"loggers={self._loggers}, frequency_manager={self._frequency_manager})"
+            f"loggers={self.loggers}, frequency_manager={self._frequency_manager})"
         )
 
 
@@ -1241,7 +1242,7 @@ class MetricLoggingWrapper(LoggingWrapperBase):
         :param params: Each key-value pair in the dictionary is the name of the
             hyper parameter and it's corresponding value.
         """
-        for log in self._loggers:
+        for log in self.loggers:
             if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
                 log.log_hyperparams(params, level)
 
@@ -1275,7 +1276,7 @@ class MetricLoggingWrapper(LoggingWrapperBase):
     def log_scalars(
         self,
         tag: str,
-        values: float,
+        values: Dict[str, float],
         step: Optional[int] = None,
         wall_time: Optional[float] = None,
         log_types: Union[str, List[str]] = ALL_TOKEN,

--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -870,13 +870,6 @@ class LoggerManager(ABC):
         """
         log_enabled = any(logger.enabled for logger in self.loggers)
         if last_log_step is not None:
-            warnings.warn(
-                message="specifying `last_log_step` is now deprecated "
-                "and will be removed in a future release. Update to use"
-                " `log_written(step)` to track the last log step",
-                category=DeprecationWarning,
-                stacklevel=2,
-            )
             self.frequency_manager.log_written(step=last_log_step)
 
         return log_enabled and self.frequency_manager.log_ready(
@@ -969,12 +962,7 @@ class LoggerManager(ABC):
         :param kwargs: additional logging arguments to support Python and custom loggers
         :return: True if logged, False otherwise.
         """
-        warnings.warn(
-            message="LoggerManager().log_scalar is deprecated and will be removed in a "
-            "future version, use LoggerManager().metric.log_scalar instead",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
+
         self.metric.log_scalar(
             tag=tag,
             value=value,
@@ -1004,12 +992,7 @@ class LoggerManager(ABC):
         :param kwargs: additional logging arguments to support Python and custom loggers
         :return: True if logged, False otherwise.
         """
-        warnings.warn(
-            message="LoggerManager().log_scalars is deprecated and will be removed"
-            " in a future version, use LoggerManager().metric.log_scalars instead",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
+
         self.metric.log_scalars(
             tag=tag,
             values=values,
@@ -1032,13 +1015,7 @@ class LoggerManager(ABC):
         :param params: Each key-value pair in the dictionary is the name of the
             hyper parameter and it's corresponding value.
         """
-        warnings.warn(
-            message="LoggerManager().log_hyperparams is deprecated and will be "
-            "removed in a future version, use "
-            "LoggerManager().metric.log_hyperparams instead",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
+
         self.metric.log_hyperparams(
             params=params,
             log_types=log_types,
@@ -1065,13 +1042,6 @@ class LoggerManager(ABC):
         :param kwargs: additional logging arguments to support Python and custom loggers
         :return: True if logged, False otherwise.
         """
-        warnings.warn(
-            message="LoggerManager().log_string is deprecated and will be "
-            "removed in a future version, use "
-            "LoggerManager().system.log_string instead",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
         self.system.log_string(
             tag=tag,
             string=string,
@@ -1190,7 +1160,7 @@ class SystemLoggingWraper(LoggingWrapperBase):
 
     def warn(self, tag, string, *args, **kwargs):
         warnings.warn(
-            "The 'warn' method is deprecated, " "use 'warning' instead",
+            "The 'warn' method is deprecated, use 'warning' instead",
             DeprecationWarning,
             2,
         )

--- a/src/sparseml/core/logger/utils/frequency_manager.py
+++ b/src/sparseml/core/logger/utils/frequency_manager.py
@@ -61,6 +61,12 @@ class FrequencyManager:
         self.last_log_step: LogStepType = None
         self.last_model_update_step: LogStepType = None
 
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(log_frequency={self.log_frequency}, "
+            f"mode={self._logging_mode}, frequency_type={self._frequency_type})"
+        )
+
     def log_ready(
         self,
         current_log_step: LogStepType,

--- a/src/sparseml/pytorch/utils/logger.py
+++ b/src/sparseml/pytorch/utils/logger.py
@@ -12,21 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Contains code for loggers that help visualize the information from each modifier
+"""
 
-# This file has been moved to src/sparseml/core/logger.py
-# and is kept here for backwards compatibility.
-# It will be removed in a future release.
+import logging
+import os
+import time
+from abc import ABC
+from datetime import datetime
+from logging import CRITICAL, DEBUG, ERROR, INFO, WARN, Logger
+from types import ModuleType
+from typing import Callable, Dict, List, Optional, Union
 
-from sparseml.core.logger import (
-    LOGGING_LEVELS,
-    BaseLogger,
-    LambdaLogger,
-    LoggerManager,
-    PythonLogger,
-    SparsificationGroupLogger,
-    TensorBoardLogger,
-    WANDBLogger,
-)
+
+try:
+    try:
+        from torch.utils.tensorboard import SummaryWriter
+    except (ModuleNotFoundError, ImportError):
+        from tensorboardX import SummaryWriter
+    tensorboard_import_error = None
+except Exception as tensorboard_err:
+    SummaryWriter = object
+    tensorboard_import_error = tensorboard_err
+
+
+try:
+    import wandb
+
+    wandb_err = None
+except Exception as err:
+    wandb = None
+    wandb_err = err
+
+from sparseml.utils import ALL_TOKEN, create_dirs
 
 
 __all__ = [
@@ -39,3 +58,942 @@ __all__ = [
     "LoggerManager",
     "LOGGING_LEVELS",
 ]
+
+LOGGING_LEVELS = {
+    "debug": DEBUG,
+    "info": INFO,
+    "warn": WARN,
+    "error": ERROR,
+    "critical": CRITICAL,
+}
+
+
+class BaseLogger(ABC):
+    """
+    Base class that all modifier loggers must implement.
+
+    :param name: name given to the logger, used for identification
+    :param enabled: True to log, False otherwise
+    """
+
+    def __init__(self, name: str, enabled: bool = True):
+        self._name = name
+        self._enabled = enabled
+
+    @property
+    def name(self) -> str:
+        """
+        :return: name given to the logger, used for identification
+        """
+        return self._name
+
+    @property
+    def enabled(self) -> bool:
+        """
+        :return: True to log, False otherwise
+        """
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value: bool):
+        """
+        :param value: True to log, False otherwise
+        """
+        self._enabled = value
+
+    def log_hyperparams(self, params: Dict[str, float]) -> bool:
+        """
+        :param params: Each key-value pair in the dictionary is the name of the
+            hyper parameter and it's corresponding value.
+        :return: True if logged, False otherwise.
+        """
+        return False
+
+    def log_scalar(
+        self,
+        tag: str,
+        value: float,
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        **kwargs,
+    ) -> bool:
+        """
+        :param tag: identifying tag to log the value with
+        :param value: value to save
+        :param step: global step for when the value was taken
+        :param wall_time: global wall time for when the value was taken
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        return False
+
+    def log_scalars(
+        self,
+        tag: str,
+        values: Dict[str, float],
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        **kwargs,
+    ) -> bool:
+        """
+        :param tag: identifying tag to log the values with
+        :param values: values to save
+        :param step: global step for when the values were taken
+        :param wall_time: global wall time for when the values were taken
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        return False
+
+    def log_string(
+        self,
+        tag: str,
+        string: str,
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        **kwargs,
+    ) -> bool:
+        """
+        :param tag: identifying tag to log the values with
+        :param values: values to save
+        :param step: global step for when the values were taken
+        :param wall_time: global wall time for when the values were taken
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        return False
+
+    def save(
+        self,
+        file_path: str,
+        **kwargs,
+    ) -> bool:
+        """
+        :param file_path: path to a file to be saved
+        :param kwargs: additional arguments that a specific logger might use
+        :return: True if saved, False otherwise
+        """
+        return False
+
+
+class LambdaLogger(BaseLogger):
+    """
+    Logger that handles calling back to a lambda function with any logs.
+
+    :param lambda_func: the lambda function to call back into with any logs.
+        The expected call sequence is (tag, value, values, step, wall_time) -> bool
+        The return type is True if logged and False otherwise.
+    :param name: name given to the logger, used for identification;
+        defaults to lambda
+    :param enabled: True to log, False otherwise
+    """
+
+    def __init__(
+        self,
+        lambda_func: Callable[
+            [
+                Optional[str],
+                Optional[Union[float, str]],
+                Optional[Dict[str, float]],
+                Optional[int],
+                Optional[float],
+                Optional[int],
+            ],
+            bool,
+        ],
+        name: str = "lambda",
+        enabled: bool = True,
+    ):
+        super().__init__(name, enabled)
+        self._lambda_func = lambda_func
+        assert lambda_func, "lambda_func must be set to a callable function"
+
+    @property
+    def lambda_func(
+        self,
+    ) -> Callable[
+        [
+            Optional[str],
+            Optional[Union[float, str]],
+            Optional[Dict[str, float]],
+            Optional[int],
+            Optional[float],
+            Optional[int],
+        ],
+        bool,
+    ]:
+        """
+        :return: the lambda function to call back into with any logs.
+            The expected call sequence is (tag, value, values, step, wall_time)
+        """
+        return self._lambda_func
+
+    def log_hyperparams(
+        self,
+        params: Dict,
+        level: Optional[int] = None,
+    ) -> bool:
+        """
+        :param params: Each key-value pair in the dictionary is the name of the
+            hyper parameter and it's corresponding value.
+        :return: True if logged, False otherwise.
+        """
+        if not self.enabled:
+            return False
+
+        return self._lambda_func(
+            tag=None,
+            value=None,
+            values=params,
+            step=None,
+            wall_time=None,
+            level=level,
+        )
+
+    def log_scalar(
+        self,
+        tag: str,
+        value: float,
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        level: Optional[int] = None,
+    ) -> bool:
+        """
+        :param tag: identifying tag to log the value with
+        :param value: value to save
+        :param step: global step for when the value was taken
+        :param wall_time: global wall time for when the value was taken,
+            defaults to time.time()
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        if not wall_time:
+            wall_time = time.time()
+
+        return self._lambda_func(
+            tag=tag,
+            value=value,
+            values=None,
+            step=step,
+            wall_time=wall_time,
+            level=level,
+        )
+
+    def log_scalars(
+        self,
+        tag: str,
+        values: Dict[str, float],
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        level: Optional[int] = None,
+    ) -> bool:
+        """
+        :param tag: identifying tag to log the values with
+        :param values: values to save
+        :param step: global step for when the values were taken
+        :param wall_time: global wall time for when the values were taken,
+            defaults to time.time()
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        if not wall_time:
+            wall_time = time.time()
+
+        return self._lambda_func(
+            tag=tag,
+            value=None,
+            values=values,
+            step=step,
+            wall_time=wall_time,
+            level=level,
+        )
+
+
+class PythonLogger(LambdaLogger):
+    """
+    Modifier logger that handles printing values into a python logger instance.
+
+    :param logger: a logger instance to log to, if None then will create it's own
+    :param log_level: default level to log any incoming data at on the logging.Logger
+        instance when an explicit log level isn't provided
+    :param name: name given to the logger, used for identification;
+        defaults to python
+    :param enabled: True to log, False otherwise
+    """
+
+    def __init__(
+        self,
+        logger: Logger = None,
+        log_level: int = None,
+        name: str = "python",
+        enabled: bool = True,
+    ):
+        self._logger = logger or self._create_default_logger(log_level=log_level)
+
+        super().__init__(
+            lambda_func=self._log_lambda,
+            name=name,
+            enabled=enabled,
+        )
+
+    def __getattr__(self, item):
+        return getattr(self._logger, item)
+
+    @property
+    def logger(self) -> Logger:
+        """
+        :return: a logger instance to log to, if None then will create it's own
+        """
+        return self._logger
+
+    def _create_default_logger(self, log_level: Optional[int] = None) -> logging.Logger:
+        """
+        Create a default modifier logger, with a file handler logging at the debug level
+        and a stream handler logging to console at the specified level
+
+        :param log_level: logging level for the console logger
+        :return: logger
+        """
+        logger = logging.getLogger(__name__)
+
+        # File handler setup, for logging modifier debug statements
+        if not any(
+            isinstance(handler, logging.FileHandler) for handler in logger.handlers
+        ):
+            base_log_path = (
+                os.environ.get("NM_TEST_LOG_DIR")
+                if os.environ.get("NM_TEST_MODE")
+                else "sparse_logs"
+            )
+            now = datetime.now()
+            dt_string = now.strftime("%d-%m-%Y_%H.%M.%S")
+            log_path = os.path.join(base_log_path, f"{dt_string}.log")
+            os.makedirs(base_log_path, exist_ok=True)
+            file_handler = logging.FileHandler(
+                log_path,
+                delay=True,
+            )
+            file_handler.setLevel(LOGGING_LEVELS["debug"])
+            logger.addHandler(file_handler)
+            logger.info(f"Logging all SparseML modifier-level logs to {log_path}")
+
+        if not any(
+            isinstance(handler, logging.StreamHandler) for handler in logger.handlers
+        ):
+            # Console handler, for logging high level modifier logs
+            stream_handler = logging.StreamHandler()
+            stream_handler.setLevel(log_level or logging.getLogger("sparseml").level)
+            logger.addHandler(stream_handler)
+
+        logger.setLevel(LOGGING_LEVELS["debug"])
+        logger.propagate = False
+
+        return logger
+
+    def _log_lambda(
+        self,
+        tag: Optional[str],
+        value: Optional[Union[float, str]],
+        values: Optional[Dict[str, float]],
+        step: Optional[int],
+        wall_time: Optional[float],
+        level: Optional[int] = None,
+    ) -> bool:
+        """
+        :param tag: identifying tag to log the values with
+        :param value: value to save
+        :param values: values to save
+        :param step: global step for when the values were taken
+        :param wall_time: global wall time for when the values were taken,
+            defaults to time.time()
+        :param level: level to log at. Corresponds to default logging package levels
+        :return: True if logged, False otherwise.
+        """
+        if not level:
+            level = LOGGING_LEVELS["debug"]
+
+        if level > LOGGING_LEVELS["debug"]:
+            format = "%s %s step %s: %s"
+            log_args = [
+                self.name,
+                tag,
+                step,
+                values or value,
+            ]
+        else:
+            format = "%s %s [%s - %s]: %s"
+            log_args = [self.name, tag, step, wall_time, values or value]
+
+        self._logger.log(level, format, *log_args)
+
+        return True
+
+    def log_string(
+        self,
+        tag: Optional[str],
+        string: Optional[str],
+        step: Optional[int],
+        wall_time: Optional[float] = None,
+        level: Optional[int] = None,
+    ) -> bool:
+        """
+        :param tag: identifying tag to log the values with
+        :param string: string to log
+        :param step: global step for when the values were taken
+        :param wall_time: global wall time for when the values were taken,
+            defaults to time.time()
+        :param level: level to log at. Corresponds to default logging package levels
+        :return: True if logged, False otherwise.
+        """
+        if not wall_time:
+            wall_time = time.time()
+
+        return self._lambda_func(
+            tag=tag,
+            value=string,
+            values=None,
+            step=step,
+            level=level,
+            wall_time=wall_time,
+        )
+
+
+class TensorBoardLogger(LambdaLogger):
+    """
+    Modifier logger that handles outputting values into a TensorBoard log directory
+    for viewing in TensorBoard.
+
+    :param log_path: the path to create a SummaryWriter at. writer must be None
+        to use if not supplied (and writer is None),
+        will create a TensorBoard dir in cwd
+    :param writer: the writer to log results to,
+        if none is given creates a new one at the log_path
+    :param name: name given to the logger, used for identification;
+        defaults to tensorboard
+    :param enabled: True to log, False otherwise
+    """
+
+    def __init__(
+        self,
+        log_path: str = None,
+        writer: SummaryWriter = None,
+        name: str = "tensorboard",
+        enabled: bool = True,
+    ):
+        if tensorboard_import_error:
+            raise tensorboard_import_error
+
+        if writer and log_path:
+            raise ValueError(
+                (
+                    "log_path given:{} and writer object passed in, "
+                    "to create a writer at the log path set writer=None"
+                ).format(log_path)
+            )
+        elif not writer and not log_path:
+            log_path = os.path.join(".", "tensorboard")
+
+        if os.environ.get("NM_TEST_MODE"):
+            test_log_root = os.environ.get("NM_TEST_LOG_DIR")
+            log_path = (
+                os.path.join(test_log_root, log_path) if log_path else test_log_root
+            )
+
+        if log_path:
+            create_dirs(log_path)
+
+        self._writer = writer if writer is not None else SummaryWriter(log_path)
+        super().__init__(
+            lambda_func=self._log_lambda,
+            name=name,
+            enabled=enabled,
+        )
+
+    @property
+    def writer(self) -> SummaryWriter:
+        """
+        :return: the writer to log results to,
+            if none is given creates a new one at the log_path
+        """
+        return self._writer
+
+    def _log_lambda(
+        self,
+        tag: Optional[str],
+        value: Optional[float],
+        values: Optional[Dict[str, float]],
+        step: Optional[int],
+        wall_time: Optional[float],
+        level: Optional[int] = None,
+    ) -> bool:
+        if value is not None:
+            self._writer.add_scalar(tag, value, step, wall_time)
+
+        if values and tag:
+            self._writer.add_scalars(tag, values, step, wall_time)
+        elif values:
+            for name, val in values.items():
+                # hyperparameters logging case
+                self._writer.add_scalar(name, val, step, wall_time)
+
+        return True
+
+
+class WANDBLogger(LambdaLogger):
+    """
+    Modifier logger that handles outputting values to Weights and Biases.
+
+    :param init_kwargs: the args to call into wandb.init with;
+        ex: wandb.init(**init_kwargs). If not supplied, then init will not be called
+    :param name: name given to the logger, used for identification;
+        defaults to wandb
+    :param enabled: True to log, False otherwise
+    """
+
+    @staticmethod
+    def available() -> bool:
+        """
+        :return: True if wandb is available and installed, False, otherwise
+        """
+        return not wandb_err
+
+    def __init__(
+        self,
+        init_kwargs: Optional[Dict] = None,
+        name: str = "wandb",
+        enabled: bool = True,
+        wandb_err: Optional[Exception] = wandb_err,
+    ):
+        if wandb_err:
+            raise ModuleNotFoundError(
+                "Error: Failed to import wandb. "
+                "Please install the wandb library in order to use it."
+            ) from wandb_err
+
+        super().__init__(
+            lambda_func=self._log_lambda,
+            name=name,
+            enabled=enabled,
+        )
+
+        if os.environ.get("NM_TEST_MODE"):
+            test_log_path = os.environ.get("NM_TEST_LOG_DIR")
+            create_dirs(test_log_path)
+            if init_kwargs:
+                init_kwargs["dir"] = test_log_path
+            else:
+                init_kwargs = {"dir": test_log_path}
+
+        if wandb_err:
+            raise wandb_err
+
+        if init_kwargs:
+            wandb.init(**init_kwargs)
+        else:
+            wandb.init()
+
+        self.wandb = wandb
+
+    def _log_lambda(
+        self,
+        tag: Optional[str],
+        value: Optional[float],
+        values: Optional[Dict[str, float]],
+        step: Optional[int],
+        wall_time: Optional[float],
+        level: Optional[int] = None,
+    ) -> bool:
+        params = {}
+
+        if value:
+            params[tag] = value
+
+        if values:
+            if tag:
+                values = {f"{tag}/{key}": val for key, val in values.items()}
+            params.update(values)
+
+        wandb.log(params, step=step)
+
+        return True
+
+    def save(
+        self,
+        file_path: str,
+    ) -> bool:
+        """
+        :param file_path: path to a file to be saved
+        """
+        wandb.save(file_path)
+        return True
+
+
+class SparsificationGroupLogger(BaseLogger):
+    """
+    Modifier logger that handles outputting values to other supported systems.
+    Supported ones include:
+      - Python logging
+      - Tensorboard
+      - Weights and Biases
+      - Lambda callback
+
+    All are optional and can be bulk disabled and enabled by this root.
+
+    :param lambda_func: an optional lambda function to call back into with any logs.
+        The expected call sequence is (tag, value, values, step, wall_time) -> bool
+        The return type is True if logged and False otherwise.
+    :param python: an optional argument for logging to a python logger.
+        May be a logging.Logger instance to log to, True to create a logger instance,
+        or non truthy to not log anything (False, None)
+    :param python_log_level: if python,
+        the level to log any incoming data at on the logging.Logger instance
+    :param tensorboard: an optional argument for logging to a tensorboard writer.
+        May be a SummaryWriter instance to log to, a string representing the directory
+        to create a new SummaryWriter to log to, True to create a new SummaryWriter,
+        or non truthy to not log anything (False, None)
+    :param wandb_: an optional argument for logging to wandb.
+        May be a dictionary to pass to the init call for wandb,
+        True to log to wandb (will not call init),
+        or non truthy to not log anything (False, None)
+    :param name: name given to the logger, used for identification;
+        defaults to sparsification
+    :param enabled: True to log, False otherwise
+    """
+
+    def __init__(
+        self,
+        lambda_func: Optional[
+            Callable[
+                [
+                    Optional[str],
+                    Optional[float],
+                    Optional[Dict[str, float]],
+                    Optional[int],
+                    Optional[float],
+                ],
+                bool,
+            ]
+        ] = None,
+        python: Optional[Union[bool, Logger]] = None,
+        python_log_level: int = logging.INFO,
+        tensorboard: Optional[Union[bool, str, SummaryWriter]] = None,
+        wandb_: Optional[Union[bool, Dict]] = None,
+        name: str = "sparsification",
+        enabled: bool = True,
+    ):
+        super().__init__(name, enabled)
+        self._loggers: List[BaseLogger] = []
+
+        if lambda_func:
+            self._loggers.append(
+                LambdaLogger(lambda_func=lambda_func, name=name, enabled=enabled)
+            )
+
+        if python:
+            self._loggers.append(
+                PythonLogger(
+                    logger=python if isinstance(python, Logger) else None,
+                    log_level=python_log_level,
+                    name=name,
+                    enabled=enabled,
+                )
+            )
+
+        if tensorboard:
+            self._loggers.append(
+                TensorBoardLogger(
+                    log_path=tensorboard if isinstance(tensorboard, str) else None,
+                    writer=(
+                        tensorboard if isinstance(tensorboard, SummaryWriter) else None
+                    ),
+                    name=name,
+                    enabled=enabled,
+                )
+            )
+
+        if wandb_ and WANDBLogger.available():
+            self._loggers.append(
+                WANDBLogger(
+                    init_kwargs=wandb_ if isinstance(wandb_, Dict) else None,
+                    name=name,
+                    enabled=enabled,
+                )
+            )
+
+    @BaseLogger.enabled.setter
+    def enabled(self, value: bool):
+        """
+        :param value: True to log, False otherwise
+        """
+        self._enabled = value
+
+        for logger in self._loggers:
+            logger.enabled = value
+
+    @property
+    def loggers(self) -> List[BaseLogger]:
+        """
+        :return: the created logger sub instances for this logger
+        """
+        return self._loggers
+
+    def log_hyperparams(self, params: Dict, level: Optional[int] = None):
+        """
+        :param params: Each key-value pair in the dictionary is the name of the
+            hyper parameter and it's corresponding value.
+        """
+        for logger in self._loggers:
+            logger.log_hyperparams(params, level)
+
+    def log_scalar(
+        self,
+        tag: str,
+        value: float,
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        level: Optional[int] = None,
+    ):
+        """
+        :param tag: identifying tag to log the value with
+        :param value: value to save
+        :param step: global step for when the value was taken
+        :param wall_time: global wall time for when the value was taken,
+            defaults to time.time()
+        """
+        for logger in self._loggers:
+            logger.log_scalar(tag, value, step, wall_time, level)
+
+    def log_scalars(
+        self,
+        tag: str,
+        values: Dict[str, float],
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        level: Optional[int] = None,
+    ):
+        """
+        :param tag: identifying tag to log the values with
+        :param values: values to save
+        :param step: global step for when the values were taken
+        :param wall_time: global wall time for when the values were taken,
+            defaults to time.time()
+        """
+        for logger in self._loggers:
+            logger.log_scalars(tag, values, step, wall_time, level)
+
+
+class LoggerManager(ABC):
+    """
+    Wrapper around loggers that handles log scheduling and handing off logs to intended
+    loggers.
+
+    :param loggers: list of loggers assigned to this manager
+    :param log_frequency: number of epochs or fraction of epochs to wait between logs
+
+    """
+
+    def __init__(
+        self,
+        loggers: Optional[List[BaseLogger]] = None,
+        log_frequency: Union[float, None] = 0.1,
+        log_python: bool = True,
+        name: str = "manager",
+    ):
+        self._loggers = loggers or []
+        self._log_frequency = log_frequency
+        self._name = name
+        if log_python and not any(
+            isinstance(log, PythonLogger) for log in self._loggers
+        ):
+            self._loggers.append(PythonLogger())
+
+    def __len__(self):
+        return len(self.loggers)
+
+    def __iter__(self):
+        return iter(self.loggers)
+
+    def add_logger(self, logger: BaseLogger):
+        """
+        add a BaseLogger implementation to the loggers of this manager
+
+        :param logger: logger object to add
+        """
+        if not isinstance(logger, BaseLogger):
+            raise ValueError(f"logger {type(logger)} must be of type BaseLogger")
+        self._loggers.append(logger)
+
+    def log_ready(self, epoch, last_log_epoch):
+        """
+        Check if there is a logger that is ready to accept a log
+
+        :param epoch: current epoch log is requested at
+        :param last_log_epoch: last time a log was recorder for this object
+        :return: True if a logger is ready to accept a log.
+        """
+        return (
+            self._log_frequency is not None
+            and (
+                epoch is None
+                or epoch == last_log_epoch
+                or epoch >= last_log_epoch + self._log_frequency
+            )
+            and any(log.enabled for log in self.loggers)
+        )
+
+    @staticmethod
+    def epoch_to_step(epoch, steps_per_epoch):
+        return round(epoch) if steps_per_epoch <= 0 else round(epoch * steps_per_epoch)
+
+    @property
+    def loggers(self) -> List[BaseLogger]:
+        """
+        :return: list of loggers assigned to this manager
+        """
+        return self._loggers
+
+    @loggers.setter
+    def loggers(self, value: List[BaseLogger]):
+        """
+        :param value: list of loggers assigned to this manager
+        """
+        self._loggers = value
+
+    @property
+    def log_frequency(self) -> Union[str, float, None]:
+        """
+        :return: number of epochs or fraction of epochs to wait between logs
+        """
+        return self._log_frequency
+
+    @log_frequency.setter
+    def log_frequency(self, value: Union[str, float, None]):
+        """
+        :param value: number of epochs or fraction of epochs to wait between logs
+        """
+        self._log_frequency = value
+
+    @property
+    def name(self) -> str:
+        """
+        :return: name given to the logger, used for identification
+        """
+        return self._name
+
+    @property
+    def wandb(self) -> Optional[ModuleType]:
+        """
+        :return: wandb module if initialized
+        """
+        for log in self.loggers:
+            if isinstance(log, WANDBLogger) and log.enabled:
+                return log.wandb
+        return None
+
+    def log_scalar(
+        self,
+        tag: str,
+        value: float,
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        log_types: Union[str, List[str]] = ALL_TOKEN,
+        level: Optional[int] = None,
+    ):
+        """
+        :param tag: identifying tag to log the value with
+        :param value: value to save
+        :param step: global step for when the value was taken
+        :param wall_time: global wall time for when the value was taken
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        for log in self.loggers:
+            if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
+                log.log_scalar(
+                    tag=tag,
+                    value=value,
+                    step=step,
+                    wall_time=wall_time,
+                    level=level,
+                )
+
+    def log_scalars(
+        self,
+        tag: str,
+        values: float,
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        log_types: Union[str, List[str]] = ALL_TOKEN,
+        level: Optional[int] = None,
+    ):
+        """
+        :param tag: identifying tag to log the values with
+        :param values: values to save
+        :param step: global step for when the values were taken
+        :param wall_time: global wall time for when the values were taken
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        for log in self.loggers:
+            if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
+                log.log_scalars(
+                    tag=tag,
+                    values=values,
+                    step=step,
+                    wall_time=wall_time,
+                    level=level,
+                )
+
+    def log_string(
+        self,
+        tag: str,
+        string: str,
+        step: Optional[int] = None,
+        wall_time: Optional[float] = None,
+        log_types: Union[str, List[str]] = ALL_TOKEN,
+        level: Optional[int] = None,
+    ):
+        """
+        :param tag: identifying tag to log the values with
+        :param values: values to save
+        :param step: global step for when the values were taken
+        :param wall_time: global wall time for when the values were taken
+        :param kwargs: additional logging arguments to support Python and custom loggers
+        :return: True if logged, False otherwise.
+        """
+        for log in self.loggers:
+            if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
+                log.log_string(
+                    tag=tag,
+                    string=string,
+                    step=step,
+                    wall_time=wall_time,
+                    level=level,
+                )
+
+    def log_hyperparams(
+        self,
+        params: Dict,
+        log_types: Union[str, List[str]] = ALL_TOKEN,
+        level: Optional[int] = None,
+    ):
+        """
+        :param params: Each key-value pair in the dictionary is the name of the
+            hyper parameter and it's corresponding value.
+        """
+        for log in self._loggers:
+            if log.enabled and (log_types == ALL_TOKEN or log.name in log_types):
+                log.log_hyperparams(params, level)
+
+    def save(
+        self,
+        file_path: str,
+        **kwargs,
+    ):
+        """
+        :param file_path: path to a file to be saved
+        :param kwargs: additional arguments that a specific logger might use
+        """
+        for log in self._loggers:
+            if log.enabled:
+                log.save(file_path, **kwargs)

--- a/tests/sparseml/pytorch/utils/test_logger.py
+++ b/tests/sparseml/pytorch/utils/test_logger.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import time
+from abc import ABC
+
+import pytest
+
+from sparseml.pytorch.utils import (
+    LambdaLogger,
+    LoggerManager,
+    PythonLogger,
+    SparsificationGroupLogger,
+    TensorBoardLogger,
+    WANDBLogger,
+)
+
+
+@pytest.mark.skipif(
+    os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
+    reason="Skipping pytorch tests",
+)
+@pytest.mark.parametrize(
+    "logger",
+    [
+        PythonLogger(),
+        TensorBoardLogger(),
+        LambdaLogger(
+            lambda_func=lambda tag, value, values, step, wall_time, level: logging.info(
+                f"{tag}, {value}, {values}, {step}, {wall_time}, {level}"
+            )
+            or True
+        ),
+        *([WANDBLogger()] if WANDBLogger.available() else []),
+        SparsificationGroupLogger(
+            lambda_func=lambda tag, value, values, step, wall_time, level: logging.info(
+                f"{tag}, {value}, {values}, {step}, {wall_time}, {level}"
+            )
+            or True,
+            python=True,
+            tensorboard=True,
+            wandb_=True,
+        ),
+        LoggerManager(),
+        LoggerManager(
+            [
+                TensorBoardLogger(),
+                WANDBLogger() if WANDBLogger.available() else PythonLogger(),
+            ]
+        ),
+    ],
+)
+class TestModifierLogger(ABC):
+    def test_name(self, logger):
+        assert logger.name is not None
+
+    def test_log_hyperparams(self, logger):
+        logger.log_hyperparams({"param1": 0.0, "param2": 1.0})
+        logger.log_hyperparams({"param1": 0.0, "param2": 1.0}, level=10)
+
+    def test_log_scalar(self, logger):
+        logger.log_scalar("test-scalar-tag", 0.1)
+        logger.log_scalar("test-scalar-tag", 0.1, 1)
+        logger.log_scalar("test-scalar-tag", 0.1, 2, time.time() - 1)
+        logger.log_scalar("test-scalar-tag", 0.1, 2, time.time() - 1, level=10)
+
+    def test_log_scalars(self, logger):
+        logger.log_scalars("test-scalars-tag", {"scalar1": 0.0, "scalar2": 1.0})
+        logger.log_scalars("test-scalars-tag", {"scalar1": 0.0, "scalar2": 1.0}, 1)
+        logger.log_scalars(
+            "test-scalars-tag", {"scalar1": 0.0, "scalar2": 1.0}, 2, time.time() - 1
+        )
+        logger.log_scalars(
+            "test-scalars-tag",
+            {"scalar1": 0.0, "scalar2": 1.0},
+            2,
+            time.time() - 1,
+            level=10,
+        )


### PR DESCRIPTION
Move(s) 
- string logging functions to SystemLoggingWrapper 
- metric logging functions to `MetricLoggingWrapper`

Test Code:
```python
from sparseml.core import LoggerManager

def local_():
    l = LoggerManager()
    l.system.debug("debug log", "Hello World!")
    l.system.warning("warn log", "Hello World!")
    l.system.critical("crtitical log", "Hello World!")
    l.system.info("info log", "Hello World!")
    
    l.metric.log_hyperparams({"lr": 0.1, "batch_size": 32})
    l.metric.log_scalar("loss", 0.1)
    l.metric.log_scalars("losses", {"train": 0.1, "val": 0.2})

if __name__ == "__main__":
    local_()
```


Output:
```
Logging all SparseML modifier-level logs to sparse_logs/02-01-2024_09.00.47.log
python debug log [None - 1704204047.9992712]: Hello World!
python warn log step None: Hello World!
python crtitical log step None: Hello World!
python info log step None: Hello World!
python None [None - None]: {'lr': 0.1, 'batch_size': 32}
python loss [None - 1704204047.9995282]: 0.1
python losses [None - 1704204047.9995587]: {'train': 0.1, 'val': 0.2}
```

Based off of #1931 