### PR TITLE
[Bug] Fix TypeError with old export flow

### DIFF
--- a/src/sparseml/transformers/sparsification/obcq/export.py
+++ b/src/sparseml/transformers/sparsification/obcq/export.py
@@ -152,7 +152,6 @@ def load_task_model(
         return SparseAutoModel.text_generation_from_pretrained(
             model_name_or_path=model_path,
             config=config,
-            model_type="model",
             trust_remote_code=trust_remote_code,
         )
 


### PR DESCRIPTION
Removes `model_type` from `SparseAutoModel.text_generation_from_pretrained` call


The old export flow was broken:

```bash
python src/sparseml/transformers/sparsification/obcq/export.py --task text-generation --sequence_length 4096 --model_path llama2.c-stories15M

...
...
Traceback (most recent call last):
  File "/home/rahul/projects/sparseml/src/sparseml/transformers/sparsification/obcq/export.py", line 543, in <module>
    main()
  File "/home/rahul/projects/sparseml/src/sparseml/transformers/sparsification/obcq/export.py", line 530, in main
    export(
  File "/home/rahul/projects/sparseml/src/sparseml/transformers/sparsification/obcq/export.py", line 508, in export
    export_transformer_to_onnx(
  File "/home/rahul/projects/sparseml/src/sparseml/transformers/sparsification/obcq/export.py", line 290, in export_transformer_to_onnx
    model = load_task_model(task, model_path, config, trust_remote_code)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/projects/sparseml/src/sparseml/transformers/sparsification/obcq/export.py", line 152, in load_task_model
    return SparseAutoModel.text_generation_from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/projects/sparseml/src/sparseml/transformers/utils/sparse_model.py", line 273, in text_generation_from_pretrained
    model = AutoModelForCausalLM.from_pretrained(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/venvs/.base_venv/lib/python3.11/site-packages/transformers/models/auto/auto_factory.py", line 565, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/venvs/.base_venv/lib/python3.11/site-packages/transformers/modeling_utils.py", line 3085, in from_pretrained
    model = cls(config, *model_args, **model_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: LlamaForCausalLM.__init__() got an unexpected keyword argument 'model_type'
```

Now the same command works:
```bash
python src/sparseml/transformers/sparsification/obcq/export.py --task text-generation --sequence_length 4096 --model_path llama2.c-stories15M
...
...
2024-01-25 16:03:00 __main__     INFO     Created deployment folder at /home/rahul/projects/sparseml/deployment with files: ['tokenizer.json', 'special_tokens_map.json', 'model.onnx', 'tokenizer_config.json', 'config.json']
2024-01-25 16:03:00 __main__     INFO     Created deployment folder at /home/rahul/projects/sparseml/deployment with files: ['tokenizer.json', 'special_tokens_map.json', 'model.onnx', 'tokenizer_config.json', 'config.json']
```

The checkpoint used for testing is: <https://huggingface.co/Xenova/llama2.c-stories15M/>



