### PR TITLE
Allow Finetuning without a recipe

### DIFF
--- a/src/sparseml/core/recipe/container.py
+++ b/src/sparseml/core/recipe/container.py
@@ -143,3 +143,16 @@ class RecipeContainer:
             return True
 
         return False
+
+    def check_any_recipe_exists(self) -> bool:
+        """
+        Checks if any recipes have been added to the container, compiled or not
+
+        :return: True if any recipes exist in the container, False otherwise
+        """
+        if self.compiled_recipe is not None:
+            return True
+        if len(self.recipes) > 0:
+            return True
+
+        return False

--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -474,6 +474,10 @@ class LifecycleCallbacks:
                 f"Use the corresponding method instead."
             )
 
+        # skip event callbacks if no recipe was provided
+        if not active_session().lifecycle.recipe_container.check_any_recipe_exists():
+            return
+
         return active_session().event(event_type, **kwargs)
 
     @classmethod

--- a/src/sparseml/transformers/finetune/README.md
+++ b/src/sparseml/transformers/finetune/README.md
@@ -1,0 +1,76 @@
+# Sparse Finetuning
+
+## Launching from Console Scripts
+
+### with DataParallel (default)
+
+```bash
+sparseml.transformers.text_generation.train
+    --model_name PATH_TO_MODEL
+    --distill_teacher PATH_TO_TEACHER
+    --dataset_name DATASET_NAME
+    --recipe PATH_TO_RECIPE
+    --output_dir PATH_TO_OUTPUT
+    --num_train_epochs 1
+    --splits "train"
+```
+
+Also supported:
+
+* `sparseml.transformers.text_generation.finetune`
+* `sparseml.transformers.text_generation.eval`
+
+### with FSDP
+
+```bash
+accelerate launch 
+    --config_file example_fsdp_config.yaml 
+    --no_python sparseml.transformers.text_generation.finetune
+    --model_name PATH_TO_MODEL
+    --distill_teacher PATH_TO_TEACHER
+    --dataset_name DATASET_NAME
+    --recipe PATH_TO_RECIPE
+    --output_dir PATH_TO_OUTPUT
+    --num_train_epochs 1
+    --splits "train"
+```
+
+See [configure_fsdp.md](https://github.com/neuralmagic/sparseml/blob/main/integrations/huggingface-transformers/finetuning/configure_fsdp.md) for additional instructions on setting up FSDP configuration
+
+## Launching from Python
+
+```python
+from sparseml.transformers.finetune.text_generation import run_train
+
+model = "./obcq_deployment"
+teacher_model = "Xenova/llama2.c-stories15M"
+dataset_name = "open_platypus"
+concatenate_data = False
+output_dir = "./output_finetune"
+recipe = "test_trainer_recipe.yaml"
+num_train_epochs=2
+overwrite_output_dir = True
+splits = {
+    "train": "train[:50%]",
+}
+
+run_train(
+    model_name_or_path=model,
+    distill_teacher=teacher_model,
+    dataset_name=dataset_name,
+    output_dir=output_dir,
+    recipe=recipe,
+    num_train_epochs=num_train_epochs,
+    overwrite_output_dir=overwrite_output_dir,
+    concatenate_data = concatenate_data,
+    splits = splits
+)
+```
+
+## Additional Configuration
+
+Finetuning arguments are split up into 3 groups:
+
+* ModelArguments: `src/sparseml/transformers/finetune/model_args.py`
+* TrainingArguments: `src/sparseml/transformers/finetune/training_args.py`
+* DataTrainingArguments: `src/sparseml/transformers/finetune/data/data_training_args.py`

--- a/src/sparseml/transformers/finetune/runner.py
+++ b/src/sparseml/transformers/finetune/runner.py
@@ -75,8 +75,13 @@ class StageRunner:
         """
         splits = self._data_args.splits
         tokenized_datasets = {}
-        if self._data_args.splits is None:
+        if splits is None:
             splits = {"all": None}
+        elif isinstance(splits, str):
+            splits = {splits: splits}
+        elif isinstance(splits, List):
+            splits = {s: s for s in splits}
+
         for split_name, split_str in splits.items():
             dataset_manager = TextGenerationDataset.load_from_registry(
                 self._data_args.dataset_name,

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -154,6 +154,13 @@ class SessionManagerMixIn:
                 f"from {load_path}"
             )
 
+        if self.recipe is None:
+            _LOGGER.warning(
+                "No training recipe was provided, finetuning will be run "
+                "without event callbacks to SparseML. To supply a recipe "
+                "pass a yaml file or string to the `recipe` argument."
+            )
+
     def initialize_structure(self):
         """
         Initialize any recipe structural changes such as quantization on the model,
@@ -270,7 +277,7 @@ class SessionManagerMixIn:
 
         if session_manager.active_session().lifecycle.initialized_:
             state = callbacks.loss_calculated(loss=loss)
-            if state.loss is not None:
+            if state and state.loss is not None:
                 loss = state.loss
             callbacks.optim_pre_step()
 
@@ -404,6 +411,9 @@ class SessionManagerMixIn:
 
         self.save_state()
         self.save_optimizer_and_scheduler(output_dir)
+
+        if not self.recipe:
+            return
 
         # save recipe, will contain modifiers from the model's original recipe as well
         # as those added from self.recipe

--- a/tests/sparseml/core/test_session.py
+++ b/tests/sparseml/core/test_session.py
@@ -295,6 +295,7 @@ class TestLifecycleCallbacks:
         self, event_type, monkeypatch, setup_active_session
     ):
         monkeypatch.setattr(setup_active_session, "event", active_session_event_mock)
+        setup_active_session.lifecycle.recipe_container.recipes = ["dummy_recipe.yaml"]
         result = session_module.LifecycleCallbacks.event(event_type=event_type)
         assert result == event_type, f"{event_type} did not invoke session event"
 
@@ -312,6 +313,7 @@ class TestLifecycleCallbacks:
         self, method_name, expected_event_type, monkeypatch, setup_active_session
     ):
         monkeypatch.setattr(setup_active_session, "event", active_session_event_mock)
+        setup_active_session.lifecycle.recipe_container.recipes = ["dummy_recipe.yaml"]
         method = getattr(session_module.LifecycleCallbacks, method_name)
         result = method()
         assert (


### PR DESCRIPTION
Previously the finetuning script would error out if no recipe was provided, because the event callbacks had no modifiers to trigger. This PR logs a warning if the user doesn't provide a recipe, but allows finetuning to run by skipping all lifecycle event callbacks if no recipe exists. Also fixing a small bug related to the "splits" argument parsing.

Asana ticket: https://app.asana.com/0/1203126676641557/1206292400209195/f 

### Testing
This example script launches finetuning without a recipe:

```
  from sparseml.transformers.finetune.text_generation import run_general
  
  model = "Xenova/llama2.c-stories15M"
  dataset_name = "open_platypus"
  concatenate_data = False
  do_train = True
  do_eval = False
  output_dir = "./output_finetune"
  num_train_epochs=2
  overwrite_output_dir = True
  splits = "train"

  run_general(
      model_name_or_path=model,
      dataset_name=dataset_name,
      do_train=do_train,
      do_eval=do_eval,
      output_dir=output_dir,
      recipe=None,
      num_train_epochs=num_train_epochs,
      overwrite_output_dir=overwrite_output_dir,
      concatenate_data = concatenate_data,
      splits = splits
  )
```