### PR TITLE
Skip tests that do not work on CentOS 7

### DIFF
--- a/tests/sparseml/pytorch/datasets/classification/test_cifar.py
+++ b/tests/sparseml/pytorch/datasets/classification/test_cifar.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import platform
 
 import pytest
 from torch.utils.data import Dataset
@@ -30,6 +31,10 @@ def _validate_cifar(dataset: Dataset, num_classes: int):
     assert item[1] < num_classes
 
 
+@pytest.mark.skipif(
+    "centos-7" in platform.platform(),
+    reason="torchvision cannot pull remote model on CentOS 7",
+)
 @pytest.mark.skipif(
     os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
     reason="Skipping pytorch tests",
@@ -49,6 +54,10 @@ def test_cifar_10():
     _validate_cifar(reg_dataset, 10)
 
 
+@pytest.mark.skipif(
+    "centos-7" in platform.platform(),
+    reason="torchvision cannot pull remote model on CentOS 7",
+)
 @pytest.mark.skipif(
     os.getenv("NM_ML_SKIP_PYTORCH_TESTS", False),
     reason="Skipping pytorch tests",

--- a/tests/sparseml/pytorch/models/external/test_torchvision.py
+++ b/tests/sparseml/pytorch/models/external/test_torchvision.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import platform
 from typing import Callable, Union
 
 import pytest
@@ -34,9 +35,29 @@ from tests.sparseml.pytorch.models.utils import compare_model
     "key,pretrained,constructor",
     [
         ("torchvision.mobilenet_v2", False, torchvision_models.mobilenet_v2),
-        ("torchvision.mobilenet_v2", True, torchvision_models.mobilenet_v2),
+        pytest.param(
+            "torchvision.mobilenet_v2",
+            True,
+            torchvision_models.mobilenet_v2,
+            marks=[
+                pytest.mark.skipif(
+                    "centos" in platform.platform(),
+                    reason="torchvision cannot pull remote model on CentOS 7",
+                )
+            ],
+        ),
         ("torchvision.resnet50", False, torchvision_models.resnet50),
-        ("torchvision.resnet50", True, torchvision_models.resnet50),
+        pytest.param(
+            "torchvision.resnet50",
+            True,
+            torchvision_models.resnet50,
+            marks=[
+                pytest.mark.skipif(
+                    "centos" in platform.platform(),
+                    reason="torchvision cannot pull remote model on CentOS 7",
+                )
+            ],
+        ),
     ],
 )
 def test_torchvision_registry_models(


### PR DESCRIPTION
This PR adds a conditional skip to a few tests that do not work on CentOS 7 due to external dependencies.