### PR TITLE
Set correct split for ultrachat200k

### DIFF
--- a/src/sparseml/transformers/finetune/data/ultrachat_200k.py
+++ b/src/sparseml/transformers/finetune/data/ultrachat_200k.py
@@ -43,6 +43,10 @@ class UltraChatDataset(TextGenerationDataset):
     def __init__(self, data_args, split, tokenizer):
         data_args = deepcopy(data_args)
         data_args.dataset_name = "HuggingFaceH4/ultrachat_200k"
+
+        if split in ["train", "test"]:
+            split += "_sft"
+        
         super().__init__(
             text_column="messages",
             data_args=data_args,


### PR DESCRIPTION
ultrachat200k doesn't have train or test splits. It has train_sft and test_sft for fine-tuning and train_gen and test_gen for PPO style optimization. Our flows load "train" and "test" splits, so this PR adds support for these splits by pointing them to the respective sft versions