### PR TITLE
Reduce Log Clutter for Quantized Models

### DIFF
--- a/src/sparseml/transformers/utils/sparse_model.py
+++ b/src/sparseml/transformers/utils/sparse_model.py
@@ -91,9 +91,16 @@ class SparseAutoModelForCausalLM(AutoModelForCausalLM):
                 zoo_stub=pretrained_model_name_or_path
             )
 
+        # temporarily set the log level to error, to ignore printing out long missing
+        # and unexpected key error messages (these are EXPECTED for quantized models)
+        logger = logging.getLogger("transformers.modeling_utils")
+        restore_log_level = logger.getEffectiveLevel()
+        logger.setLevel(level=logging.ERROR)
         model = super(AutoModelForCausalLM, cls).from_pretrained(
             pretrained_model_name_or_path, *model_args, **kwargs
         )
+        logger.setLevel(level=restore_log_level)
+
         recipe = resolve_recipe(recipe, pretrained_model_name_or_path)
         if recipe:
             apply_recipe_structure_to_model(


### PR DESCRIPTION
Temporarily changing the log level to ERROR when loading the model, this avoids the really long printout of unexpected/missing keys when loading a quantized model before the structure has been applied

Asana ticket: https://app.asana.com/0/1206109050183159/1206513598188995/f

### Testing

```
from sparseml.transformers.utils.sparse_model import SparseAutoModelForCausalLM
model = SparseAutoModelForCausalLM.from_pretrained("zoo:llama2-7b-llama2_chat_llama2_pretrain-base_quantized", device_map="auto")
```

#### Before
```
Loading checkpoint shards: 100%|████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.11s/it]
Some weights of the model checkpoint at /home/ubuntu/.cache/sparsezoo/neuralmagic/llama2-7b-open_platypus_orca_llama2_pretrain-pruned40_quantized/training were not used when initializing LlamaForCausalLM: 

['model.layers.20.self_attn.attn_weights_matmul.left_input.quant.activation_post_process.scale', 'model.layers.16.self_attn.k_proj.quant.activation_post_process.fake_quant_enabled', 'model.layers.21.self_attn.attn_output_matmul.right_input.quant.activation_post_process.activation_post_process.eps', 'model.layers.23.self_attn.q_proj.quant.activation_post_process.zero_point', 'model.layers.26.self_attn.v_proj.quant.activation_post_process.activation_post_process.min_val', 'model.layers.16.self_attn.o_proj.quant.activation_post_process.activation_post_process.max_val', 'model.layers.29.self_attn.k_proj.module.weight_fake_quant.observer_enabled', 'model.layers.31.mlp.gate_proj.quant.activation_post_process.activation_post_process.eps', 
.....
(really long message)
Found recipe in the model_path: /home/sadkins/.cache/sparsezoo/neuralmagic/llama2-7b-llama2_chat_llama2_pretrain-base_quantized/training/recipe.yaml
```

#### After 
```
Loading checkpoint shards: 100%|████████████████████████████████████████████████| 2/2 [00:06<00:00,  3.11s/it]
Found recipe in the model_path: /home/sadkins/.cache/sparsezoo/neuralmagic/llama2-7b-llama2_chat_llama2_pretrain-base_quantized/training/recipe.yaml
```