### PR TITLE
[Pretraining] Support for Dataset Streaming during Finetuning

### DIFF
--- a/src/sparseml/transformers/finetune/data/base.py
+++ b/src/sparseml/transformers/finetune/data/base.py
@@ -79,7 +79,11 @@ class TextGenerationDataset(RegistryMixin):
         :return: the requested dataset
         """
         return get_raw_dataset(
-            self.data_args, cache_dir, split=self.split, **self.raw_kwargs
+            self.data_args,
+            cache_dir,
+            split=self.split,
+            streaming=self.data_args.streaming,
+            **self.raw_kwargs,
         )
 
     def tokenize_and_process(self, raw_dataset: Dataset) -> Dataset:
@@ -122,26 +126,26 @@ class TextGenerationDataset(RegistryMixin):
             tokenize_fn,
             batched=True,
             remove_columns=[self.text_column],
-            num_proc=self.data_args.preprocessing_num_workers,
-            load_from_cache_file=not self.data_args.overwrite_cache,
-            desc="Running tokenizer on dataset",
+            #num_proc=self.data_args.preprocessing_num_workers,
+            #load_from_cache_file=not self.data_args.overwrite_cache,
+            #desc="Running tokenizer on dataset",
         )
 
         if self.data_args.concatenate_data:
             dataset = dataset.map(
                 group_text_fn,
                 batched=True,
-                num_proc=self.data_args.preprocessing_num_workers,
-                load_from_cache_file=not self.data_args.overwrite_cache,
-                desc="Grouping text",
+                #num_proc=self.data_args.preprocessing_num_workers,
+                #load_from_cache_file=not self.data_args.overwrite_cache,
+                #desc="Grouping text",
             )
 
         dataset = dataset.map(
             label_fn,
             batched=True,
-            num_proc=self.data_args.preprocessing_num_workers,
-            load_from_cache_file=not self.data_args.overwrite_cache,
-            desc="Adding labels",
+            #num_proc=self.data_args.preprocessing_num_workers,
+            #load_from_cache_file=not self.data_args.overwrite_cache,
+            #desc="Adding labels",
         )
 
         return dataset

--- a/src/sparseml/transformers/finetune/data/data_args.py
+++ b/src/sparseml/transformers/finetune/data/data_args.py
@@ -62,6 +62,10 @@ class DataTrainingArguments:
         default=512,
         metadata={"help": "Number of samples to use for one-shot calibration"},
     )
+    streaming: Optional[bool] = field(
+        default=False,
+        metadata={"help": "Whether to stream data from dataset"},
+    )
     overwrite_cache: bool = field(
         default=False,
         metadata={"help": "Overwrite the cached preprocessed datasets or not."},

--- a/src/sparseml/transformers/finetune/data/data_args.py
+++ b/src/sparseml/transformers/finetune/data/data_args.py
@@ -64,7 +64,7 @@ class DataTrainingArguments:
     )
     streaming: Optional[bool] = field(
         default=False,
-        metadata={"help": "Whether to stream data from dataset"},
+        metadata={"help": "True to stream data from a cloud dataset"},
     )
     overwrite_cache: bool = field(
         default=False,

--- a/src/sparseml/transformers/finetune/data/data_helpers.py
+++ b/src/sparseml/transformers/finetune/data/data_helpers.py
@@ -20,17 +20,24 @@ from datasets import Dataset, load_dataset
 __all__ = ["get_raw_dataset", "make_dataset_splits"]
 
 
-def get_raw_dataset(data_args, cache_dir: Optional[str] = None, **kwargs) -> Dataset:
+def get_raw_dataset(
+    data_args,
+    cache_dir: Optional[str] = None,
+    streaming: Optional[bool] = False,
+    **kwargs,
+) -> Dataset:
     """
     Load the raw dataset from Hugging Face, using cached copy if available
 
     :param cache_dir: disk location to search for cached dataset
