### PR TITLE
FSDP Compatible, Sequential SparseGPT

### DIFF
--- a/src/sparseml/modifiers/obcq/base.py
+++ b/src/sparseml/modifiers/obcq/base.py
@@ -56,7 +56,7 @@ class SparseGPTModifier(WandaPruningModifier):
     block_size: int
     quantize: Union[bool, Dict]
     dampening_frac: Optional[float] = 0.01
-    sequential_update: Optional[bool] = True
+    sequential_update: Optional[bool] = False
     prunen_: Optional[int] = None
     prunem_: Optional[int] = None
     target_ids: Optional[List[str]] = None

--- a/src/sparseml/modifiers/pruning/wanda/base.py
+++ b/src/sparseml/modifiers/pruning/wanda/base.py
@@ -38,12 +38,15 @@ class WandaPruningModifier(Modifier):
     :param mask_structure: String to define the structure of the mask to apply.
         Must be of the form N:M where N, M are integers that define a custom block
         shape. Defaults to 0:0 which represents an unstructured mask.
+    :param sequential_update: Whether or not to update weights sequentially by layer,
+        True saves on GPU memory
     :param targets: list of layer names to compress during OBCQ, or '__ALL__'
         to compress every layer in the model
     """
 
     sparsity: Union[float, List[float]]
     mask_structure: str = "0:0"
+    sequential_update: Optional[bool] = False
     targets: Union[str, List[str], None] = ALL_TOKEN
     compressible_layers_: Optional[List] = None
     prunen_: Optional[int] = None

--- a/src/sparseml/modifiers/utils/layer_compressor.py
+++ b/src/sparseml/modifiers/utils/layer_compressor.py
@@ -84,9 +84,9 @@ class LayerCompressor:
 
         for name in subset:
             layer = subset[name]
-            with FullyShardedDataParallel.summon_full_params(self.layer):
-                wrapper = self.module_compressor_class(name, layer)
             full_name = self._get_full_submodule_name(name)
+            with FullyShardedDataParallel.summon_full_params(self.layer):
+                wrapper = self.module_compressor_class(full_name, layer)
             set_layer(full_name, wrapper, self.model)
             self.modules[name] = wrapper
 


### PR DESCRIPTION
Adding back the `sequential_update` flag to `SparseGPTModifier` and `WandaModifier`. Previously this flag affected whether or not we calibrate modules within a transformers block sequentially. Regardless of this flag we would always perform OBCQ sequentially across different transformer blocks.

In the updated FSDP compatible implementation, transformers blocks are calibrated in parallel with no option for sequential calibration. The new `sequential_update` flag affects whether transformer blocks are processed sequentially, modules within blocks are always calibrated in parallel. Note that running sequential updates requires a lot more computation, as the whole model forward pass it run `num_calibration_samples` times for each transformer block