### PR TITLE
Fix Dtype Casting for Finetuning Teacher

### DIFF
--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -206,6 +206,7 @@ def main(
         "config": teacher_config,
         "cache_dir": model_args.cache_dir,
         "use_auth_token": True if model_args.use_auth_token else None,
+        "torch_dtype": parse_dtype(model_args.precision),
     }
     # this calls from_pretrained under the hood so should be FSDP safe
     model = SparseAutoModel.text_generation_from_pretrained(


### PR DESCRIPTION
The`--precision` argument was being applied to the student model but not the teacher. This caused a type mismatch error during training. The fix is to cast the teacher to dtype provided by `--precision` (auto by default)

Before:
If `--precision float16`
```
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::Half != float
```

After:
Finetuning runs as expected
