### PR TITLE
Reset SparseSession Between Runs

### DIFF
--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -259,6 +259,7 @@ def main(
     # setup new SparseSession unless user requests otherwise
     if training_args.clear_sparse_session:
         session_manager.create_session()
+        session_manager.active_session().reset()
     session_manager.pre_initialize_structure(model=model, framework=Framework.pytorch)
 
     # Load tokenizer

--- a/src/sparseml/transformers/finetune/training_args.py
+++ b/src/sparseml/transformers/finetune/training_args.py
@@ -71,3 +71,7 @@ class TrainingArguments(HFTrainingArgs):
         default="cuda:0",
         metadata={"help": "Device to run oneshot calibration on"},
     )
+    clear_sparse_session: Optional[bool] = field(
+        default=True,
+        metadata={"help": "Whether to clear SparseSession data between runs."},
+    )

--- a/tests/sparseml/transformers/finetune/test_finetune.py
+++ b/tests/sparseml/transformers/finetune/test_finetune.py
@@ -22,7 +22,6 @@ from pathlib import Path
 import pytest
 import torch
 
-import sparseml.core.session as session_manager
 from sparseml.transformers import apply, oneshot, train
 
 
@@ -76,9 +75,6 @@ def test_oneshot_then_finetune(tmp_path: Path):
         splits=splits,
         oneshot_device=device,
     )
-
-    session = session_manager.active_session()
-    session.reset()
 
     recipe_str = "tests/sparseml/transformers/finetune/test_finetune_recipe.yaml"
     model = tmp_path / "oneshot_out"


### PR DESCRIPTION
When running sparseML commands such as `sparseml.transformers.apply/train/oneshot` in a Jupyter notebook, running multiple commands in a row would fail because the SparseSession object was persisting between runs.

To fix this we call `session_manager.create_session()` at the beginning of each run to clear data from the previous run. Also made this a cmd line arg in case the user wants the force the session to persist

### Testing 

Unit test `test_oneshot_then_finetune` previously required a session reset between sections, now that this is handled internally its no longer required.