### PR TITLE
Fixing FSDP Memory Load Issue

### DIFF
--- a/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
+++ b/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
@@ -5,7 +5,7 @@ downcast_bf16: 'no'
 fsdp_config:
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
   fsdp_backward_prefetch_policy: BACKWARD_PRE
-  fsdp_cpu_ram_efficient_loading: false
+  fsdp_cpu_ram_efficient_loading: true
   fsdp_forward_prefetch: false
   fsdp_offload_params: false
   fsdp_sharding_strategy: 1
@@ -14,8 +14,9 @@ fsdp_config:
   fsdp_use_orig_params: false
 machine_rank: 0
 main_training_function: main
+mixed_precision: bf16
 num_machines: 1
-num_processes: 2
+num_processes: 4
 rdzv_backend: static
 same_network: true
 tpu_env: []

--- a/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
+++ b/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
@@ -15,7 +15,7 @@ fsdp_config:
 machine_rank: 0
 main_training_function: main
 num_machines: 1
-num_processes: 4
+num_processes: 2
 rdzv_backend: static
 same_network: true
 tpu_env: []

--- a/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
+++ b/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
@@ -5,7 +5,7 @@ downcast_bf16: 'no'
 fsdp_config:
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
   fsdp_backward_prefetch_policy: BACKWARD_PRE
-  fsdp_cpu_ram_efficient_loading: true
+  fsdp_cpu_ram_efficient_loading: false
   fsdp_forward_prefetch: false
   fsdp_offload_params: false
   fsdp_sharding_strategy: 1
@@ -14,7 +14,6 @@ fsdp_config:
   fsdp_use_orig_params: false
 machine_rank: 0
 main_training_function: main
-mixed_precision: bf16
 num_machines: 1
 num_processes: 4
 rdzv_backend: static

--- a/src/sparseml/pytorch/utils/sparsification_info/configs.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/configs.py
@@ -179,7 +179,7 @@ class SparsificationSummaries(SparsificationInfo):
         for param_name, param in module.named_parameters():
             num_parameters = param.numel()
             num_zero_parameters = param.numel() - param.count_nonzero().item()
-            num_parameters = max(1, num_parameters) # avoid FSDP divide by 0
+            num_parameters = max(1, num_parameters)  # avoid FSDP divide by 0
 
             if (
                 lower_threshold_pruning
@@ -260,7 +260,7 @@ class SparsificationPruning(SparsificationInfo):
         for param_name, param in module.named_parameters():
             num_parameters = param.numel()
             num_zero_parameters = param.numel() - param.count_nonzero().item()
-            num_parameters = max(1, num_parameters) # avoid FSDP divide by 0
+            num_parameters = max(1, num_parameters)  # avoid FSDP divide by 0
 
             zero_count = num_zero_parameters
             zero_count_percent = num_zero_parameters / num_parameters

--- a/src/sparseml/pytorch/utils/sparsification_info/configs.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/configs.py
@@ -179,6 +179,7 @@ class SparsificationSummaries(SparsificationInfo):
         for param_name, param in module.named_parameters():
             num_parameters = param.numel()
             num_zero_parameters = param.numel() - param.count_nonzero().item()
+            num_parameters = max(1, num_parameters) # avoid FSDP divide by 0
 
             if (
                 lower_threshold_pruning
@@ -259,6 +260,7 @@ class SparsificationPruning(SparsificationInfo):
         for param_name, param in module.named_parameters():
             num_parameters = param.numel()
             num_zero_parameters = param.numel() - param.count_nonzero().item()
+            num_parameters = max(1, num_parameters) # avoid FSDP divide by 0
 
             zero_count = num_zero_parameters
             zero_count_percent = num_zero_parameters / num_parameters

--- a/src/sparseml/transformers/finetune/runner.py
+++ b/src/sparseml/transformers/finetune/runner.py
@@ -158,7 +158,7 @@ class StageRunner:
         # first time, calls to summon_full_params will fail ¯\_(ツ)_/¯
         dummy_inp = dict(next(iter(calib_data)))
         with torch.no_grad():
-            dummy_inp.pop(PADDING_MASK_COLUMN_NAME)
+            dummy_inp.pop(PADDING_MASK_COLUMN_NAME, None)
             self.trainer.model(**dummy_inp)
         torch.cuda.empty_cache()
 

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -194,9 +194,13 @@ def main(
         else None
     )
 
+    # Trainer handles device assignment for FSDP and training, don't do mapping here
+    # if running oneshot outside of FSDP, apply user device settings
     device_map = None
-    if training_args.fsdp is None and training_args.do_oneshot:
+    fsdp_enabled = os.environ.get("ACCELERATE_USE_FSDP", "false") == "true"
+    if not fsdp_enabled and training_args.do_oneshot:
         device_map = training_args.oneshot_device
+        _LOGGER.warning(f"Moving {model_path} to device {device_map} for One-Shot")
     model_kwargs = {
         "config": config,
         "cache_dir": model_args.cache_dir,

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -194,13 +194,16 @@ def main(
         else None
     )
 
+    device_map = None
+    if training_args.fsdp is None and training_args.do_oneshot:
+        device_map = training_args.oneshot_device
     model_kwargs = {
         "config": config,
         "cache_dir": model_args.cache_dir,
         "revision": model_args.model_revision,
         "use_auth_token": True if model_args.use_auth_token else None,
         "torch_dtype": parse_dtype(model_args.precision),
-        "device_map": training_args.oneshot_device,
+        "device_map": device_map,
     }
     teacher_kwargs = {
         "config": teacher_config,


### PR DESCRIPTION
The input model was always being loaded to `oneshot_device` (default value `cuda:0`). This should not happen in FSDP mode, where the FSDP config determines model device mapping, or when running training/finetuning only. This was causing extra upfront memory usage loading the model on a single device


Also fixing 2 other small bugs: 
* the sparsification logger had a divide by zero error for some FSDP configs (`use_orig_params=True`),
* not accounting for the `padding_mask` column when running the dummy forward pass in FSDP mode