### PR TITLE
[Logger Refactor] Add timer in logger manager

### DIFF
--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -21,6 +21,7 @@ import os
 import time
 import warnings
 from abc import ABC
+from contextlib import contextmanager
 from datetime import datetime
 from logging import CRITICAL, DEBUG, ERROR, INFO, WARN, Logger
 from pathlib import Path
@@ -1122,6 +1123,25 @@ class SystemLoggingWraper(LoggingWrapperBase):
                     wall_time=wall_time,
                     level=level,
                 )
+
+    @contextmanager
+    def time(self, tag: Optional[str] = None, *args, **kwargs):
+        """
+        Context manager to log the time it takes to run the block of code
+
+        Usage:
+        >>> with LoggerManager().system.time("my_block"):
+        >>>    time.sleep(1)
+
+        :param tag: identifying tag to log the values with
+        """
+
+        start = time.time()
+        yield
+        elapsed = time.time() - start
+        if not tag:
+            tag = f"{DEFAULT_TAG}_time"
+        self.log_string(tag=tag, string=f"{elapsed:.3f}s", *args, **kwargs)
 
     def debug(self, tag, string, *args, **kwargs):
         """

--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -1075,6 +1075,25 @@ class LoggerManager(ABC):
             if log.enabled:
                 log.save(file_path, **kwargs)
 
+    @contextmanager
+    def time(self, tag: Optional[str] = None, *args, **kwargs):
+        """
+        Context manager to log the time it takes to run the block of code
+
+        Usage:
+        >>> with LoggerManager().system.time("my_block"):
+        >>>    time.sleep(1)
+
+        :param tag: identifying tag to log the values with
+        """
+
+        start = time.time()
+        yield
+        elapsed = time.time() - start
+        if not tag:
+            tag = f"{DEFAULT_TAG}_time_secs"
+        self.log_scalar(tag=tag, string=float(f"{elapsed:.3f}"), *args, **kwargs)
+
 
 class LoggingWrapperBase:
     """
@@ -1123,25 +1142,6 @@ class SystemLoggingWraper(LoggingWrapperBase):
                     wall_time=wall_time,
                     level=level,
                 )
-
-    @contextmanager
-    def time(self, tag: Optional[str] = None, *args, **kwargs):
-        """
-        Context manager to log the time it takes to run the block of code
-
-        Usage:
-        >>> with LoggerManager().system.time("my_block"):
-        >>>    time.sleep(1)
-
-        :param tag: identifying tag to log the values with
-        """
-
-        start = time.time()
-        yield
-        elapsed = time.time() - start
-        if not tag:
-            tag = f"{DEFAULT_TAG}_time"
-        self.log_string(tag=tag, string=f"{elapsed:.3f}s", *args, **kwargs)
 
     def debug(self, tag, string, *args, **kwargs):
         """

--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -1081,7 +1081,7 @@ class LoggerManager(ABC):
         Context manager to log the time it takes to run the block of code
 
         Usage:
-        >>> with LoggerManager().system.time("my_block"):
+        >>> with LoggerManager().time("my_block"):
         >>>    time.sleep(1)
 
         :param tag: identifying tag to log the values with

--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -1092,7 +1092,7 @@ class LoggerManager(ABC):
         elapsed = time.time() - start
         if not tag:
             tag = f"{DEFAULT_TAG}_time_secs"
-        self.log_scalar(tag=tag, string=float(f"{elapsed:.3f}"), *args, **kwargs)
+        self.log_scalar(tag=tag, value=float(f"{elapsed:.3f}"), *args, **kwargs)
 
 
 class LoggingWrapperBase:


### PR DESCRIPTION
This PR adds a time context manager to LoggerManager

```python
from time import sleep
from sparseml.core import LoggerManager
from logging import INFO
logger_manager = LoggerManager()

with logger_manager.time('test', level=INFO):
    sleep(1)
```

Output:
```bash
Logging all SparseML modifier-level logs to sparse_logs/17-01-2024_08.49.07.log
2024-01-17 08:49:07 sparseml.core.logger.logger INFO     Logging all SparseML modifier-level logs to sparse_logs/17-01-2024_08.49.07.log
manager test: 1.000s

```
