### PR TITLE
[Forkless SparseML Transformers] Updating SparseML to be compatible with the forkless transformers

### DIFF
--- a/src/sparseml/experimental/sparsegpt/examples/llama2/recipes/llama_recipe.yaml
+++ b/src/sparseml/experimental/sparsegpt/examples/llama2/recipes/llama_recipe.yaml
@@ -11,7 +11,7 @@ quantization_modifiers:
     ignore:
       - LlamaRotaryEmbedding
       - LlamaRMSNorm
-      - SiLUActivation
+      - SiLU
       - model.layers.0.mlp.down_proj
       - model.layers.1.mlp.down_proj
       - model.layers.2.mlp.down_proj

--- a/src/sparseml/transformers/finetune/callbacks.py
+++ b/src/sparseml/transformers/finetune/callbacks.py
@@ -131,11 +131,6 @@ class DisableHalfPrecisionCallback(TrainerCallback):
 
         :param epoch: epoch to disable from
         """
-        if not self.on_begin_called:
-            # disable if training loops haven't started so we don't load
-            # the empty scaler state dict and instead disable it from the start
-            self.trainer.use_cuda_amp = False
-
         if hasattr(self.trainer, "scaler"):
             self.trainer.scaler._enabled = False
 

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -373,13 +373,7 @@ class SessionManagerMixIn:
         """
         self.initialize_structure()
 
-        # Always evaluate w/ fp32 to be closer to DeepSparse
-        use_cuda_amp = self.use_cuda_amp
-        if not self.args.fp16_full_eval and not self.args.bf16_full_eval:
-            self.use_cuda_amp = False
-
         output = super().evaluate(*args, **kwargs)
-        self.use_cuda_amp = use_cuda_amp
         self.finalize_session()
 
         return output

--- a/src/sparseml/transformers/finetune/trainer.py
+++ b/src/sparseml/transformers/finetune/trainer.py
@@ -91,10 +91,6 @@ class Trainer(SessionManagerMixIn, HFTransformersTrainer):
                         os.path.join(output_dir, "scheduler.pt"),
                     )
             reissue_pt_warnings(caught_warnings)
-            if self.use_cuda_amp:
-                torch.save(
-                    self.scaler.state_dict(), os.path.join(output_dir, "scaler.pt")
-                )
 
     def _save_checkpoint(self, model, trial, metrics=None):
         # Call into the save checkpoint by HF Transformers, which saves the

--- a/src/sparseml/transformers/sparsification/obcq/README.md
+++ b/src/sparseml/transformers/sparsification/obcq/README.md
@@ -194,7 +194,7 @@ test_stage:
       # These operations don't make sense to quantize
       - LlamaRotaryEmbedding
       - LlamaRMSNorm
-      - SiLUActivation
+      - SiLU
       # Skip quantizing the BMMs
       - QuantizableMatMul
       # Skip quantizing the layers with the most sensitive activations
@@ -242,7 +242,7 @@ test_stage:
       # These operations don't make sense to quantize
       - MistralRotaryEmbedding
       - MistralRMSNorm
-      - SiLUActivation
+      - SiLU
       # Skip quantizing the layers with the most sensitive activations
       - model.layers.1.mlp.down_proj
       - model.layers.31.mlp.down_proj

--- a/src/sparseml/transformers/sparsification/obcq/example_llama.yaml
+++ b/src/sparseml/transformers/sparsification/obcq/example_llama.yaml
@@ -10,7 +10,7 @@ test_stage:
       ignore:
         - LlamaRotaryEmbedding
         - LlamaRMSNorm
-        - SiLUActivation
+        - SiLU
         - model.layers.0.mlp.down_proj
         - model.layers.1.mlp.down_proj
         - model.layers.2.mlp.down_proj

--- a/src/sparseml/transformers/sparsification/obcq/example_mistral.yaml
+++ b/src/sparseml/transformers/sparsification/obcq/example_mistral.yaml
@@ -4,7 +4,7 @@ test_stage:
       ignore:
         - MistralRotaryEmbedding
         - MistralRMSNorm
-        - SiLUActivation
+        - SiLU
         - model.layers.1.mlp.down_proj
         - model.layers.31.mlp.down_proj
         - model.layers.30.mlp.down_proj

--- a/src/sparseml/transformers/sparsification/question_answering.py
+++ b/src/sparseml/transformers/sparsification/question_answering.py
@@ -79,11 +79,6 @@ class _QuestionAnsweringTrainer(TransformersTrainer):
         eval_dataloader = self.get_eval_dataloader(eval_dataset)
         eval_examples = self.eval_examples if eval_examples is None else eval_examples
 
-        # Always evaluate w/ fp32 to be closer to DeepSparse
-        use_cuda_amp = self.use_cuda_amp
-        if not self.args.fp16_full_eval and not self.args.bf16_full_eval:
-            self.use_cuda_amp = False
-
         # Temporarily disable metric computation, we will do it in the loop here.
         compute_metrics = self.compute_metrics
         self.compute_metrics = None
@@ -128,8 +123,6 @@ class _QuestionAnsweringTrainer(TransformersTrainer):
         self.control = self.callback_handler.on_evaluate(
             self.args, self.state, self.control, metrics
         )
