### PR TITLE
Fix integration choices in export.py

### DIFF
--- a/src/sparseml/export/export.py
+++ b/src/sparseml/export/export.py
@@ -395,7 +395,7 @@ def export(
 )
 @click.option(
     "--integration",
-    type=click.Choice(["image-classification, transformers"]),
+    type=click.Choice(["image-classification", "transformers"]),
     default=None,
     help="Integration the model was trained under. By default, inferred from the model",
 )


### PR DESCRIPTION
Previously this would fail if `--integration` was defined because the only valid value was the unfortunate string "image-classification, transformers":
```
sparseml.export --integration transformers --task model obcq_deployment
Usage: sparseml.export [OPTIONS] SOURCE_PATH
Try 'sparseml.export --help' for help.

Error: Invalid value for '--integration': 'transformers' is not 'image-classification, transformers'.
```