### PR TITLE
[Fix] log format when step is `None`

### DIFF
--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -422,13 +422,17 @@ class PythonLogger(LambdaLogger):
             level = LOGGING_LEVELS["debug"]
 
         if level > LOGGING_LEVELS["debug"]:
-            format = "%s %s step %s: %s"
-            log_args = [
-                self.name,
-                tag,
-                step,
-                values or value,
-            ]
+            if step is not None:
+                format = "%s %s step %s: %s"
+                log_args = [
+                    self.name,
+                    tag,
+                    step,
+                    values or value,
+                ]
+            else:
+                format = "%s %s: %s"
+                log_args = [self.name, tag, values or value]
         else:
             format = "%s %s [%s - %s]: %s"
             log_args = [self.name, tag, step, wall_time, values or value]


### PR DESCRIPTION
This PR updates the log format if step is `None`
giving us cleaner output

```python
def check_none_step():
    logger_manager = LoggerManager()
    logger_manager.system.info("info log", "Hello World!")
```

Output:
```bash
$ python local/scripts/dummy.py                                                                                                                               (remove-none-step|✚1⚑8)
Logging all SparseML modifier-level logs to sparse_logs/02-01-2024_09.39.49.log
2024-01-02 09:39:49 sparseml.core.logger.logger INFO     Logging all SparseML modifier-level logs to sparse_logs/02-01-2024_09.39.49.log
python info log: Hello World!
```

Before, a `None` step was also logged