### PR TITLE
Fix Percentage Split Loads

### DIFF
--- a/src/sparseml/transformers/finetune/runner.py
+++ b/src/sparseml/transformers/finetune/runner.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import re
 from typing import List, Optional
 
 import torch
@@ -85,12 +86,20 @@ class StageRunner:
         """
         splits = self._data_args.splits
         tokenized_datasets = {}
+
+        def _get_split_name(inp_str):
+            # strip out split name, for ex train[60%:] -> train
+            match = re.match(r"(\w*)\[.*\]", inp_str)
+            if match is not None:
+                return match.group(1)
+            return inp_str
+
         if splits is None:
             splits = {"all": None}
         elif isinstance(splits, str):
-            splits = {splits: splits}
+            splits = {_get_split_name(splits): splits}
         elif isinstance(splits, List):
-            splits = {s: s for s in splits}
+            splits = {_get_split_name(s): s for s in splits}
 
         for split_name, split_str in splits.items():
             dataset_manager = TextGenerationDataset.load_from_registry(


### PR DESCRIPTION
A bug in dataset loading was causing the following error when trying to load percentages of a split:

Input:
```
sparseml.transformers.text_generation.train --model_name Xenova/llama2.c-stories15M --dataset_name open_platypus --output_dir test_split --splits "train[60%:]" --num_train_epochs 1 --overwrite_output_dir True
```
Output:
```
File "/home/sadkins/sparseml/src/sparseml/transformers/finetune/data/data_helpers.py", line 73, in make_dataset_splits
  raise ValueError("--do_train requires a train dataset")
ValueError: --do_train requires a train dataset
```

With this change we parse the split name using a regex, so `train`, `train[60%:]` and `{"train": "train[60%]"}` will all be supported as inputs. Adding in a unit test to test all these cases as well