### PR TITLE
[cherry-pick][yolov8][fix] 'DetectionModel' object has no attribute 'args' (#1958)

### DIFF
--- a/src/sparseml/yolov8/trainers.py
+++ b/src/sparseml/yolov8/trainers.py
@@ -884,6 +884,10 @@ class SparseYOLO(YOLO):
         if args.task == "segment":
             args = check_coco128_segmentation(args)
 
+        if not hasattr(self.model, "args"):
+            # set model args from overrides if possible
+            self.model.args = overrides
+
         validator = self.ValidatorClass(args=args)
         validator(
             model=self.model,


### PR DESCRIPTION
fixes issue at api level due to args not being set properly
see #1516 for fix at CLI level