### PR TITLE
[Eval] Add eval cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -282,6 +282,9 @@ def _setup_entry_points() -> Dict:
         ]
     )
 
+    # eval entrypoint
+    entry_points["console_scripts"].append("sparseml.eval=sparseml.evaluation.cli:main")
+
     return entry_points
 
 

--- a/src/sparseml/__init__.py
+++ b/src/sparseml/__init__.py
@@ -44,6 +44,6 @@ from .sparsification import (
     load_sparsification_info,
 )
 from .analytics import sparseml_analytics as _analytics
-
+from .evaluation.evaluator import evaluate
 
 _analytics.send_event("python__init")

--- a/src/sparseml/evaluation/__init__.py
+++ b/src/sparseml/evaluation/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/sparseml/evaluation/cli.py
+++ b/src/sparseml/evaluation/cli.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+######
+Command help:
+$ sparseml.eval --help                                                                                (add-eval-cli|✚1…2)
+Usage: sparseml.eval [OPTIONS] [INTEGRATION_ARGS]...
+
+Options:
+  --model_path PATH               A path to a local directory containing
+                                  pytorch model(including all the auxiliary
+                                  files) or a SparseZoo/HugginFace stub
+                                  [required]
+  -d, --dataset TEXT              The name of dataset to evaluate on. The user
+                                  may pass multiple datasets names by passing
+                                  the option multiple times.
+  -i, --integration TEXT          Name of the evaluation integration to use.
+                                  Must be a valid integration name that is
+                                  registered in the evaluation registry
+                                  [required]
+  -s, --save_path TEXT            The path to save the evaluation results. The
+                                  results will be saved under the name
+                                  'result.yaml`/'result.json' depending on the
+                                  serialization type. If argument is not
+                                  provided, the results will be saved in the
+                                  current directory
+  -t, --type_serialization [yaml|json]
+                                  The serialization type to use save the
+                                  evaluation results. The default is json
+  -b, --batch_size INTEGER        The batch size to use for the evaluation.
+                                  Must be greater than 0
+  --nsamples INTEGER              The number of samples to evaluate on. Must
+                                  be greater than 0
+  --help                          Show this message and exit.
+
+INTEGRATION_ARGS:
+    Additional, unstructured arguments to pass to the evaluation integration.
+
+#########
+EXAMPLES
+#########
+
+"""  # noqa: E501
+import logging
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import click
+from sparseml.evaluation.evaluator import evaluate
+from sparsezoo.evaluation.results import Result, save_result
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@click.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+    )
+)
+@click.option(
+    "--model_path",
+    type=click.Path(dir_okay=True, file_okay=True),
+    required=True,
+    help="A path to a local directory containing pytorch model"
+    "(including all the auxiliary files) or a SparseZoo/HugginFace stub",
+)
+@click.option(
+    "-d",
+    "--dataset",
+    type=str,
+    multiple=True,
+    help="The name of dataset to evaluate on. The user may pass multiple "
+    "datasets names by passing the option multiple times.",
+)
+@click.option(
+    "-i",
+    "--integration",
+    type=str,
+    required=True,
+    help="Name of the evaluation integration to use. Must be a valid "
+    "integration name that is registered in the evaluation registry",
+)
+@click.option(
+    "-s",
+    "--save_path",
+    type=click.UNPROCESSED,
+    default=None,
+    help="The path to save the evaluation results. The results will "
+    "be saved under the name 'result.yaml`/'result.json' depending on "
+    "the serialization type. If argument is not provided, the results "
+    "will be saved in the current directory",
+)
+@click.option(
+    "-t",
+    "--type_serialization",
+    type=click.Choice(["yaml", "json"]),
+    default="json",
+    help="The serialization type to use save the evaluation results. "
+    "The default is json",
+)
+@click.option(
+    "-b",
+    "--batch_size",
+    type=int,
+    default=1,
+    help="The batch size to use for the evaluation. Must be greater than 0",
+)
+@click.option(
+    "--nsamples",
+    type=int,
+    default=None,
+    help="The number of samples to evaluate on. Must be greater than 0",
+)
+@click.argument("integration_args", nargs=-1, type=click.UNPROCESSED)
+def main(
+    model_path,
+    dataset,
+    integration,
+    save_path,
+    type_serialization,
+    batch_size,
+    nsamples,
+    integration_args,
+):
+    # join datasets to a list if multiple datasets are passed
+    datasets = list(dataset) if not isinstance(dataset, str) else dataset
+    # format kwargs to a  dict
+    integration_args = _args_to_dict(integration_args)
+
+    _LOGGER.info(
+        f"Datasets to evaluate on: {datasets}\n"
+        f"Batch size: {batch_size}\n"
+        f"Additional integration arguments supplied: {integration_args}"
+    )
+
+    result: Result = evaluate(
+        model=model_path,
+        datasets=datasets,
+        integration=integration,
+        batch_size=batch_size,
+        nsamples=nsamples,
+        **integration_args,
+    )
+
+    _LOGGER.info(f"Evaluation done. Results:\n{result}")
+
+    save_path = (
+        Path.cwd() / f"results.{type_serialization}"
+        if not save_path
+        else Path(save_path).absolute().with_suffix(f".{type_serialization}")
+    )
+
+    if save_path:
+        _LOGGER.info(f"Saving the evaluation results to {save_path}")
+        save_result(result=result, save_path=save_path, save_format=type_serialization)
+
+
+def _args_to_dict(args: Tuple[Any, ...]) -> Dict[str, Any]:
+    """
+    Convert a tuple of args to a dict of args.
+
+    :param args: The args to convert. Should be a tuple of alternating
+        arg names and arg values e.g.('--arg1', 1, 'arg2', 2, -arg3', 3).
+        The names can optionally have a '-' or `--` in front of them.
+    :return: The converted args as a dict.
+    """
+    # Note: this function will ne moved to
+    # nm_utils soon
+
+    if len(args) == 0:
+        return {}
+    # names are uneven indices, values are even indices
+    args_names = args[0::2]
+    args_values = args[1::2]
+    # remove any '-' or '--' from the names
+    args_names = [name.lstrip("-") for name in args_names]
+
+    return dict(zip(args_names, args_values))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sparseml/evaluation/cli.py
+++ b/src/sparseml/evaluation/cli.py
@@ -15,7 +15,7 @@
 """
 ######
 Command help:
-$ sparseml.eval --help                                                                                (add-eval-cli|✚1…2)
+$ sparseml.eval --help
 Usage: sparseml.eval [OPTIONS] [INTEGRATION_ARGS]...
 
 Options:

--- a/src/sparseml/evaluation/evaluator.py
+++ b/src/sparseml/evaluation/evaluator.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from sparseml.evaluation.registry import SparseMLEvaluationRegistry
+from sparsezoo.evaluation.results import Result
+
+
+__all__ = ["evaluate"]
+
+
+def evaluate(
+    target: str,
+    datasets: str,
+    integration: str,
+    batch_size: int = 1,
+    **kwargs,
+) -> Result:
+    """
+    Evaluate a target model on a dataset using the specified integration.
+
+    :param target: Path to the model folder or the model stub from
+        SparseZoo/HuggingFace to evaluate. For example,
+        `mgoin/llama2.c-stories15M-quant-pt`
+    :param datasets: The dataset(s) to evaluate on. For example,
+        `open_playtpus`
+    :param integration: Name of the eval integration to use.
+        Example, `perplexity`
+    :param batch_size: The batch size to use for evals, defaults to 1
+    :return: The evaluation result as a Result object
+    """
+
+    eval_integration = SparseMLEvaluationRegistry.resolve(
+        name=integration, datasets=datasets
+    )
+    return eval_integration(target, datasets, batch_size, **kwargs)

--- a/src/sparseml/evaluation/evaluator.py
+++ b/src/sparseml/evaluation/evaluator.py
@@ -34,7 +34,7 @@ def evaluate(
         SparseZoo/HuggingFace to evaluate. For example,
         `mgoin/llama2.c-stories15M-quant-pt`
     :param datasets: The dataset(s) to evaluate on. For example,
-        `open_playtpus`
+        `open_platypus`
     :param integration: Name of the eval integration to use.
         Example, `perplexity`
     :param batch_size: The batch size to use for evals, defaults to 1

--- a/src/sparseml/evaluation/evaluator.py
+++ b/src/sparseml/evaluation/evaluator.py
@@ -21,7 +21,7 @@ __all__ = ["evaluate"]
 
 
 def evaluate(
-    target: str,
+    model_path: str,
     datasets: str,
     integration: str,
     batch_size: int = 1,
@@ -30,7 +30,7 @@ def evaluate(
     """
     Evaluate a target model on a dataset using the specified integration.
 
-    :param target: Path to the model folder or the model stub from
+    :param model_path: Path to the model folder or the model stub from
         SparseZoo/HuggingFace to evaluate. For example,
         `mgoin/llama2.c-stories15M-quant-pt`
     :param datasets: The dataset(s) to evaluate on. For example,
@@ -44,4 +44,4 @@ def evaluate(
     eval_integration = SparseMLEvaluationRegistry.resolve(
         name=integration, datasets=datasets
     )
-    return eval_integration(target, datasets, batch_size, **kwargs)
+    return eval_integration(model_path, datasets, batch_size, **kwargs)

--- a/src/sparseml/evaluation/integrations/__init__.py
+++ b/src/sparseml/evaluation/integrations/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/sparseml/evaluation/integrations_config.yaml
+++ b/src/sparseml/evaluation/integrations_config.yaml
@@ -1,0 +1,16 @@
+# This file is used to dynamically load integrations for evaluation
+# Each integration must have a name and it's corresponding file path
+# The file path should be relative to the integrations_config.yaml file
+# The file path must contain a callable registered with the name of the 
+# integration
+
+# NOTE: Do NOT use "." to specify the relative path
+#  it is assumed the integrations locations are with respect 
+#  this file.
+
+# The integrations will be loaded in only when they are needed
+
+# Example:
+# my_eval_integration: integrations/my_eval_integration.py
+# my_eval_integration2: integrations/my_eval_integration2.py
+

--- a/src/sparseml/evaluation/registry.py
+++ b/src/sparseml/evaluation/registry.py
@@ -68,6 +68,7 @@ def collect_integrations(name: str):
     integrations = _standardize_integration_dict(
         integrations_location_dict=_load_yaml(path=INTEGRATION_CONFIG_PATH)
     )
+    name = standardize_lookup_name(name)
 
     if name in integrations:
         location = integrations[name]

--- a/src/sparseml/evaluation/registry.py
+++ b/src/sparseml/evaluation/registry.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Callable, Dict
+
+import yaml
+
+from sparsezoo.evaluation import EvaluationRegistry
+from sparsezoo.evaluation.results import Result
+from sparsezoo.utils.registry import standardize_lookup_name
+
+
+__all__ = ["SparseMLEvaluationRegistry", "collect_integrations"]
+
+_LOGGER = logging.getLogger(__name__)
+
+INTEGRATION_CONFIG_NAME: str = "integrations_config.yaml"
+INTEGRATION_CONFIG_PATH: Path = Path(__file__).parent / INTEGRATION_CONFIG_NAME
+
+
+class SparseMLEvaluationRegistry(EvaluationRegistry):
+    """
+    This class is used to register and retrieve evaluation integrations for
+    SparseML. It is a subclass of the SparseZoo EvaluationRegistry class.
+    """
+
+    @classmethod
+    def resolve(cls, name: str, *args, **kwargs) -> Callable[..., Result]:
+        """
+        Resolve an evaluation integration by name.
+
+        :param name: The name of the evaluation integration to resolve
+        :param args: The arguments to pass to the evaluation integration
+        :param kwargs: The keyword arguments to pass to the evaluation integration
+        :return: The evaluation integration associated with the name
+        """
+        collect_integrations(name=name)
+        return cls.get_value_from_registry(name=name)
+
+
+def collect_integrations(name: str):
+    """
+    This function is used to collect integrations based on name, this method
+    is responsible for triggering the registration with the SparseML Evaluation
+    registry.
+
+    This is done by importing the module associated with each integration.
+    This function is called automatically when the registry is accessed.
+    The specific integration(s) `callable` must be decorated with the
+    `@SparseMLEvaluationRegistry.register` decorator.
+
+    :param name: The name of the integration to collect, is case insentitive
+    """
+    integrations = _standardize_integration_dict(
+        integrations_location_dict=_load_yaml(path=INTEGRATION_CONFIG_PATH)
+    )
+
+    if name in integrations:
+        location = integrations[name]
+        _LOGGER.debug(f"Auto collecting {name} integration for eval from {location}")
+        try:
+            spec = importlib.util.spec_from_file_location(
+                f"eval_plugin_{name}", location
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            _LOGGER.info(f"Auto collected {name} integration for eval")
+        except ImportError as import_error:
+            _LOGGER.info(
+                f"Auto collection of {name} integration for eval "
+                f"failed with error: {import_error}"
+                "The integration must be registered and collected/imported "
+                "manually."
+            )
+        return
+
+    _LOGGER.debug(f"No integrations found for the given name {name}")
+
+
+def _load_yaml(path: Path):
+    """
+    Load a yaml file from the given path.
+
+    :param path: The path to the yaml file
+    :return: The loaded yaml file
+    """
+    with path.open("r") as file:
+        return yaml.safe_load(file)
+
+
+def _standardize_integration_dict(
+    integrations_location_dict: Dict[str, str]
+) -> Dict[str, str]:
+    """
+    Standardize the names of the integrations in the given dictionary.
+
+    :param integrations_location_dict: Dictionary of integration names to
+        their locations
+    :return: A copy of the dictionary with the standardized integration names
+    """
+    return {
+        standardize_lookup_name(name): _resolve_relative_path(location)
+        for name, location in integrations_location_dict.items()
+    }
+
+
+def _resolve_relative_path(relative_path: Path) -> Path:
+    """
+    Resolve the given path to an absolute path.
+
+    :param relative_path: The path to resolve w.r.t
+        the current file
+    :return: The resolved absolute path
+    """
+    current_file_path = Path(__file__).resolve()
+    absolute_path = (current_file_path.parent / relative_path).resolve()
+    return absolute_path

--- a/tests/sparseml/evaluation/__init__.py
+++ b/tests/sparseml/evaluation/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/sparseml/evaluation/test_evaluator.py
+++ b/tests/sparseml/evaluation/test_evaluator.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+from sparseml.evaluation.evaluator import evaluate
+from sparsezoo.evaluation.results import Result
+
+
+def test_evaluate_calls_integration_with_correct_parameters(mocker):
+    mock_integration = MagicMock(return_value=Result(formatted=[], raw=None))
+    mock_resolve = mocker.patch(
+        "sparseml.evaluation.evaluator.SparseMLEvaluationRegistry.resolve",
+        return_value=mock_integration,
+    )
+    target = "model_path"
+    datasets = "dataset_name"
+    integration = "integration_name"
+    batch_size = 10
+
+    result = evaluate(target, datasets, integration, batch_size)
+
+    mock_resolve.assert_called_once_with(name=integration, datasets=datasets)
+    mock_integration.assert_called_once_with(target, datasets, batch_size)
+    assert isinstance(result, Result)

--- a/tests/sparseml/evaluation/test_registry.py
+++ b/tests/sparseml/evaluation/test_registry.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sparseml.evaluation.registry import SparseMLEvaluationRegistry
+
+
+def test_resolve_returns_value_from_registry(mocker):
+    mock_collect_integrations = mocker.patch(
+        "sparseml.evaluation.registry.collect_integrations"
+    )
+    mock_get_value_from_registry = mocker.patch.object(
+        SparseMLEvaluationRegistry, "get_value_from_registry", return_value="value"
+    )
+    name = "integration_name"
+
+    result = SparseMLEvaluationRegistry.resolve(name)
+
+    mock_collect_integrations.assert_called_once()
+    mock_get_value_from_registry.assert_called_once_with(name=name)
+    assert result == "value"


### PR DESCRIPTION
This PR adds a CLI for `sparseml.eval`

```
$ sparseml.eval --help                                                                                (add-eval-cli|✚1…2)
Usage: sparseml.eval [OPTIONS] [INTEGRATION_ARGS]...

Options:
  --model_path PATH               A path to a local directory containing
                                  pytorch model(including all the auxiliary
                                  files) or a SparseZoo/HugginFace stub
                                  [required]
  -d, --dataset TEXT              The name of dataset to evaluate on. The user
                                  may pass multiple datasets names by passing
                                  the option multiple times.
  -i, --integration TEXT          Name of the evaluation integration to use.
                                  Must be a valid integration name that is
                                  registered in the evaluation registry
                                  [required]
  -s, --save_path TEXT            The path to save the evaluation results. The
                                  results will be saved under the name
                                  'result.yaml`/'result.json' depending on the
                                  serialization type. If argument is not
                                  provided, the results will be saved in the
                                  current directory
  -t, --type_serialization [yaml|json]
                                  The serialization type to use save the
                                  evaluation results. The default is json
  -b, --batch_size INTEGER        The batch size to use for the evaluation.
                                  Must be greater than 0
  --nsamples INTEGER              The number of samples to evaluate on. Must
                                  be greater than 0
  --help                          Show this message and exit.
```