+    :param streaming: True to stream data from Hugging Face, otherwise download
     :return: the requested dataset
     """
     raw_datasets = load_dataset(
         data_args.dataset_name,
         data_args.dataset_config_name,
         cache_dir=cache_dir,
+        streaming=streaming,
         **kwargs,
     )
 

--- a/src/sparseml/transformers/finetune/data/evolcodealpaca.py
+++ b/src/sparseml/transformers/finetune/data/evolcodealpaca.py
@@ -67,8 +67,9 @@ class EvolCodeAlpacaDataset(TextGenerationDataset):
                 sample["text"] += sample["output"]
             return sample
 
-        raw_dataset = raw_dataset.map(
-            restructure_fn,
+        raw_dataset = self.map(
+            raw_dataset,
+            function=restructure_fn,
             batched=False,
             remove_columns=["output", "instruction"],
             num_proc=self.data_args.preprocessing_num_workers,

--- a/src/sparseml/transformers/finetune/data/evolcodealpaca.py
+++ b/src/sparseml/transformers/finetune/data/evolcodealpaca.py
@@ -15,7 +15,6 @@ from copy import deepcopy
 from typing import Optional
 
 from sparseml.transformers.finetune.data import TextGenerationDataset
-from sparseml.transformers.finetune.data.data_helpers import get_raw_dataset
 
 
 @TextGenerationDataset.register(name="evolcodealpaca")
@@ -50,13 +49,7 @@ class EvolCodeAlpacaDataset(TextGenerationDataset):
         :param cache_dir: disk location to search for cached dataset
         :return: the requested dataset
         """
-        raw_dataset = get_raw_dataset(
-            self.data_args,
-            cache_dir,
-            split=self.split,
-            streaming=self.data_args.streaming,
-            **self.raw_kwargs,
-        )
+        raw_dataset = super().get_raw_dataset(cache_dir=cache_dir)
 
         # helper fn for restructuring each dataset entry using the alpaca template
         def restructure_fn(sample):

--- a/src/sparseml/transformers/finetune/data/evolcodealpaca.py
+++ b/src/sparseml/transformers/finetune/data/evolcodealpaca.py
@@ -51,7 +51,11 @@ class EvolCodeAlpacaDataset(TextGenerationDataset):
         :return: the requested dataset
         """
         raw_dataset = get_raw_dataset(
-            self.data_args, cache_dir, split=self.split, **self.raw_kwargs
+            self.data_args,
+            cache_dir,
+            split=self.split,
+            streaming=self.data_args.streaming,
+            **self.raw_kwargs,
         )
 
         # helper fn for restructuring each dataset entry using the alpaca template

--- a/src/sparseml/transformers/finetune/data/gsm8k.py
+++ b/src/sparseml/transformers/finetune/data/gsm8k.py
@@ -16,7 +16,6 @@ from copy import deepcopy
 from typing import Optional
 
 from sparseml.transformers.finetune.data import TextGenerationDataset
-from sparseml.transformers.finetune.data.data_helpers import get_raw_dataset
 
 
 @TextGenerationDataset.register(name="gsm8k")
@@ -46,13 +45,7 @@ class GSM8KDataset(TextGenerationDataset):
         :param cache_dir: disk location to search for cached dataset
         :return: the requested dataset
         """
-        raw_dataset = get_raw_dataset(
-            self.data_args,
-            cache_dir,
-            split=self.split,
-            streaming=self.data_args.streaming,
-            **self.raw_kwargs,
-        )
+        raw_dataset = super().get_raw_dataset(cache_dir=cache_dir)
 
         # helper fn for restructuring each dataset entry using the gsm template
         def restructure_fn(sample):

