### PR TITLE
Fix for unexpected column

### DIFF
--- a/src/sparseml/modifiers/utils/pytorch_helpers.py
+++ b/src/sparseml/modifiers/utils/pytorch_helpers.py
@@ -86,6 +86,8 @@ def run_calibration_forward(
             break
         if mask_padding:
             batch = apply_pad_mask_to_batch(batch)
+        else:
+            batch.pop(PADDING_MASK_COLUMN_NAME)
         batch = tensors_to_device(batch, model_device)
         with torch.no_grad():
             forward_fn(batch, module=model)


### PR DESCRIPTION
https://github.com/neuralmagic/sparseml/commit/2e264e04760ca66266ce7249ad4cb71c6ec41c1f introduced a bug for quantization modifiers, we need to remove the padding column if it is unused to avoid a `TypeError: LlamaForCausalLM.forward() got an unexpected keyword argument 'padding_mask'`