### PR TITLE
Finetuning Fixes

### DIFF
--- a/src/sparseml/modifiers/distillation/utils/pytorch/model_wrapper.py
+++ b/src/sparseml/modifiers/distillation/utils/pytorch/model_wrapper.py
@@ -57,9 +57,10 @@ class KDModelWrapper(Module):
             self.teacher_model(*args, **kwargs)
 
         layerwise_comps = []
+        nonpadding_tokens = kwargs["attention_mask"] == 1
         for key, (student_wrapper, teacher_wrapper) in self.wrappers.items():
-            student_out = student_wrapper.kd_last_transformed
-            teacher_out = teacher_wrapper.kd_last_transformed
+            student_out = student_wrapper.kd_last_transformed[nonpadding_tokens]
+            teacher_out = teacher_wrapper.kd_last_transformed[nonpadding_tokens]
             comp = self.kd_comparison(student_out, teacher_out)
             layerwise_comps.append(comp)
 

--- a/src/sparseml/modifiers/utils/pytorch_helpers.py
+++ b/src/sparseml/modifiers/utils/pytorch_helpers.py
@@ -23,23 +23,19 @@ from tqdm import tqdm
 from sparseml.pytorch.utils import tensors_module_forward, tensors_to_device
 
 
-PADDING_MASK_COLUMN_NAME = "padding_mask"
-
 __all__ = ["apply_pad_mask_to_batch", "run_calibration_forward"]
 
 
 def apply_pad_mask_to_batch(batch: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
     """
-    Apply a mask to the input ids of a batch if one exists. This is used to zero out
+    Apply a mask to the input ids of a batch. This is used to zero out
     padding tokens so they do not contribute to the hessian calculation in the
     SparseGPT algorithm
 
     :param batch: batch to apply padding to if it exists
     :return: batch with padding zeroed out in the input_ids
     """
-    if PADDING_MASK_COLUMN_NAME in batch:
-        batch["input_ids"] = batch["input_ids"] * batch[PADDING_MASK_COLUMN_NAME]
-        batch.pop(PADDING_MASK_COLUMN_NAME)
+    batch["input_ids"] = batch["input_ids"] * batch["attention_mask"]
     return batch
 
 
@@ -86,8 +82,6 @@ def run_calibration_forward(
             break
         if mask_padding:
             batch = apply_pad_mask_to_batch(batch)
-        else:
-            batch.pop(PADDING_MASK_COLUMN_NAME, None)
         batch = tensors_to_device(batch, model_device)
         with torch.no_grad():
             forward_fn(batch, module=model)

--- a/src/sparseml/transformers/finetune/data/base.py
+++ b/src/sparseml/transformers/finetune/data/base.py
@@ -18,7 +18,6 @@ from typing import Optional, Union
 from datasets import Dataset, IterableDataset
 from transformers import AutoTokenizer
 
-from sparseml.modifiers.utils.pytorch_helpers import PADDING_MASK_COLUMN_NAME
 from sparseml.transformers.finetune.data.data_args import DataTrainingArguments
 from sparseml.transformers.finetune.data.data_helpers import (
     get_custom_datasets_from_path,
@@ -107,16 +106,12 @@ class TextGenerationDataset(RegistryMixin):
             **self.raw_kwargs,
         )
 
-    def tokenize_and_process(
-        self, raw_dataset: Dataset, store_padding_mask: bool = False
-    ) -> Dataset:
+    def tokenize_and_process(self, raw_dataset: Dataset) -> Dataset:
         """
         Sets up the raw dataset for finetuning, performs tokenization, concatenates
         entries to max sequence length if desired, and adds labels to each entry
 
         :param raw_dataset: dataset to process
-        :param store_padding_mask: when set, keep track of a padding mask for each
-        embedding in the dataset. Used for zeroing out padding during one-shot pruning.
         """
         # helper fn for tokenizing text column
         def tokenize_fn(data):
@@ -127,7 +122,9 @@ class TextGenerationDataset(RegistryMixin):
                 truncation=True,
             )
             if "prompt" in data:
-                result["prompt"] = self.tokenizer(data["prompt"], max_length=self.max_seq_length, truncation=True)["input_ids"]
+                result["prompt"] = self.tokenizer(
+                    data["prompt"], max_length=self.max_seq_length, truncation=True
+                )["input_ids"]
             return result
 
         # helper fn for filling to max_sequence_length by concatenating entries
@@ -151,20 +148,20 @@ class TextGenerationDataset(RegistryMixin):
                 prompt_len = len(data["prompt"])
             data["labels"] = data["input_ids"].copy()
             data["labels"][:prompt_len] = [-100] * prompt_len
+            padding = len(data["attention_mask"]) - sum(data["attention_mask"])
+            if padding > 0:
+                data["labels"][-padding:] = [-100] * padding
             return data
 
         dataset = self.map(
             raw_dataset,
             function=tokenize_fn,
             batched=True,
-            remove_columns=[self.text_column] if not store_padding_mask else None,
+            remove_columns=[self.text_column],
             num_proc=self.data_args.preprocessing_num_workers,
             load_from_cache_file=not self.data_args.overwrite_cache,
             desc="Running tokenizer on dataset",
         )
-
-        if store_padding_mask:
-            dataset = self.create_padding_mask(dataset)
 
         if self.data_args.concatenate_data:
             dataset = self.map(
@@ -187,40 +184,6 @@ class TextGenerationDataset(RegistryMixin):
         )
 
         return dataset
-
-    def create_padding_mask(self, raw_dataset: Dataset) -> Dataset:
-        """
-        Given a dataset, add a new column to each entry that is a mask indicating
-        whether or not that element is padding
-
-        :param raw_dataset: dataset to add padding column to
-        :return: dataset with padding column added
-        """
-        # helper fn for tokenizing text column
-        def padding_mask_fn(data):
-            result = self.tokenizer(
-                data[self.text_column],
-                padding=False,
-                max_length=self.max_seq_length,
-                truncation=True,
-            )
-            non_padded_size = len(result["input_ids"])
-            mask = [1] * non_padded_size
-            padding = [0] * (self.max_seq_length - non_padded_size)
-            data[PADDING_MASK_COLUMN_NAME] = mask + padding
-            return data
-
-        padding_mask_dataset = self.map(
-            raw_dataset,
-            function=padding_mask_fn,
-            remove_columns=[self.text_column],
-            batched=False,
-            num_proc=self.data_args.preprocessing_num_workers,
-            load_from_cache_file=not self.data_args.overwrite_cache,
-            desc="Creating padding mask",
-        )
-
-        return padding_mask_dataset
 
     def map(
         self, dataset: Union[Dataset, IterableDataset], **kwargs

--- a/src/sparseml/transformers/finetune/data/base.py
+++ b/src/sparseml/transformers/finetune/data/base.py
@@ -126,6 +126,8 @@ class TextGenerationDataset(RegistryMixin):
                 max_length=self.max_seq_length,
                 truncation=True,
             )
+            if "prompt" in data:
+                result["prompt"] = self.tokenizer(data["prompt"], max_length=self.max_seq_length, truncation=True)["input_ids"]
             return result
 
         # helper fn for filling to max_sequence_length by concatenating entries
@@ -144,7 +146,11 @@ class TextGenerationDataset(RegistryMixin):
 
         # helper fn for adding labels, needed for loss calculation
         def label_fn(data):
+            prompt_len = 0
+            if "prompt" in data:
+                prompt_len = len(data["prompt"])
             data["labels"] = data["input_ids"].copy()
+            data["labels"][:prompt_len] = [-100] * prompt_len
             return data
 
         dataset = self.map(
@@ -173,7 +179,8 @@ class TextGenerationDataset(RegistryMixin):
         dataset = self.map(
             dataset,
             function=label_fn,
-            batched=True,
+            batched=False,
+            remove_columns=["prompt"] if "prompt" in dataset.column_names else None,
             num_proc=self.data_args.preprocessing_num_workers,
             load_from_cache_file=not self.data_args.overwrite_cache,
             desc="Adding labels",

--- a/src/sparseml/transformers/finetune/data/evolcodealpaca.py
+++ b/src/sparseml/transformers/finetune/data/evolcodealpaca.py
@@ -56,6 +56,7 @@ class EvolCodeAlpacaDataset(TextGenerationDataset):
             sample["text"] = self.EVOL_ALPACA_TEMPLATE.format(
                 instruction=sample["instruction"]
             )
+            sample["prompt"] = sample["text"]
             if "output" in sample:
                 sample["text"] += sample["output"]
             return sample

--- a/src/sparseml/transformers/finetune/data/gsm8k.py
+++ b/src/sparseml/transformers/finetune/data/gsm8k.py
@@ -50,6 +50,7 @@ class GSM8KDataset(TextGenerationDataset):
         # helper fn for restructuring each dataset entry using the gsm template
         def restructure_fn(sample):
             sample["text"] = self.GSM_TEMPLATE.format(question=sample["question"])
+            sample["prompt"] = sample["text"]
             if "answer" in sample:
                 sample["text"] += " " + sample["answer"]
             return sample

--- a/src/sparseml/transformers/finetune/data/open_platypus.py
+++ b/src/sparseml/transformers/finetune/data/open_platypus.py
@@ -65,6 +65,7 @@ class OpenPlatypusDataset(TextGenerationDataset):
                     instruction=sample["instruction"]
                 )
 
+            sample["prompt"] = sample["text"]
             if "output" in sample:
                 sample["text"] += sample["output"]
             return sample

--- a/src/sparseml/transformers/finetune/runner.py
+++ b/src/sparseml/transformers/finetune/runner.py
@@ -25,7 +25,6 @@ from transformers import AutoTokenizer
 
 import sparseml.core.session as session_manager
 from sparseml.core.recipe import Recipe, StageRunType
-from sparseml.modifiers.utils.pytorch_helpers import PADDING_MASK_COLUMN_NAME
 from sparseml.pytorch.model_load.helpers import (
     get_completed_stages,
     get_session_model,
@@ -114,13 +113,8 @@ class StageRunner:
                 tokenizer=tokenizer,
             )
 
-            store_padding_mask = False
-            if self._training_args.do_oneshot and split_name == "calibration":
-                store_padding_mask = True
             raw_dataset = dataset_manager.get_raw_dataset(self._model_args.cache_dir)
-            tokenized_dataset = dataset_manager.tokenize_and_process(
-                raw_dataset, store_padding_mask=store_padding_mask
-            )
+            tokenized_dataset = dataset_manager.tokenize_and_process(raw_dataset)
             tokenized_datasets[split_name] = tokenized_dataset
 
         self.datasets = make_dataset_splits(
@@ -159,7 +153,6 @@ class StageRunner:
         # first time, calls to summon_full_params will fail ¯\_(ツ)_/¯
         dummy_inp = dict(next(iter(calib_data)))
         with torch.no_grad():
-            dummy_inp.pop(PADDING_MASK_COLUMN_NAME, None)
             self.trainer.model(**dummy_inp)
         torch.cuda.empty_cache()
 

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -310,7 +310,7 @@ class SessionManagerMixIn:
         do_log = self.state.global_step % self.args.logging_steps == 0
         if do_log:
             log = {}
-            log["step_loss"] = 0.5 * loss.item()
+            log["step_loss"] = loss.item()
             log["perplexity"] = torch.exp(loss).item()
 
         if session_manager.active_session().lifecycle.initialized_:

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -310,7 +310,7 @@ class SessionManagerMixIn:
         do_log = self.state.global_step % self.args.logging_steps == 0
         if do_log:
             log = {}
-            log["step_loss"] = loss.item()
+            log["step_loss"] = 0.5 * loss.item()
             log["perplexity"] = torch.exp(loss).item()
 
         if session_manager.active_session().lifecycle.initialized_:

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -23,12 +23,7 @@ import os
 
 import datasets
 import transformers
-from transformers import (
-    AutoConfig,
-    DataCollatorForLanguageModeling,
-    HfArgumentParser,
-    set_seed,
-)
+from transformers import AutoConfig, DefaultDataCollator, HfArgumentParser, set_seed
 
 from sparseml.core.recipe import Recipe, StageRunType
 from sparseml.pytorch.model_load.helpers import (
@@ -292,7 +287,9 @@ def main(
     calib_dataset = stage_runner.get_dataset_split("calibration")
 
     # Initialize our Trainer
-    data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+    data_collator = (
+        DefaultDataCollator()
+    )  # DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
     trainer = Trainer(
         model_init=get_session_model,
         teacher=teacher,

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -287,9 +287,7 @@ def main(
     calib_dataset = stage_runner.get_dataset_split("calibration")
 
     # Initialize our Trainer
-    data_collator = (
-        DefaultDataCollator()
-    )  # DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+    data_collator = DefaultDataCollator()
     trainer = Trainer(
         model_init=get_session_model,
         teacher=teacher,


### PR DESCRIPTION
* Only compare non-padding tokens in distillation to match with paper
* Remove padding_mask column, using attention_mask instead to simplify things
* Mask out prompt in labels to match llama-recipes implementation, all datasets that use prompts add a "prompt" column
* Use DefaultDataCollator instead of CausalLM one, otherwise HuggingFace overwrites our labels!

### Metrics on Llama7b Distillation
* Winogrande (32): 73.56%
* Arc Challenge (16): 50.09%
* TruthfulQA (32): 43.25% 
* GSM8k (16): 

Full Results: 
SparseML: https://docs.google.com/spreadsheets/d/1-AMyNT8oY1bDmtkRm3llnhNmK6FMIX7mxYlgcWC4O6c/edit#gid=2087112309
Llama Recipes: https://docs.google.com/spreadsheets/d/1qeEi9ICbu9hkwpnFReOh1jbXShj0dOGYbaFb3M2AVi4/edit#gid=0