-
-        self.use_cuda_amp = use_cuda_amp
 
         return metrics
 

--- a/src/sparseml/transformers/sparsification/trainer.py
+++ b/src/sparseml/transformers/sparsification/trainer.py
@@ -35,7 +35,7 @@ from transformers.file_utils import PaddingStrategy
 from transformers.integrations import TensorBoardCallback
 from transformers.trainer_callback import TrainerState
 from transformers.trainer_pt_utils import reissue_pt_warnings
-from transformers.trainer_utils import ShardedDDPOption, get_last_checkpoint
+from transformers.trainer_utils import get_last_checkpoint
 
 from sparseml.pytorch.model_load.helpers import log_model_load
 from sparseml.pytorch.optim import ScheduledModifierManager, ScheduledOptimizer
@@ -810,14 +810,8 @@ class TrainerInterface(RecipeManagerTrainerInterface):
         :return: the output from super.evaluate()
         """
         applied = self.apply_manager(epoch=math.inf, checkpoint=None)
-
-        # Always evaluate w/ fp32 to be closer to DeepSparse
-        use_cuda_amp = self.use_cuda_amp
-        if not self.args.fp16_full_eval and not self.args.bf16_full_eval:
-            self.use_cuda_amp = False
-
         output = super().evaluate(*args, **kwargs)
-        self.use_cuda_amp = use_cuda_amp
+
         if applied:
             self.finalize_manager()
 
@@ -894,9 +888,6 @@ class TransformersTrainer(HFTransformersTrainer):
         if output_dir is None:
             output_dir = self.args.output_dir
 
-        if self.sharded_ddp == ShardedDDPOption.SIMPLE and self.optimizer is not None:
-            self.optimizer.consolidate_state_dict()
-
         if self.is_world_process_zero():
             if self.optimizer is not None:
                 torch.save(
@@ -910,10 +901,6 @@ class TransformersTrainer(HFTransformersTrainer):
                         os.path.join(output_dir, "scheduler.pt"),
                     )
             reissue_pt_warnings(caught_warnings)
-            if self.use_cuda_amp:
-                torch.save(
-                    self.scaler.state_dict(), os.path.join(output_dir, "scaler.pt")
-                )
 
     def _load_optimizer_and_scheduler(self, checkpoint):
         """
@@ -1044,10 +1031,6 @@ class DisableHalfPrecisionCallback(TrainerCallback):
         return manager_q_active or arch_manager_q_active
 
     def disable_amp(self, epoch: float):
-        if not self.on_begin_called:
-            # disable if training loops haven't started so we don't load
-            # the empty scaler state dict and instead disable it from the start
-            self.trainer.use_cuda_amp = False
 
         if hasattr(self.trainer, "scaler"):
             self.trainer.scaler._enabled = False

--- a/tests/sparseml/transformers/finetune/test_quantization.yaml
+++ b/tests/sparseml/transformers/finetune/test_quantization.yaml
@@ -4,7 +4,7 @@ test_stage:
       ignore:
         - LlamaRotaryEmbedding
         - LlamaRMSNorm
-        - SiLUActivation
+        - SiLU
         - model.layers.0.mlp.down_proj
         - model.layers.1.mlp.down_proj
         - model.layers.2.mlp.down_proj

--- a/tests/sparseml/transformers/obcq/test_repeats.py
+++ b/tests/sparseml/transformers/obcq/test_repeats.py
@@ -97,7 +97,7 @@ def test_fail_on_repeated_quant(tmp_path):
                 ignore:
                     - LlamaRotaryEmbedding
                     - LlamaRMSNorm
-                    - SiLUActivation
+                    - SiLU
                 scheme_overrides:
                     Embedding:
                         input_activations: null
@@ -110,7 +110,7 @@ def test_fail_on_repeated_quant(tmp_path):
                 ignore:
                     - LlamaRotaryEmbedding
                     - LlamaRMSNorm
-                    - SiLUActivation
+                    - SiLU
                     - Embedding
     """
 
@@ -152,7 +152,7 @@ def test_separate_quants_allowed(tmp_path):
                 ignore:
                     - LlamaRotaryEmbedding
                     - LlamaRMSNorm
-                    - SiLUActivation
+                    - SiLU
                     - Linear
                 scheme_overrides:
                     Embedding:
@@ -166,7 +166,7 @@ def test_separate_quants_allowed(tmp_path):
                 ignore:
                     - LlamaRotaryEmbedding
                     - LlamaRMSNorm
-                    - SiLUActivation
+                    - SiLU
                     - Embedding
                     - MatMulLeftInput_QK
                     - MatMulRightInput_QK

--- a/tests/sparseml/transformers/obcq/test_tiny.yaml
+++ b/tests/sparseml/transformers/obcq/test_tiny.yaml
@@ -10,7 +10,7 @@ test_stage:
       ignore:
         - LlamaRotaryEmbedding
         - LlamaRMSNorm
-        - SiLUActivation
+        - SiLU
         - model.layers.0.mlp.down_proj
         - model.layers.1.mlp.down_proj
         - model.layers.2.mlp.down_proj


### PR DESCRIPTION
Accounts for the fact that:
- `SiLUActivation` is being renamed to `SiLU`
- `trainer` no longer has the attribute `use_cuda_amp`