### PR TITLE
Reduce Distillation Memory Overhead

### DIFF
--- a/src/sparseml/modifiers/distillation/output/pytorch.py
+++ b/src/sparseml/modifiers/distillation/output/pytorch.py
@@ -60,25 +60,10 @@ class OutputDistillationModifierPyTorch(OutputDistillationModifier):
                     f"model and teacher model layers for target {target} do not match"
                 )
 
-            # Ensure the student and teacher layer are on the same device
-            device = None
             for (key, student_layer), teacher_layer in zip(
                 model_layers.items(), teacher_layers.values()
             ):
-                for name, param in student_layer.named_parameters():
-                    device = param.device
-                    teacher_param = getattr(teacher_layer, name)
-                    teacher_param.data = teacher_param.to(device)
-
-                for name, buffer in student_layer.named_buffers():
-                    if hasattr(teacher_layer, name):
-                        device = buffer.device
-                        teacher_buffer = getattr(teacher_layer, name)
-                        teacher_buffer.data = teacher_buffer.to(device)
-
                 wrapper = self._create_wrapper(student_layer, teacher_layer, state)
-                kd_comparison_buffer = getattr(wrapper, wrapper.KD_COMPARISON_BUFFER)
-                kd_comparison_buffer.data = kd_comparison_buffer.to(device)
                 state.model.set_layer(key, wrapper)
                 self.wrappers_[key] = wrapper
                 wrapper.kd_enabled = True

--- a/src/sparseml/pytorch/utils/sparsification_info/helpers.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/helpers.py
@@ -105,7 +105,7 @@ def get_precision_information(
 
 def _get_num_bits(dtype: torch.dtype) -> int:
     # Get the number of bits of a torch dtype
-    if dtype == torch.float16:
+    if dtype == torch.float16 or dtype == torch.bfloat16:
         return 16
     elif dtype == torch.float32:
         return 32

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -214,6 +214,7 @@ def main(
         "cache_dir": model_args.cache_dir,
         "use_auth_token": True if model_args.use_auth_token else None,
         "torch_dtype": parse_dtype(model_args.precision),
+        "device_map": "auto",  # spread teacher across GPUs, used for inference only
     }
     # this calls from_pretrained under the hood so should be FSDP safe
     model = SparseAutoModel.text_generation_from_pretrained(

--- a/src/sparseml/utils/fsdp/context.py
+++ b/src/sparseml/utils/fsdp/context.py
@@ -14,6 +14,7 @@
 
 try:
     from torch.distributed.fsdp import FullyShardedDataParallel
+    from torch.distributed.fsdp._common_utils import TrainingState
 except ImportError:
     FullyShardedDataParallel = None
 
@@ -27,6 +28,12 @@ FSDP_WRAPPER_NAME = "_fsdp_wrapped_module."
 
 def summon_full_params_context(model):
     if FullyShardedDataParallel is not None:
+        # avoid nested summon_full_param context
+        if (
+            hasattr(model, "training_state")
+            and model.training_state is TrainingState.SUMMON_FULL_PARAMS
+        ):
+            return nullcontext()
         return FullyShardedDataParallel.summon_full_params(model)
 
     return nullcontext()


### PR DESCRIPTION
Previously we would force the teacher layer onto the same device as the student layer at initialization. This worked ok when we initialized modifiers before initializing FSDP but there are two problems with this
* we are only ever running inference on the teacher model, so there is no need to make FSDP deal with its gradients. We can save a lot of memory by leaving the teacher out of FSDP
* For alternating flows, we need to initialize modifiers after FSDP is applied. In this case, if we try to force the teacher onto the student layer we are likely to run out of memory because FSDP wasn't able to account for the extra memory during initialization

### Summary of Changes
* load teacher with device_map=auto to spread it across GPUs before FSDP initialization. This allows FSDP to account for the teacher when sharding the model
* rather than moving the teacher layer to the student device at initialization, just move the input tensor back and forth in `kd_wrapper.py` during the teacher forward pass
* Add an additional check in the FSDP context manager, so we avoid entering it twice

### Testing 
This script would previously run out of memory on GPU6 FSDP, now it runs 
```
#!/bin/bash

FSDP_CONFIG='/nm/drive0/sadkins/sparseml/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml'
MODEL_NAME='/nm/drive0/sadkins/models/llama2-7b-open_platypus_orca_llama2_pretrain-pruned40.oneshot/training'
TEACHER_NAME='/nm/drive0/sadkins/models/llama2-7b-open_platypus_orca_llama2_pretrain-pruned40/training'
RECIPE='_test_scripts/test_trainer_recipe.yaml'
DATASET_NAME='open_platypus'
OUTPUT_DIR='llama7b_profile_40'

accelerate launch --config_file $FSDP_CONFIG \
    --no_python sparseml.transformers.text_generation.finetune \
    --model_name $MODEL_NAME \
    --distill_teacher $TEACHER_NAME \
    --dataset_name $DATASET_NAME \
    --output_dir $OUTPUT_DIR \
    --overwrite_output_dir 'true' \
    --num_train_epochs 1 \
    --splits 'train' \
    --per_device_train_batch_size 4 \
    --precision 'bfloat16' \
    --recipe $RECIPE
```