### PR TITLE
Clean up One-Shot Recipe Output

### DIFF
--- a/src/sparseml/core/recipe/recipe.py
+++ b/src/sparseml/core/recipe/recipe.py
@@ -474,7 +474,12 @@ class Recipe(RecipeBase):
         yaml_dict = self._get_yaml_dict()
 
         ret = yaml.dump(
-            yaml_dict, stream=file_stream, allow_unicode=True, sort_keys=False
+            yaml_dict,
+            stream=file_stream,
+            allow_unicode=True,
+            sort_keys=False,
+            default_flow_style=None,
+            width=88,
         )
 
         if file_stream is not None:


### PR DESCRIPTION
Small change to how yaml is dumped to make nested lists more readable (needed for LogarithmicEqualization and SmoothQuant). This still isn't perfect, but there are limited output formatting options provided by the yaml library. This is just a cosmetic change, I tested that both the before and after recipe formats work fine as input oneshot recipes.

### Before:
```yaml
    SmoothQuantModifier:
      smoothing_strength: 0.5
      mappings:
      - - - re:.*q_proj
          - re:.*k_proj
          - re:.*v_proj
        - re:.*input_layernorm
      - - - re:.*gate_proj
          - re:.*up_proj
        - re:.*post_attention_layernorm
```

### After:
```yaml
    SmoothQuantModifier:
      smoothing_strength: 0.5
      mappings:
      - - ['re:.*q_proj', 're:.*k_proj', 're:.*v_proj']
        - re:.*input_layernorm
      - - ['re:.*gate_proj', 're:.*up_proj']
        - re:.*post_attention_layernorm
```

Asana ticket: https://app.asana.com/0/1205229323407165/1206400045066180/f