### PR TITLE
Fix where the logs are coming from

### DIFF
--- a/src/sparseml/modifiers/obcq/pytorch.py
+++ b/src/sparseml/modifiers/obcq/pytorch.py
@@ -55,10 +55,15 @@ class SparseGPTModifierPyTorch(WandaPruningModifierPyTorch, SparseGPTModifier):
 
         :param state: session state storing input model and calibration data
         """
+
         if not self.initialized_structure_:
             self.on_initialize_structure(state, **kwargs)
         if self.quantization_modifier_:
             self.quantization_modifier_.initialize(state, **kwargs)
+
+        # temporary work around until logger refactor lands
+        # we can then use the LoggerManager from state
+        self.logger_ = _LOGGER
 
         return super(SparseGPTModifierPyTorch, self).on_initialize(state, **kwargs)
 


### PR DESCRIPTION
Before this PR even when SparseGPT modifier was used things were logged from `sparseml.modifiers.pruning.wanda.pytorch` due to common functionality

Test command:
```bash
python src/sparseml/transformers/sparsification/obcq/obcq.py Xenova/llama2.c-stories15M open_platypus --recip
e tests/sparseml/transformers/obcq/test_tiny.yaml --save False
 ```

```bash
2024-01-18 17:08:15 __main__     INFO     Running one_shot on device cuda:0
2024-01-18 17:08:15 __main__     INFO     Running one_shot on device cuda:0
2024-01-18 17:08:18 sparseml.core.recipe.recipe INFO     Loading recipe from file tests/sparseml/transformers/obcq/test_tiny.yaml
2024-01-18 17:08:19 sparseml.modifiers.smoothquant.pytorch INFO     Running SmoothQuantModifier calibration with 512 samples...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [00:04<00:00, 117.45it/s]
2024-01-18 17:08:23 sparseml.modifiers.smoothquant.pytorch INFO     Smoothing activation scales...
2024-01-18 17:08:23 sparseml.modifiers.quantization.pytorch INFO     Running QuantizationModifier calibration with 512 samples...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [00:27<00:00, 18.38it/s]
2024-01-18 17:08:51 sparseml.modifiers.pruning.wanda.pytorch INFO     Preparing model.layers.0 for compression
2024-01-18 17:08:51 sparseml.modifiers.pruning.wanda.pytorch INFO     Preparing model.layers.1 for compression
2024-01-18 17:08:51 sparseml.modifiers.pruning.wanda.pytorch INFO     Preparing model.layers.2 for compression
2024-01-18 17:08:51 sparseml.modifiers.pruning.wanda.pytorch INFO     Preparing model.layers.3 for compression
2024-01-18 17:08:51 sparseml.modifiers.pruning.wanda.pytorch INFO     Preparing model.layers.4 for compression
2024-01-18 17:08:51 sparseml.modifiers.pruning.wanda.pytorch INFO     Preparing model.layers.5 for compression
2024-01-18 17:08:51 sparseml.modifiers.pruning.wanda.pytorch INFO     Running SparseGPTModifier calibration with 512 samples...
2024-01-18 17:08:51 sparseml.modifiers.pruning.wanda.pytorch INFO     
===== Compressing layer 1/6 to sparsity 0.5 =====
2024-01-18 17:08:52 sparseml.modifiers.pruning.wanda.pytorch INFO     Calibrating model.layers.0...
```

This PR adds a workaround for now, to log from the correct place, Now for the same command logs look like:
```bash
2024-01-18 17:12:48 __main__     INFO     Running one_shot on device cuda:0
2024-01-18 17:12:48 __main__     INFO     Running one_shot on device cuda:0
2024-01-18 17:12:51 sparseml.core.recipe.recipe INFO     Loading recipe from file tests/sparseml/transformers/obcq/test_tiny.yaml
2024-01-18 17:12:51 sparseml.modifiers.smoothquant.pytorch INFO     Running SmoothQuantModifier calibration with 512 samples...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [00:04<00:00, 119.35it/s]
2024-01-18 17:12:55 sparseml.modifiers.smoothquant.pytorch INFO     Smoothing activation scales...
2024-01-18 17:12:56 sparseml.modifiers.quantization.pytorch INFO     Running QuantizationModifier calibration with 512 samples...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [00:27<00:00, 18.37it/s]
2024-01-18 17:13:24 sparseml.modifiers.obcq.pytorch INFO     Preparing model.layers.0 for compression
2024-01-18 17:13:24 sparseml.modifiers.obcq.pytorch INFO     Preparing model.layers.1 for compression
2024-01-18 17:13:24 sparseml.modifiers.obcq.pytorch INFO     Preparing model.layers.2 for compression
2024-01-18 17:13:24 sparseml.modifiers.obcq.pytorch INFO     Preparing model.layers.3 for compression
2024-01-18 17:13:24 sparseml.modifiers.obcq.pytorch INFO     Preparing model.layers.4 for compression
2024-01-18 17:13:24 sparseml.modifiers.obcq.pytorch INFO     Preparing model.layers.5 for compression
2024-01-18 17:13:24 sparseml.modifiers.obcq.pytorch INFO     Running SparseGPTModifier calibration with 512 samples...
2024-01-18 17:13:24 sparseml.modifiers.pruning.wanda.pytorch INFO     
===== Compressing layer 1/6 to sparsity 0.5 =====
2024-01-18 17:13:24 sparseml.modifiers.obcq.pytorch INFO     Calibrating model.layers.0...
```

Now the log location is correct, `sparseml.modifiers.obcq.pytorch`
