### PR TITLE
Adding HistogramObserver

### DIFF
--- a/src/sparseml/modifiers/quantization/utils/quantization_scheme.py
+++ b/src/sparseml/modifiers/quantization/utils/quantization_scheme.py
@@ -121,7 +121,7 @@ class QuantizationArgs(BaseModel):
 
     @validator("strategy")
     def validate_strategy(cls, value):
-        valid_scopes = ["tensor", "channel"]
+        valid_scopes = ["tensor", "channel", "histogram"]
         if value not in valid_scopes:
             raise ValueError(f"`strategy` must be one of {valid_scopes}, got {value}")
         return value
@@ -303,6 +303,14 @@ def get_observer(
         observer_cls = torch_quantization.MovingAveragePerChannelMinMaxObserver
         observer_kwargs = dict(
             ch_axis=0,
+            dtype=dtype,
+            qscheme=qscheme,
+            reduce_range=reduce_range,
+        )
+    elif strategy == "histrogram":
+        qscheme = torch.per_channel_symmetric if symmetric else torch.per_channel_affine
+        observer_cls = torch_quantization.HistogramObserver
+        observer_kwargs = dict(
             dtype=dtype,
             qscheme=qscheme,
             reduce_range=reduce_range,

--- a/src/sparseml/modifiers/quantization/utils/quantization_scheme.py
+++ b/src/sparseml/modifiers/quantization/utils/quantization_scheme.py
@@ -307,8 +307,8 @@ def get_observer(
             qscheme=qscheme,
             reduce_range=reduce_range,
         )
-    elif strategy == "histrogram":
-        qscheme = torch.per_channel_symmetric if symmetric else torch.per_channel_affine
+    elif strategy == "histogram":
+        qscheme = torch.per_tensor_symmetric if symmetric else torch.per_tensor_affine
         observer_cls = torch_quantization.HistogramObserver
         observer_kwargs = dict(
             dtype=dtype,


### PR DESCRIPTION
The PR adds support for utilizing HistogramObserver from PyTorch which computes the min/max values for quantization by minimizing quantization error.
The implementation has been tested on CodeLlama and Llama-2 models.