### PR TITLE
Eval docs UI and some fixes (#2069)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include LICENSE
 recursive-include src/sparseml/yolov5 *.yaml *.sh
 recursive-include src/sparseml/yolact *.sh
 recursive-include src/sparseml/yolov8 *.yaml
+recursive-include src/sparseml/evaluation *.yaml

--- a/src/sparseml/evaluation/integrations/perplexity.py
+++ b/src/sparseml/evaluation/integrations/perplexity.py
@@ -41,8 +41,19 @@ def perplexity_eval(
     datasets: str = "wikitext",
     batch_size: int = 1,
     device: Optional[str] = None,
-    nsamples: Optional[int] = None,
+    limit: Optional[int] = None,
+    **kwargs,
 ) -> Result:
+    """
+    Perform perplexity evaluation on a language model.
+
+    :param model_path: The path to the model to evaluate
+    :param datasets: The name of the dataset to evaluate on
+    :param batch_size: The batch size to use for evaluation
+    :param device: The device to use for evaluation
+    :param limit: The number of samples to evaluate on
+    :param kwargs: Additional arguments for the evaluation
+    """
     dataset_config_name = _infer_dataset_config_name(datasets)
     task = "text-generation"
     split = "test"
@@ -53,7 +64,7 @@ def perplexity_eval(
         dataset_name=datasets,
         dataset_config_name=dataset_config_name,
         split=split,
-        nsamples=nsamples,
+        limit=limit,
     )
     add_start_token = True
     max_length = None
@@ -189,7 +200,7 @@ def _load_perplexity_dataset(
     dataset_name: str,
     dataset_config_name: str,
     split: str = "test",
-    nsamples: Optional[int] = None,
+    limit: Optional[int] = None,
 ) -> List[str]:
     """
     Loads the dataset for perplexity evaluation.
@@ -205,6 +216,6 @@ def _load_perplexity_dataset(
     for s in dataset:
         if s != "":
             inputs.append(s)
-        if nsamples is not None and len(inputs) >= nsamples:
+        if limit is not None and len(inputs) >= limit:
             break
     return inputs

--- a/src/sparseml/evaluation/integrations_config.yaml
+++ b/src/sparseml/evaluation/integrations_config.yaml
@@ -15,5 +15,9 @@
 # my_eval_integration2: integrations/my_eval_integration2.py
 
 perplexity: integrations/perplexity.py
-lm-eval-harness: integrations/lm_eval_harness.py
+lm-eval-harness: integrations/lm_evaluation_harness.py
 
+# this is a workound to allow collection via both lm-eval-harness 
+# and lm-evaluation-harness, support for aliases for collections
+# will be added in the future
+lm-evaluation-harness: integrations/lm_evaluation_harness.py 

--- a/src/sparseml/evaluation/registry.py
+++ b/src/sparseml/evaluation/registry.py
@@ -99,15 +99,11 @@ def collect_integrations(
             spec.loader.exec_module(module)
             _LOGGER.info(f"Auto collected {name} integration for eval")
         except ImportError as import_error:
-            _LOGGER.info(
-                f"Auto collection of {name} integration for eval "
-                f"failed with error: {import_error}"
-                "The integration must be registered and collected/imported "
-                "manually."
-            )
-        return
-
-    _LOGGER.debug(f"No integrations found for the given name {name}")
+            raise ImportError(
+                f"Collection of {name} integration for eval failed"
+            ) from import_error
+    else:
+        raise ValueError(f"No registered integrations found for the given name {name}")
 
 
 def _load_yaml(path: Path):

--- a/src/sparseml/transformers/utils/sparse_model.py
+++ b/src/sparseml/transformers/utils/sparse_model.py
@@ -34,7 +34,7 @@ from sparseml.pytorch.model_load.helpers import (
     log_model_load,
 )
 from sparseml.transformers.utils.helpers import resolve_recipe
-from sparsezoo import Model
+from sparseml.utils import download_zoo_training_dir
 
 
 __all__ = ["SparseAutoModel", "SparseAutoModelForCausalLM", "get_shared_tokenizer_src"]
@@ -87,9 +87,9 @@ class SparseAutoModelForCausalLM(AutoModelForCausalLM):
                 "Passed zoo stub to SparseAutoModelForCausalLM object. "
                 "Loading model from SparseZoo training files..."
             )
-            pretrained_model_name_or_path = Model(
-                pretrained_model_name_or_path
-            ).training.path
+            pretrained_model_name_or_path = download_zoo_training_dir(
+                zoo_stub=pretrained_model_name_or_path
+            )
 
         model = super(AutoModelForCausalLM, cls).from_pretrained(
             pretrained_model_name_or_path, *model_args, **kwargs

--- a/src/sparseml/utils/helpers.py
+++ b/src/sparseml/utils/helpers.py
@@ -32,6 +32,7 @@ from urllib.parse import urlparse
 
 import numpy
 
+from sparsezoo import Model
 from sparsezoo.utils import load_numpy_list
 
 
@@ -68,6 +69,7 @@ __all__ = [
     "json_to_jsonl",
     "deprecation_warning",
     "parse_kwarg_tuples",
+    "download_zoo_training_dir",
 ]
 
 
@@ -895,3 +897,26 @@ def parse_kwarg_tuples(kwargs: tuple) -> Dict:
     kwargs_names = [name.lstrip("-") for name in kwargs_names]
 
     return dict(zip(kwargs_names, kwargs_values))
+
+
+def download_zoo_training_dir(zoo_stub: str) -> str:
+    """
+    Helper function to download the training directory from a zoo stub,
+    takes care of downloading the missing files in the training
+    directory if any (This can happen if a some subset of files in the
+    training directory were downloaded before)
+
+    :param zoo_stub: The zoo stub to download the training directory from
+    :return: The path to the downloaded training directory
+    """
+    sparsezoo_model = Model(zoo_stub)
+    training_dir_path = sparsezoo_model.training.path
+
+    # download missing files if any this can happen if
+    # some subset of files in the training directory
+    # were downloaded before
+
+    for file_name in sparsezoo_model.training.files:
+        file_name.path
+
+    return training_dir_path

--- a/tests/sparseml/evaluation/test_evaluator.py
+++ b/tests/sparseml/evaluation/test_evaluator.py
@@ -14,6 +14,8 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from sparseml.evaluation.evaluator import evaluate
 from sparsezoo.evaluation.results import Result
 
@@ -37,3 +39,11 @@ def test_evaluate_calls_integration_with_correct_parameters(mocker):
     )
 
     assert isinstance(result, Result)
+
+
+def test_evaluate_raises_value_error_for_unregistered_integration():
+    with pytest.raises(ValueError, match="No registered integrations"):
+        evaluate(
+            model_path="model_path",
+            integration="foo",
+        )

--- a/tests/sparseml/test_imports.py
+++ b/tests/sparseml/test_imports.py
@@ -22,6 +22,7 @@ def test_imports():
         SparsificationInfo,
         check_version,
         detect_framework,
+        evaluate,
         execute_in_sparseml_framework,
         framework_info,
         get_main_logger,


### PR DESCRIPTION
* Better Error Message
 - Raise ImportError instead of just logging

* Raise ImportError over generic exception in lm-eval

* Raise ValueError if no integration found and not a debug log

* Add test for unregistered integrations

* Update instructions to install
- right dependencies
- and in correct order

* Add evaluate to test imports Conform lm-eval-harness to deepsparse
Add collection support for both
- lm-eval-harness -lm-evaluation-harness
Add _get_config for sparsezoo stubs

* Add support to download missing files in the training directory if any

* Add doctsrings Conform CLI to docs
Conform CLI to DeepSparse

* Remove branch name from help

* Add integrations_config.yaml to Manifest

* Address review comments from @dbogunowicz

* Use regex maybe? (#2071)