### PR TITLE
[bug] remove missed lines that caused failure

### DIFF
--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -222,9 +222,6 @@ class SparseSession:
         :param kwargs: additional kwargs to pass to the lifecycle's finalize method
         :return: the modified state of the session after finalizing
         """
-        # log losses on finalization
-        self._log_loss(event_type=EventType.LOSS_CALCULATED, loss=self.state.loss)
-
         mod_data = self._lifecycle.finalize(**kwargs)
 
         return ModifiedState(


### PR DESCRIPTION
This PR fixes a test failure caused because we were logging losses on finalization. These lines were supposed to be deleted as part of a diiferent diff but were missed.

```
$ pytest -vv tests/sparseml/transformers/obcq/test_obcq.py                                                                   (main|✚1…1⚑2)
=========================================================== test session starts ===========================================================
platform linux -- Python 3.11.5, pytest-7.4.4, pluggy-1.3.0 -- /home/rahul/venvs/.base_venv/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/rahul/projects/sparseml
configfile: pyproject.toml
plugins: flaky-3.7.0, anyio-4.2.0, mock-3.12.0
collected 5 items                                                                                                                         

tests/sparseml/transformers/obcq/test_obcq.py::test_obcq_tinystories[tests/sparseml/transformers/obcq/test_tiny.yaml] PASSED        [ 20%]
tests/sparseml/transformers/obcq/test_obcq.py::test_obcq_tinystories[tests/sparseml/transformers/obcq/test_tiny2.yaml] PASSED       [ 40%]
tests/sparseml/transformers/obcq/test_obcq.py::test_obcq_tinystories[tests/sparseml/transformers/obcq/test_tiny_w_head.yaml] PASSED [ 60%]
tests/sparseml/transformers/obcq/test_obcq.py::test_lm_head_target PASSED                                                           [ 80%]
tests/sparseml/transformers/obcq/test_obcq.py::test_sparsities PASSED                                                               [100%]

```