### PR TITLE
remove column should not depend on preprocessing func

### DIFF
--- a/src/sparseml/transformers/finetune/data/custom.py
+++ b/src/sparseml/transformers/finetune/data/custom.py
@@ -47,12 +47,20 @@ class CustomDataset(TextGenerationDataset):
 
         raw_dataset: DatasetDict = super().get_raw_dataset()
 
+        if self.remove_columns is not None:
+            raw_dataset = self.map(
+                raw_dataset,
+                batched=False,
+                remove_columns=self.remove_columns,
+                num_proc=self.data_args.preprocessing_num_workers,
+                desc="Removing redandant columns",
+            )
+
         if self.preprocessing_func is not None:
             raw_dataset = self.map(
                 raw_dataset,
                 function=self.preprocessing_func,
                 batched=False,
-                remove_columns=self.remove_columns,
                 num_proc=self.data_args.preprocessing_num_workers,
                 desc="Applying custom func to the custom dataset",
             )


### PR DESCRIPTION
# Description
Helper to get an example going on colab.
Bug on remove columns, only ran if preprocessing func existed, which remove col should not depend on.