--- a/src/sparseml/transformers/finetune/data/gsm8k.py
+++ b/src/sparseml/transformers/finetune/data/gsm8k.py
@@ -47,7 +47,11 @@ class GSM8KDataset(TextGenerationDataset):
         :return: the requested dataset
         """
         raw_dataset = get_raw_dataset(
-            self.data_args, cache_dir, split=self.split, **self.raw_kwargs
+            self.data_args,
+            cache_dir,
+            split=self.split,
+            streaming=self.data_args.streaming,
+            **self.raw_kwargs,
         )
 
         # helper fn for restructuring each dataset entry using the gsm template

--- a/src/sparseml/transformers/finetune/data/gsm8k.py
+++ b/src/sparseml/transformers/finetune/data/gsm8k.py
@@ -61,8 +61,9 @@ class GSM8KDataset(TextGenerationDataset):
                 sample["text"] += " " + sample["answer"]
             return sample
 
-        raw_dataset = raw_dataset.map(
-            restructure_fn,
+        raw_dataset = self.map(
+            raw_dataset,
+            function=restructure_fn,
             batched=False,
             remove_columns=["question", "answer"],
             num_proc=self.data_args.preprocessing_num_workers,

--- a/src/sparseml/transformers/finetune/data/open_platypus.py
+++ b/src/sparseml/transformers/finetune/data/open_platypus.py
@@ -76,12 +76,13 @@ class OpenPlatypusDataset(TextGenerationDataset):
                 sample["text"] += sample["output"]
             return sample
 
-        raw_dataset = raw_dataset.map(
-            restructure_fn,
+        raw_dataset = self.map(
+            raw_dataset,
+            function=restructure_fn,
             batched=False,
             remove_columns=["input", "output", "instruction", "data_source"],
-            #num_proc=self.data_args.preprocessing_num_workers,
-            #load_from_cache_file=not self.data_args.overwrite_cache,
-            #desc="Restructuring Platypus Dataset",
+            num_proc=self.data_args.preprocessing_num_workers,
+            load_from_cache_file=not self.data_args.overwrite_cache,
+            desc="Restructuring Platypus Dataset",
         )
         return raw_dataset

--- a/src/sparseml/transformers/finetune/data/open_platypus.py
+++ b/src/sparseml/transformers/finetune/data/open_platypus.py
@@ -15,7 +15,6 @@ from copy import deepcopy
 from typing import Optional
 
 from sparseml.transformers.finetune.data import TextGenerationDataset
-from sparseml.transformers.finetune.data.data_helpers import get_raw_dataset
 
 
 @TextGenerationDataset.register(name="open_platypus")
@@ -53,13 +52,7 @@ class OpenPlatypusDataset(TextGenerationDataset):
         :param cache_dir: disk location to search for cached dataset
         :return: the requested dataset
         """
-        raw_dataset = get_raw_dataset(
-            self.data_args,
-            cache_dir,
-            split=self.split,
-            streaming=self.data_args.streaming,
-            **self.raw_kwargs,
-        )
+        raw_dataset = super().get_raw_dataset(cache_dir=cache_dir)
 
         # helper fn for restructuring each dataset entry using the alpaca template
         def restructure_fn(sample):

--- a/src/sparseml/transformers/finetune/data/open_platypus.py
+++ b/src/sparseml/transformers/finetune/data/open_platypus.py
@@ -54,7 +54,11 @@ class OpenPlatypusDataset(TextGenerationDataset):
         :return: the requested dataset
         """
         raw_dataset = get_raw_dataset(
-            self.data_args, cache_dir, split=self.split, **self.raw_kwargs
+            self.data_args,
+            cache_dir,
+            split=self.split,
+            streaming=self.data_args.streaming,
+            **self.raw_kwargs,
         )
 
         # helper fn for restructuring each dataset entry using the alpaca template
@@ -76,8 +80,8 @@ class OpenPlatypusDataset(TextGenerationDataset):
             restructure_fn,
             batched=False,
             remove_columns=["input", "output", "instruction", "data_source"],
-            num_proc=self.data_args.preprocessing_num_workers,
-            load_from_cache_file=not self.data_args.overwrite_cache,
-            desc="Restructuring Platypus Dataset",
+            #num_proc=self.data_args.preprocessing_num_workers,
+            #load_from_cache_file=not self.data_args.overwrite_cache,
+            #desc="Restructuring Platypus Dataset",
         )
         return raw_dataset

--- a/src/sparseml/transformers/finetune/data/ultrachat_200k.py
+++ b/src/sparseml/transformers/finetune/data/ultrachat_200k.py
@@ -83,8 +83,9 @@ class UltraChatDataset(TextGenerationDataset):
             )
             return sample
 
-        raw_dataset = raw_dataset.map(
-            restructure_fn,
+        raw_dataset = self.map(
+            raw_dataset,
+            function=restructure_fn,
             batched=False,
             remove_columns=[],
             num_proc=self.data_args.preprocessing_num_workers,

--- a/src/sparseml/transformers/finetune/data/ultrachat_200k.py
+++ b/src/sparseml/transformers/finetune/data/ultrachat_200k.py
@@ -15,7 +15,6 @@ from copy import deepcopy
 from typing import Optional
 
 from sparseml.transformers.finetune.data import TextGenerationDataset
-from sparseml.transformers.finetune.data.data_helpers import get_raw_dataset
 
 
 @TextGenerationDataset.register(name="ultrachat_200k")
@@ -65,13 +64,7 @@ class UltraChatDataset(TextGenerationDataset):
         :param cache_dir: disk location to search for cached dataset
         :return: the requested dataset
         """
