### PR TITLE
[Bug] Init tensorboard logger only if available

### DIFF
--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -527,6 +527,13 @@ class TensorBoardLogger(LambdaLogger):
             enabled=enabled,
         )
 
+    @staticmethod
+    def available() -> bool:
+        """
+        :return: True if tensorboard is available and installed, False, otherwise
+        """
+        return not tensorboard_import_error
+
     @property
     def writer(self) -> SummaryWriter:
         """
@@ -717,7 +724,7 @@ class SparsificationGroupLogger(BaseLogger):
                 )
             )
 
-        if tensorboard:
+        if tensorboard and TensorBoardLogger.available():
             self._loggers.append(
                 TensorBoardLogger(
                     log_path=tensorboard if isinstance(tensorboard, str) else None,


### PR DESCRIPTION
This PR fixes a bug where an error is raised while instantiating logger manager if tensor board is not installed

The fix was to only instantiate tensorboard logger if it is installed

Test:

Apply the following patch to emulate tensor board not being installed

```
diff --git a/src/sparseml/core/logger/logger.py b/src/sparseml/core/logger/logger.py
index 26e435a06e..35ed944167 100644
--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -46,6 +46,7 @@ except Exception as tensorboard_err:
     SummaryWriter = object
     tensorboard_import_error = tensorboard_err
 
+tensorboard_import_error = object
 
 try:
     import wandb
```

Run the following code:
```python
from sparseml.core import LoggerManager


def main():
    lm = LoggerManager()
    lm.system.info("info message", "Hello World!")

if __name__ == "__main__":
    main()
```

This test would raise an error before current diff, but passes now.