### PR TITLE
[BugFix] Remove ort from transformers dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ _transformers_deps = _pytorch_deps + [
     "scikit-learn",
     "seqeval",
     "einops",
-    "onnxruntime>=1.0.0",
     "accelerate>=0.20.3",
 ]
 _yolov5_deps = _pytorch_vision_deps + [

--- a/src/sparseml/export/validators.py
+++ b/src/sparseml/export/validators.py
@@ -133,7 +133,13 @@ def validate_correctness(
     :param validation_function: The function that will be used to validate the outputs.
     :return: True if the validation passes, False otherwise.
     """
-    import onnxruntime as ort
+    try:
+        import onnxruntime as ort
+    except ImportError as err:
+        raise ImportError(
+            "The onnxruntime package is required for the correctness validation. "
+            "Please install it using 'pip install sparseml[onnxruntime]'."
+        ) from err
 
     sample_inputs_path = os.path.join(target_path, InputsNames.basename.value)
     sample_outputs_path = os.path.join(target_path, OutputsNames.basename.value)


### PR DESCRIPTION
Now that ORT is not "required" by transformers explicitly unless validate_correctness is called this PR does two things:

- Remove ort from transformers dependency
- Raise apt install message when ort is used