-        raw_dataset = get_raw_dataset(
-            self.data_args,
-            cache_dir,
-            split=self.split,
-            streaming=self.data_args.streaming,
-            **self.raw_kwargs,
-        )
+        raw_dataset = super().get_raw_dataset(cache_dir=cache_dir)
 
         # helper fn for restructuring each dataset entry using the chat template
         def restructure_fn(sample):

--- a/src/sparseml/transformers/finetune/data/ultrachat_200k.py
+++ b/src/sparseml/transformers/finetune/data/ultrachat_200k.py
@@ -66,7 +66,11 @@ class UltraChatDataset(TextGenerationDataset):
         :return: the requested dataset
         """
         raw_dataset = get_raw_dataset(
-            self.data_args, cache_dir, split=self.split, **self.raw_kwargs
+            self.data_args,
+            cache_dir,
+            split=self.split,
+            streaming=self.data_args.streaming,
+            **self.raw_kwargs,
         )
 
         # helper fn for restructuring each dataset entry using the chat template

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch.nn import Module
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, IterableDataset
 from transformers.trainer_callback import TrainerState
 from transformers.trainer_utils import get_last_checkpoint
 
@@ -211,9 +211,13 @@ class SessionManagerMixIn:
             self.args.per_device_train_batch_size
             * self.args.gradient_accumulation_steps
         )
-        self.total_steps_per_epoch = math.ceil(
-            len(self.train_dataset) / total_batch_size
-        )
+
+        if isinstance(self.train_dataset, IterableDataset):
+            self.total_steps_per_epoch = 1
+        else:
+            self.total_steps_per_epoch = math.ceil(
+                len(self.train_dataset) / total_batch_size
+            )
         session_manager.initialize(
             optimizer=self.optimizer, steps_per_epoch=self.total_steps_per_epoch
         )

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -213,11 +213,18 @@ class SessionManagerMixIn:
         )
 
         if isinstance(self.train_dataset, IterableDataset):
+            _LOGGER.warning(
+                "Training is being run with a streamed dataset, "
+                "steps_per_epoch cannot be determined and will default to "
+                "1. SparseML modifiers utilizing this statistic may not "
+                "behave as expected. "
+            )
             self.total_steps_per_epoch = 1
         else:
             self.total_steps_per_epoch = math.ceil(
                 len(self.train_dataset) / total_batch_size
             )
+
         session_manager.initialize(
             optimizer=self.optimizer, steps_per_epoch=self.total_steps_per_epoch
         )


### PR DESCRIPTION
Adding a new `streaming` configuration to finetuning(defined in `data_args.py`). When set to true, we stream shards of data from Hugging Face during training rather than downloading the whole dataset upfront.

**Note:** In streaming mode, `max_steps` must be defined and `num_train_epochs` will be ignored if specified. This is because a streamed dataset has no defined length.

### Testing
```
sparseml.transformers.text_generation.train --model_name "Xenova/llama2.c-stories15M" --dataset_name "open_platypus" --output_dir "test_pretrain_out" --max_steps 1000 --splits train --streaming True
```
Training will run for 1000 batches, data is not downloaded and dataset mapping is not run upfront

And running with a large dataset now doesn't take forever:
```
sparseml.transformers.text_generation.train --model_name "Xenova/llama2.c-stories15M" --dataset_name "c4"  --dataset_config_name "en" --output_dir "test_pretrain_out" --max_steps 1000 --splits train --streaming True
```
(c4 still takes a few minutes to set up though)