### PR TITLE
[Export][Transformers] Enable loading `text-generation` datasets

### DIFF
--- a/src/sparseml/export/export.py
+++ b/src/sparseml/export/export.py
@@ -45,7 +45,6 @@ def export(
     opset: int = TORCH_DEFAULT_ONNX_OPSET,
     single_graph_file: bool = True,
     num_export_samples: int = 0,
-    batch_size: int = 1,
     recipe: Optional[Union[Path, str]] = None,
     deployment_directory_name: str = "deployment",
     device: str = "cpu",
@@ -90,8 +89,6 @@ def export(
         file. Defaults to True.
     :param num_export_samples: The number of samples to create for
         the exported model. Defaults to 0.
-    :param batch_size: The batch size to use for exporting the data.
-        Defaults to None.
     :param deployment_directory_name: The name of the deployment
         directory to create for the exported model. Thus, the exported
         model will be saved to `target_path/deployment_directory_name`.
@@ -157,7 +154,6 @@ def export(
         source_path,
         device=device,
         task=task,
-        batch_size=batch_size,
         recipe=recipe,
         **kwargs,
     )
@@ -223,16 +219,6 @@ def export(
         onnx_model_name=onnx_model_name,
     )
 
-    _LOGGER.info(
-        f"Applying optimizations: {graph_optimizations} to the exported model..."
-    )
-    if helper_functions.apply_optimizations is not None:
-        helper_functions.apply_optimizations(
-            exported_file_path=os.path.join(deployment_path, onnx_model_name),
-            optimizations=graph_optimizations,
-            single_graph_file=single_graph_file,
-        )
-
     if validate_structure:
         _LOGGER.info("Validating model structure...")
         validate_structure_(
@@ -252,6 +238,17 @@ def export(
                 "to True"
             )
         validate_correctness_(target_path, deployment_path, onnx_model_name)
+
+    _LOGGER.info(
+        f"Applying optimizations: {graph_optimizations} to the exported model..."
+    )
+
+    if helper_functions.apply_optimizations is not None:
+        helper_functions.apply_optimizations(
+            exported_file_path=os.path.join(deployment_path, onnx_model_name),
+            optimizations=graph_optimizations,
+            single_graph_file=single_graph_file,
+        )
 
     _LOGGER.info(
         f"Successfully exported model from:\n{target_path}"

--- a/src/sparseml/export/export_data.py
+++ b/src/sparseml/export/export_data.py
@@ -188,12 +188,36 @@ def run_inference_with_dict_data(
     else:
         inputs = {key: value.to(model.device) for key, value in data.items()}
         output_vals = model(**inputs)
+        if "past_key_values" in output_vals.keys():
+            output_vals = _unnest_past_key_values(output_vals)
         output = {
             name: torch.squeeze(val).detach().to("cpu")
             for name, val in output_vals.items()
         }
     inputs = {key: value.to("cpu") for key, value in data.items()}
     return inputs, labels, output
+
+
+def _unnest_past_key_values(output_vals: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Unnest the past key values from the output of the model.
+    (so they exist on the top level of the output dictionary)
+    By default the past key values are nested in a list of unnamed
+    tuples. This function unnests them and names them.
+
+    :param output_vals: The output of the model
+    :return: The output of the model with the past key values unpacked
+    """
+
+    past_key_values = output_vals["past_key_values"]
+    output_vals = {
+        key: value for key, value in output_vals.items() if key != "past_key_values"
+    }
+    for i, past_key_values in enumerate(past_key_values):
+        key, value = past_key_values
+        output_vals[f"past_key_values_{i}_key"] = key
+        output_vals[f"past_key_values_{i}_value"] = value
+    return output_vals
 
 
 def run_inference_with_tuple_or_list_data(

--- a/src/sparseml/export/validators.py
+++ b/src/sparseml/export/validators.py
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import logging
 import os.path
+from collections import OrderedDict
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Union
+
+import numpy
+import onnxruntime as ort
 
 from sparseml.export.export_data import InputsNames, LabelNames, OutputsNames
 from sparseml.export.helpers import ONNX_MODEL_NAME
-from sparsezoo.inference import InferenceRunner
-from sparsezoo.objects import File, NumpyDirectory
+from sparsezoo.utils.numpy import load_numpy
 
 
 __all__ = ["validate_correctness", "validate_structure"]
@@ -98,47 +102,82 @@ def check_file_presence(file_paths: List[str]) -> List[str]:
     return missing_files
 
 
-# TODO: Need to add few changes to sparsezoo to support this function
+def top_k_match(
+    ground_truth: numpy.ndarray, prediction: numpy.ndarray, k: int = 2
+) -> bool:
+    """
+    Checks if the top k predictions match the ground truth.
+
+    :param ground_truth: The ground truth array.
+    :param prediction: The prediction array.
+    :param k: The number of top predictions to consider.
+    """
+    top_k_prediction = numpy.argsort(prediction.flatten())[-k:]
+    top_k_ground_truth = numpy.argsort(ground_truth.flatten())[-k:]
+    return numpy.all(top_k_prediction == top_k_ground_truth)
+
+
 def validate_correctness(
-    target_path: Union[str, Path], directory: Union[str, Path], onnx_model_name: str
-):
+    target_path: Union[str, Path],
+    directory: Union[str, Path],
+    onnx_model_name: str,
+    validation_function: Callable[..., bool] = top_k_match,
+) -> bool:
     """
     Validates the correctness of the exported ONNX model by
     running it on a set of sample inputs and comparing the
-    resulting outputs with precomputed ground truth values.
+    resulting outputs using a validation function.
 
     :param target_path: The directory where the sample inputs and outputs are stored.
     :param directory: The directory where the ONNX model is stored.
     :param onnx_model_name: The name of the ONNX model.
+    :param validation_function: The function that will be used to validate the outputs.
+    :return: True if the validation passes, False otherwise.
     """
-    # TODO: During testing add a support for tar.gz scenario (potentially)
+
     sample_inputs_path = os.path.join(target_path, InputsNames.basename.value)
     sample_outputs_path = os.path.join(target_path, OutputsNames.basename.value)
 
-    sample_inputs = NumpyDirectory(
-        name=InputsNames.basename.value,
-        files=[
-            File(name=file_name, path=os.path.join(sample_inputs_path, file_name))
-            for file_name in os.listdir(sample_inputs_path)
-        ],
-        path=sample_inputs_path,
-    )
-    sample_outputs = NumpyDirectory(
-        name=OutputsNames.basename.value,
-        files=[
-            File(name=file_name, path=os.path.join(sample_outputs_path, file_name))
-            for file_name in os.listdir(sample_outputs_path)
-        ],
-        path=sample_outputs_path,
-    )
-    onnx_model = File(
-        name=onnx_model_name, path=os.path.join(directory, onnx_model_name)
-    )
+    sample_inputs_files = sorted(glob.glob(os.path.join(sample_inputs_path, "*")))
+    sample_outputs_files = sorted(glob.glob(os.path.join(sample_outputs_path, "*")))
 
-    runner = InferenceRunner(
-        sample_inputs=sample_inputs,
-        sample_outputs=sample_outputs,
-        onnx_file=onnx_model,
-    )
+    session = ort.InferenceSession(os.path.join(directory, onnx_model_name))
 
-    runner.validate_with_onnx_runtime()
+    validations = (
+        []
+    )  # stores boolean per sample pair (True if validation passes, False otherwise)
+
+    for sample_input_file, sample_output_file in zip(
+        sample_inputs_files, sample_outputs_files
+    ):
+        sample_input = load_numpy(sample_input_file)
+        sample_output = load_numpy(sample_output_file)
+
+        sample_input_with_batch_dim = OrderedDict(
+            (key, numpy.expand_dims(value, 0)) for key, value in sample_input.items()
+        )
+        outputs = session.run(None, sample_input_with_batch_dim)
+        if isinstance(outputs, list):
+            validations_sample = []
+            for o1, o2 in zip(outputs, sample_output.values()):
+                validations_sample.append(validation_function(o1, o2))
+            validations.append(all(validations_sample))
+        else:
+            validations.append(validation_function(outputs, sample_output))
+
+    if not all(validations):
+        _LOGGER.error(
+            f"Correctness validation failed for exported model: {onnx_model_name}. "
+            "The model outputs match the expected outputs "
+            f"only for {sum(validations)}/{len(validations)} samples "
+            f"(according to the validation function: {validation_function.__name__}. "
+            f"Some failures are expected in the case of quantized models, but not in "
+            f"the case of non-quantized models. If in doubt, validate the performance "
+            f"of the exported ONNX model using the NeuralMagic evaluation module."
+        )
+        return False
+
+    _LOGGER.info(
+        f"Successfully validated the exported model on all {len(validations)} samples."
+    )
+    return True

--- a/src/sparseml/pytorch/image_classification/integration_helper_functions.py
+++ b/src/sparseml/pytorch/image_classification/integration_helper_functions.py
@@ -37,7 +37,7 @@ from src.sparseml.pytorch.image_classification.utils.helpers import (
 
 def create_model(
     source_path: Union[Path, str],
-    batch_size: Optional[int] = None,
+    batch_size: Optional[int] = 1,
     device: Optional[str] = None,
     **kwargs,
 ) -> Tuple[torch.nn.Module, Dict[str, Any]]:

--- a/src/sparseml/pytorch/torch_to_onnx_exporter.py
+++ b/src/sparseml/pytorch/torch_to_onnx_exporter.py
@@ -233,7 +233,7 @@ class _TorchOnnxExport(BaseTransform):
         if _PARSED_TORCH_VERSION < version.parse("1.10.0"):
             kwargs["strip_doc_string"] = True
         else:
-            kwargs["training"] = torch.onnx.TrainingMode.PRESERVE
+            kwargs["training"] = torch.onnx.TrainingMode.EVAL
             kwargs["do_constant_folding"] = not module.training
             kwargs["keep_initializers_as_inputs"] = False
 

--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -539,7 +539,7 @@ def _tensors_export_batch(
 
     if isinstance(tensors, Iterable):
         # TODO: I am breaking something here? - dbogunowicz
-        for index, tens in enumerate(zip(tensors)):
+        for index, tens in enumerate(tensors):
             exported_paths.append(
                 tensor_export(
                     tens, export_dir, "{}-{:04d}".format(name_prefix, counter + index)

--- a/src/sparseml/transformers/integration_helper_functions.py
+++ b/src/sparseml/transformers/integration_helper_functions.py
@@ -97,23 +97,20 @@ def create_model(
         device=device,
     )
 
+    validation_dataset = None
     data_args = _parse_data_args(data_args)
 
     if data_args:
-        dataset = load_task_dataset(
+        validation_dataset = load_task_dataset(
             task=task,
             tokenizer=tokenizer,
             data_args=data_args,
             model=model,
             config=config,
+            split="validation",
         )
-        validation_dataset = dataset.get("validation")
-
-    else:
-        validation_dataset = None
 
     trainer = initialize_trainer(model, source_path, validation_dataset)
-    # TODO: Parse out dataloader from the trainer
 
     return model, dict(
         trainer=trainer,

--- a/src/sparseml/transformers/integration_helper_functions.py
+++ b/src/sparseml/transformers/integration_helper_functions.py
@@ -50,6 +50,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def create_model(
     source_path: Union[Path, str],
+    dataset_with_labels: bool = False,
     device: Optional[str] = None,
     task: Optional[str] = None,
     recipe: Optional[str] = None,
@@ -60,6 +61,9 @@ def create_model(
     loaded_model_kwargs (any relevant objects created along with the model)
 
     :param source_path: The path to the model
+    :param dataset_with_labels: Whether the allow the dataset to
+        have "labels" inputs or not. Text-generation datasets may
+        contain labels (needed for training only)
     :param device: The device to use for the model and dataloader instantiation
     :param task: The task to use for the model and dataloader instantiation
     :param recipe: The recipe to use for the model and dataloader instantiation.
@@ -109,6 +113,8 @@ def create_model(
             config=config,
             split="validation",
         )
+        if task in TaskNames.text_generation.value and not dataset_with_labels:
+            validation_dataset = validation_dataset.remove_columns("labels")
 
     trainer = initialize_trainer(model, source_path, validation_dataset)
 

--- a/src/sparseml/transformers/utils/sparse_model.py
+++ b/src/sparseml/transformers/utils/sparse_model.py
@@ -258,6 +258,14 @@ class SparseAutoModel:
         :param kwargs: keyword arguments to pass through to the AutoModel call
         :return: the created model for text generation
         """
+        # set the config so that exported model is a decoder and does
+        # not take past_key_values as input
+        config.is_decoder = True
+        # whether to use past key values an input
+        config.use_past = False
+        # whether to output past key values
+        config.use_cache = False
+
         if config.model_type == "opt":
             # TODO: Talk to Alex whether this pathway needs to be maintained
             def skip(*args, **kwargs):

--- a/tests/sparseml/export/image_classification/test_image_classification.py
+++ b/tests/sparseml/export/image_classification/test_image_classification.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import glob
 import os
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -25,7 +25,11 @@ from sparsezoo import Model
 
 
 @pytest.mark.parametrize(
-    "stub, arch_key", [("zoo:resnet_v1-50-imagenet-pruned95_quantized", "resnetv1-50")]
+    "stub, arch_key",
+    [
+        ("zoo:resnet_v1-50-imagenet-pruned95_quantized", "resnetv1-50"),
+        ("zoo:mobilenet_v1-1.0-imagenette-base", "mobilenet_v1"),
+    ],
 )
 class TestEndToEndExport:
     @pytest.fixture()
@@ -33,7 +37,8 @@ class TestEndToEndExport:
         model_path = tmp_path / "model"
         target_path = tmp_path / "target"
 
-        source_path = Model(stub, model_path).training.path
+        self.model = Model(stub, model_path)
+        source_path = self.model.training.path
 
         # if no arch_key supplied explicitly, it can be fetched from the checkpoint
         # and thus the integration can be inferred (we can set it to None)
@@ -118,51 +123,81 @@ class TestEndToEndExport:
         kwargs["dataset_name"] = "imagenette"
         kwargs["dataset_path"] = target_path.parent / "dataset"
 
-        num_samples = 10
-        batch_size = 2
+        num_samples = 20
 
         export(
             source_path=source_path,
             target_path=target_path,
             integration=integration,
             num_export_samples=num_samples,
-            batch_size=batch_size,
             **kwargs,
         )
+        # test that the samples were properly exported
         assert (target_path / "deployment" / "model.onnx").exists()
-        assert (
-            len(os.listdir(os.path.join(target_path, "sample-labels"))) == num_samples
-        )
-        assert (
-            len(os.listdir(os.path.join(target_path, "sample-inputs"))) == num_samples
-        )
-        assert (
-            len(os.listdir(os.path.join(target_path, "sample-outputs"))) == num_samples
-        )
-        # # open the sample-inputs file and check the batch size
-        sample_input = np.load(
-            glob.glob(os.path.join(target_path, "sample-inputs/*"))[0]
-        )["arr_0"]
-        assert sample_input.shape[0] == batch_size
 
-    @pytest.mark.skipif(
-        reason="skipping since this functionality needs some more attention"
-    )
-    def test_export_validate_correctness(self, setup):
+        # download the existing samples
+        self.model.sample_inputs.download()
+        self.model.sample_outputs["framework"].download()
+        self.model.sample_labels.download()
+
+        # make sure that the exported data has
+        # the correct structure (backward compatibility)
+        self._test_exported_sample_data_structure(
+            new_samples_dir=target_path / "sample-inputs",
+            old_samples_dir=Path(source_path).parent / "sample-inputs",
+            file_prefix="inp",
+        )
+
+        self._test_exported_sample_data_structure(
+            new_samples_dir=target_path / "sample-labels",
+            old_samples_dir=Path(source_path).parent / "sample-labels",
+            file_prefix="lab",
+        )
+
+        self._test_exported_sample_data_structure(
+            new_samples_dir=target_path / "sample-outputs",
+            old_samples_dir=Path(source_path).parent / "sample-outputs",
+            file_prefix="out",
+        )
+
+    def test_export_validate_correctness(self, caplog, setup):
         source_path, target_path, integration, kwargs = setup
         del kwargs["num_classes"]
         kwargs["dataset_name"] = "imagenette"
         kwargs["dataset_path"] = target_path.parent / "dataset"
 
-        num_samples = 10
-        batch_size = 2
-
+        num_samples = 3
         export(
             source_path=source_path,
             target_path=target_path,
             integration=integration,
             num_export_samples=num_samples,
-            batch_size=batch_size,
             validate_correctness=True,
             **kwargs,
         )
+        assert "ERROR" not in caplog.text
+
+    @staticmethod
+    def _test_exported_sample_data_structure(
+        new_samples_dir, old_samples_dir, file_prefix
+    ):
+        assert new_samples_dir.exists()
+        assert set(os.listdir(new_samples_dir)) == set(os.listdir(old_samples_dir))
+
+        # read the first sample from the newly
+        # generated samples and the downloaded samples
+        sample_input_new = np.load(
+            os.path.join(new_samples_dir, f"{file_prefix}-0000.npz")
+        )
+        sample_input_old = np.load(
+            os.path.join(old_samples_dir, f"{file_prefix}-0000.npz")
+        )
+        # outputs can have different shapes (imagenette is 10, imagenet is 1000)
+        if file_prefix == "out":
+            return
+        if file_prefix == "lab":
+            if "classes" in sample_input_old:
+                # one-hot encoded labels, so we cannot compare directly
+                return
+        for s1, s2 in zip(sample_input_new.values(), sample_input_old.values()):
+            assert s1.shape == s2.shape


### PR DESCRIPTION
## Feature description

From now on, whenever we export the `text-generation` model, we are also able to load the appropriate dataset.
This is achieved by integrating @Satrat latest registry for LLM dataloaders into the transformers export.


## Testing

```python
export(
            source_path=source_path,
            target_path=target_path,
            task='text-generation',
            num_export_samples=4,
            **dict(
                data_args=dict(
                    dataset_name="wikitext", dataset_config_name="wikitext-2-raw-v1"
                )
            ),
        )
```

```bash
Fetching 10 files: 100%|██████████| 10/10 [00:00<00:00, 52.54it/s]
...
2024-01-04 18:00:59 sparseml.export.export INFO     Exporting 4 samples...
4it [00:02,  1.61it/s]
2024-01-04 18:01:01 sparseml.export.export_data INFO     Exporting sample-inputs to /tmp/pytest-of-damian/pytest-0/test_export_samples_roneneldan0/target...
2024-01-04 18:01:01 sparseml.export.export_data INFO     Successfully exported sample-inputs to /tmp/pytest-of-damian/pytest-0/test_export_samples_roneneldan0/target!
2024-01-04 18:01:01 sparseml.export.export_data INFO     Exporting sample-outputs to /tmp/pytest-of-damian/pytest-0/test_export_samples_roneneldan0/target...
2024-01-04 18:02:46 sparseml.export.export_data INFO     Successfully exported sample-outputs to /tmp/pytest-of-damian/pytest-0/test_export_samples_roneneldan0/target!
...
2024-01-04 18:02:47 sparseml.exporters.transforms.kv_cache.transforms_codegen INFO     Successfully adjusted the causal_mask input
2024-01-04 18:02:47 sparseml.exporters.transforms.onnx_transform INFO     [AdditionalTransformsCodeGen] Transformed 10 matches
2024-01-04 18:02:47 sparseml.export.helpers INFO     Optimization: kv_cache_injection has been successfully applied to the ONNX model: /tmp/pytest-of-damian/pytest-0/test_export_samples_roneneldan0/target/deployment/model.onnx
2024-01-04 18:02:47 sparseml.export.export INFO     Validating model structure...
2024-01-04 18:02:47 sparseml.export.validators WARNING  File /tmp/pytest-of-damian/pytest-0/test_export_samples_roneneldan0/target/sample-labels is missing.
2024-01-04 18:02:47 sparseml.export.validators WARNING  File /tmp/pytest-of-damian/pytest-0/test_export_samples_roneneldan0/target/deployment/tokenizer.model is missing.
2024-01-04 18:02:47 sparseml.export.export INFO     Successfully exported model from:
/tmp/pytest-of-damian/pytest-0/test_export_samples_roneneldan0/target
to
/tmp/pytest-of-damian/pytest-0/test_export_samples_roneneldan0/target/deployment
for integration: transformers
```
