### PR TITLE
[BugFix] Fix typo

### DIFF
--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -209,7 +209,7 @@ class SparseSession:
         return ModifiedState(
             model=self.state.model.model if self.state.model else None,
             optimizer=self.state.optimizer.optimizer if self.state.optimizer else None,
-            loss=self.state.loss.loss if self.state.loss else None,
+            loss=self.state.loss,
             modifier_data=mod_data,
         )
 


### PR DESCRIPTION
The loss is stored in `state.loss` and not `state.loss.loss`