### PR TITLE
add [llm] install extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,7 @@ def _setup_extras() -> Dict:
         "torch_all": _pytorch_all_deps,
         "torchvision": _pytorch_vision_deps,
         "transformers": _transformers_deps,
+        "llm": _transformers_deps,
         "notebook": _notebook_deps,
         "tf_v1": _tensorflow_v1_deps,
         "tf_v1_gpu": _tensorflow_v1_gpu_deps,


### PR DESCRIPTION
adds `[llm]` install extra as an alias to `[transformers]` for llm task specific dependencies such as for evals will keep those as not installed unless otherwise requested