### PR TITLE
[Fix] Fix imports: `from sparseml.transformers import load_dataset, apply`

### DIFF
--- a/src/sparseml/experimental/sparsegpt/examples/llama2/compare_obcq.py
+++ b/src/sparseml/experimental/sparsegpt/examples/llama2/compare_obcq.py
@@ -17,7 +17,7 @@ from sparseml.experimental.sparsegpt.dispatch import evaluate_perplexity, load_m
 from sparseml.experimental.sparsegpt.llama2 import load_data
 from sparseml.experimental.sparsegpt.main import sequential
 from sparseml.modifiers.obcq.utils.helpers import ppl_eval_general
-from sparseml.transformers.sparsification.obcq.obcq import one_shot
+from sparseml.transformers import apply
 from sparseml.transformers.sparsification.obcq.utils.helpers import llama_forward
 
 
@@ -93,7 +93,7 @@ if __name__ == "__main__":
     torch.cuda.empty_cache()
 
     prod_args = ProdArgs()
-    prod_model = one_shot(
+    prod_model = apply(
         model_path=prod_args.model,
         dataset_name=prod_args.dataset,
         num_samples=prod_args.nsamples,

--- a/src/sparseml/experimental/sparsegpt/examples/opt/compare_obcq.py
+++ b/src/sparseml/experimental/sparsegpt/examples/opt/compare_obcq.py
@@ -18,7 +18,7 @@ from sparseml.experimental.sparsegpt.dispatch import evaluate_perplexity, load_m
 from sparseml.experimental.sparsegpt.main import sequential
 from sparseml.experimental.sparsegpt.opt import load_data
 from sparseml.modifiers.obcq.utils.helpers import ppl_eval_general
-from sparseml.transformers.sparsification.obcq.obcq import one_shot
+from sparseml.transformers.sparsification.obcq.obcq import apply
 from sparseml.transformers.sparsification.obcq.utils.helpers import opt_forward
 
 
@@ -94,7 +94,7 @@ if __name__ == "__main__":
     torch.cuda.empty_cache()
 
     prod_args = ProdArgs()
-    prod_model = one_shot(
+    prod_model = apply(
         model_path=prod_args.model,
         dataset_name=prod_args.dataset,
         num_samples=prod_args.nsamples,

--- a/src/sparseml/transformers/__init__.py
+++ b/src/sparseml/transformers/__init__.py
@@ -58,3 +58,4 @@ _check_transformers_install()
 # (import order matters for circular import avoidance)
 from .utils import *
 from .export import *
+from .sparsification import *

--- a/src/sparseml/transformers/sparsification/__init__.py
+++ b/src/sparseml/transformers/sparsification/__init__.py
@@ -19,6 +19,7 @@ Hugging Face transformers flows
 
 # flake8: noqa
 
+from .obcq import *
 from .question_answering import *
 from .trainer import *
 from .training_args import *

--- a/src/sparseml/transformers/sparsification/__init__.py
+++ b/src/sparseml/transformers/sparsification/__init__.py
@@ -18,8 +18,9 @@ Hugging Face transformers flows
 """
 
 # flake8: noqa
-
-from .obcq import *
+# isort: skip_file
+# (import order matters for circular import avoidance)
 from .question_answering import *
 from .trainer import *
 from .training_args import *
+from .obcq import *

--- a/src/sparseml/transformers/sparsification/obcq/__init__.py
+++ b/src/sparseml/transformers/sparsification/obcq/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# flake8: noqa
+from .obcq import apply

--- a/src/sparseml/transformers/sparsification/obcq/obcq.py
+++ b/src/sparseml/transformers/sparsification/obcq/obcq.py
@@ -36,14 +36,14 @@ from sparseml.transformers.utils.helpers import resolve_sequence_length
 from sparseml.transformers.utils.initializers import initialize_sparse_model
 
 
-__all__ = ["one_shot"]
+__all__ = ["apply"]
 
 _LOGGER = logging.getLogger(__name__)
 SUPPORTED_MODELS = ["opt", "llama", "mistral"]
 SUPPORTED_PRECISION = ["auto", "half", "full", "float16", "bfloat16", "float32"]
 
 
-def one_shot(
+def apply(
     model_path: str,
     dataset_name: str,
     dataset_config_name: Optional[str] = None,
@@ -210,7 +210,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    one_shot(
+    apply(
         model_path=args.model,
         dataset_name=args.dataset,
         dataset_config_name=args.dataset_config,

--- a/src/sparseml/transformers/utils/__init__.py
+++ b/src/sparseml/transformers/utils/__init__.py
@@ -18,6 +18,7 @@ Utilities for applying sparsification algorithms to Hugging Face transformers fl
 
 # flake8: noqa
 from .helpers import *
+from .load_task_dataset import *
 from .metrics import *
 from .sparse_config import *
 from .sparse_model import *

--- a/src/sparseml/transformers/utils/load_task_dataset.py
+++ b/src/sparseml/transformers/utils/load_task_dataset.py
@@ -14,19 +14,25 @@
 
 from typing import Any, Dict, Optional
 
+import datasets
 from torch.nn import Module
 from transformers import AutoConfig
 
-from sparseml.transformers import SparseAutoTokenizer
 from sparseml.transformers.utils.helpers import TaskNames
 
 
-__all__ = ["load_task_dataset"]
+__all__ = ["load_task_dataset", "load_dataset"]
+
+
+def load_dataset(*args, **kwargs):
+    # a wrapper around datasets.load_dataset
+    # to be expanded in the future
+    return datasets.load_dataset(*args, **kwargs)
 
 
 def load_task_dataset(
     task: str,
-    tokenizer: SparseAutoTokenizer,
+    tokenizer: "AutoTokenizer",  # noqa F821
     data_args: Dict[str, Any],
     model: Module,
     split: Optional[str] = None,

--- a/tests/sparseml/transformers/obcq/test_obcq.py
+++ b/tests/sparseml/transformers/obcq/test_obcq.py
@@ -23,10 +23,10 @@ from sparseml.core.state import State
 from sparseml.modifiers.obcq import SparseGPTModifier
 from sparseml.modifiers.obcq.utils.helpers import ppl_eval_general
 from sparseml.pytorch.utils.helpers import tensor_sparsity
+from sparseml.transformers import apply
 from sparseml.transformers.finetune.data import TextGenerationDataset
 from sparseml.transformers.finetune.data.data_args import DataTrainingArguments
 from sparseml.transformers.finetune.data.data_helpers import format_calibration_data
-from sparseml.transformers.sparsification.obcq.obcq import one_shot
 from sparseml.transformers.sparsification.obcq.utils.helpers import llama_forward
 from sparseml.transformers.utils.helpers import resolve_sequence_length
 from sparseml.transformers.utils.initializers import (
@@ -53,7 +53,7 @@ def test_obcq_tinystories(recipe_file_path):
     config = initialize_config(model_path=tiny_model_path)
 
     # test recipe with 50% sparsity, quantization and smoothquant
-    tiny_model = one_shot(
+    tiny_model = apply(
         model_path=tiny_model_path,
         dataset_name=dataset_name,
         num_samples=num_samples,
@@ -143,7 +143,7 @@ def test_sparsities():
         device = "cpu"
 
     # test recipe with 50% sparsity, quantization and smoothquant
-    tiny_model = one_shot(
+    tiny_model = apply(
         model_path=tiny_model_path,
         dataset_name="open_platypus",
         num_samples=64,

--- a/tests/sparseml/transformers/obcq/test_repeats.py
+++ b/tests/sparseml/transformers/obcq/test_repeats.py
@@ -20,7 +20,7 @@ import yaml
 
 import sparseml.core.session as session_manager
 from sparseml.pytorch.utils.helpers import tensor_sparsity
-from sparseml.transformers.sparsification.obcq.obcq import one_shot
+from sparseml.transformers import apply
 from sparseml.utils.pytorch import qat_active
 
 
@@ -39,7 +39,7 @@ def test_consecutive_runs(tmp_path):
         device = "cpu"
 
     # test recipe with 50% sparsity, quantization and smoothquant
-    first_tiny_model = one_shot(
+    first_tiny_model = apply(
         model_path=tiny_model_path,
         dataset_name="open_platypus",
         num_samples=16,
@@ -61,7 +61,7 @@ def test_consecutive_runs(tmp_path):
     session.reset()
 
     # reload saved model and up sparsity to 0.7
-    second_tiny_model = one_shot(
+    second_tiny_model = apply(
         model_path=tmp_path / "test1" / "obcq_deployment",
         dataset_name="open_platypus",
         num_samples=16,
@@ -119,7 +119,7 @@ def test_fail_on_repeated_quant(tmp_path):
     if not torch.cuda.is_available():
         device = "cpu"
 
-    one_shot(
+    apply(
         model_path=tiny_model_path,
         dataset_name="open_platypus",
         num_samples=4,
@@ -135,7 +135,7 @@ def test_fail_on_repeated_quant(tmp_path):
     # When trying to re-quantize with the second recipe, we should error out
     # to avoid nested quantizations
     with pytest.raises(RuntimeError):
-        one_shot(
+        apply(
             model_path=tmp_path / "obcq_deployment",
             dataset_name="open_platypus",
             num_samples=4,
@@ -182,7 +182,7 @@ def test_separate_quants_allowed(tmp_path):
     if not torch.cuda.is_available():
         device = "cpu"
 
-    first_model = one_shot(
+    first_model = apply(
         model_path=tiny_model_path,
         dataset_name="open_platypus",
         num_samples=4,
@@ -202,7 +202,7 @@ def test_separate_quants_allowed(tmp_path):
 
     # When trying to re-quantize with the second recipe, we should error out
     # to avoid nested quantizations
-    second_model = one_shot(
+    second_model = apply(
         model_path=tmp_path / "obcq_deployment",
         dataset_name="open_platypus",
         num_samples=4,


### PR DESCRIPTION
- [x] Enable importing `load_dataset` function from `sparseml.transformers` (for now this will be a wrapper over `datasets.load_dataset`
- [x] Enable import `apply` function from `sparseml.transformers` (renamed from `one_shot`)

This is the fix for the ticket:
https://app.asana.com/0/1206109050183159/1206581738370606/f

```python
from sparseml.transformers import SparseAutoModelForCausalLM, SparseAutoTokenizer, load_dataset, apply
# executes without errors
```