### PR TITLE
[Missed Changes] Logger changes that were missed

### DIFF
--- a/src/sparseml/core/helpers.py
+++ b/src/sparseml/core/helpers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Any, Generator, Tuple
+from typing import Any, Generator, Optional, Tuple, Union
 
 from sparseml.core.logger import LoggerManager
 from sparseml.core.model.base import ModifiableModel
@@ -29,7 +29,8 @@ __all__ = [
 def should_log_model_info(
     model: ModifiableModel,
     loggers: LoggerManager,
-    epoch: float,
+    current_log_step: float,
+    last_log_step: Optional[float] = None,
 ) -> bool:
     """
     Check if we should log model level info
@@ -40,17 +41,20 @@ def should_log_model_info(
 
     :param model: The model whose info we want to log
     :param loggers: The logger manager to log to
-    :param epoch: The current epoch
+    :param current_log_step: The current epoch
+    :param last_log_step: The last step we logged model info at
     :return: True if we should log model level info, False otherwise
     """
     return (
         hasattr(model, "loggable_items")
         and isinstance(loggers, LoggerManager)
-        and loggers.log_ready(current_log_step=epoch)
+        and loggers.log_ready(
+            current_log_step=current_log_step, last_log_step=last_log_step
+        )
     )
 
 
-def log_model_info(state: State, epoch):
+def log_model_info(state: State, current_log_step):
     """
     Log model level info to the logger
     Relies on `state.model` having a `loggable_items` method
@@ -59,25 +63,28 @@ def log_model_info(state: State, epoch):
     `LoggerManager` instance.
 
     :param state: The current state of sparsification
-    :param epoch: The epoch number to log model info
-        at
+    :param current_log_step: The current log step to log
+        model info at
     """
-    _log_epoch(logger_manager=state.loggers, epoch=epoch)
+    _log_current_step(logger_manager=state.loggers, current_log_step=current_log_step)
     _log_model_loggable_items(
         logger_manager=state.loggers,
         loggable_items=state.model.loggable_items(),
-        epoch=epoch,
+        epoch=current_log_step,
     )
 
 
-def _log_epoch(logger_manager: LoggerManager, epoch: int):
+def _log_current_step(
+    logger_manager: LoggerManager, current_log_step: Union[float, int]
+):
     """
-    Log the epoch to the logger_manager
+    Log the Current Log Step to the logger_manager
 
     :param logger_manager: The logger manager to log to
-    :param epoch: The epoch to log
+    :param current_log_step: The logging step
     """
-    logger_manager.log_scalar(tag="Epoch", value=float(epoch), step=epoch)
+    tag = logger_manager.frequency_manager.frequency_type
+    logger_manager.log_scalar(tag=tag, value=current_log_step, step=current_log_step)
 
 
 def _log_model_loggable_items(

--- a/src/sparseml/core/helpers.py
+++ b/src/sparseml/core/helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import functools
 from typing import Any, Generator, Optional, Tuple, Union
 
 from sparseml.core.logger import LoggerManager
@@ -21,9 +22,27 @@ from sparseml.core.state import State
 
 
 __all__ = [
+    "callback_closure",
     "should_log_model_info",
     "log_model_info",
 ]
+
+
+def callback_closure(func, callback):
+    """
+    Closure to add a callback after function invocation
+
+    :param func: the function to wrap
+    :param callback: the callback to call after the function is invoked
+    """
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        return_value = func(*args, **kwargs)
+        callback()
+        return return_value
+
+    return wrapped
 
 
 def should_log_model_info(

--- a/src/sparseml/core/lifecycle/session.py
+++ b/src/sparseml/core/lifecycle/session.py
@@ -17,7 +17,7 @@ from typing import Any, List, Optional
 
 from sparseml.core.event import EventType
 from sparseml.core.framework import Framework
-from sparseml.core.helpers import log_model_info, should_log_model_info
+from sparseml.core.helpers import log_model_info_at_current_step
 from sparseml.core.lifecycle.event import CallbacksEventLifecycle, EventLifecycle
 from sparseml.core.modifier import StageModifiers
 from sparseml.core.recipe import RecipeContainer
@@ -246,14 +246,7 @@ class SparsificationLifecycle:
 
             def _optimizer_log_callback():
                 current_step = optimizer.get_current_optimizer_step()
-                if should_log_model_info(
-                    model=self.state.model,
-                    loggers=self.state.loggers,
-                    current_log_step=current_step,
-                    last_log_step=self.state._last_log_step,
-                ):
-                    log_model_info(state=self.state, current_log_step=current_step)
-                    self.state._last_log_step = current_step
+                log_model_info_at_current_step(self.state, current_step=current_step)
 
             optimizer.attach_optim_callbacks(
                 func_name="step", callback=_optimizer_log_callback
@@ -275,17 +268,7 @@ class SparsificationLifecycle:
                         steps_per_epoch=len(self.state.data.train),
                     )
                 )
-
-                if should_log_model_info(
-                    model=self.state.model,
-                    loggers=self.state.loggers,
-                    current_log_step=current_step,
-                    last_log_step=self.state._last_log_step,
-                ):
-                    log_model_info(
-                        state=self.state, current_log_step=self.state._last_log_step
-                    )
-                    self.state._last_log_step = current_step
+                log_model_info_at_current_step(self.state, current_step=current_step)
 
             model.attach_model_callback(
                 func_name="forward", callback=_model_logging_callback

--- a/src/sparseml/core/model/base.py
+++ b/src/sparseml/core/model/base.py
@@ -167,3 +167,9 @@ class ModifiableModel(Generic[MT, LT, PT], MultiFrameworkObject):
         :return: True if QAT is active in any layer, False otherwise
         """
         raise NotImplementedError()
+
+    def attach_model_callback(self, func_name: str, callback):
+        """
+        Attach callbacks to the model
+        """
+        raise NotImplementedError()

--- a/src/sparseml/core/model/pytorch.py
+++ b/src/sparseml/core/model/pytorch.py
@@ -56,12 +56,6 @@ class ModifiableModelPyTorch(ModifiableModel[Module, Module, Parameter]):
     ):
         super().__init__(framework=framework, model=model, layer_prefix=layer_prefix)
 
-    def __call__(self, *args, **kwargs):
-        """
-        Forward pass through the model
-        """
-        return self.model(*args, **kwargs)
-
     def get_layers_params(
         self, targets: Union[str, List[str]]
     ) -> Dict[str, ModelParameterizedLayer[Module, Parameter]]:

--- a/src/sparseml/core/model/pytorch.py
+++ b/src/sparseml/core/model/pytorch.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 from torch.nn import Module, Parameter
 
 from sparseml.core.framework import Framework
+from sparseml.core.helpers import callback_closure
 from sparseml.core.model.base import ModelParameterizedLayer, ModifiableModel
 from sparseml.pytorch.utils.sparsification_info.module_sparsification_info import (
     ModuleSparsificationInfo,
@@ -152,3 +153,20 @@ class ModifiableModelPyTorch(ModifiableModel[Module, Module, Parameter]):
         :return: True if QAT is active in any layer, False otherwise
         """
         return qat_active(self.model)
+
+    def attach_model_callback(self, func_name: str, callback):
+        """
+        Attach a callback to the model for the given function name
+
+        :param func_name: the name of the function to attach the callback to
+        :param callback: the callback to attach after function invocation
+        """
+        model_func = getattr(self.model, func_name, None)
+        if model_func is not None and callable(model_func):
+            setattr(
+                self.model,
+                func_name,
+                callback_closure(func=model_func, callback=callback),
+            )
+        else:
+            raise ValueError(f"model does not have function {func_name}")

--- a/src/sparseml/core/model/pytorch.py
+++ b/src/sparseml/core/model/pytorch.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 from torch.nn import Module, Parameter
 
 from sparseml.core.framework import Framework
-from sparseml.core.helpers import callback_closure
+from sparseml.core.helpers import attach_callback_to_object
 from sparseml.core.model.base import ModelParameterizedLayer, ModifiableModel
 from sparseml.pytorch.utils.sparsification_info.module_sparsification_info import (
     ModuleSparsificationInfo,
@@ -161,12 +161,9 @@ class ModifiableModelPyTorch(ModifiableModel[Module, Module, Parameter]):
         :param func_name: the name of the function to attach the callback to
         :param callback: the callback to attach after function invocation
         """
-        model_func = getattr(self.model, func_name, None)
-        if model_func is not None and callable(model_func):
-            setattr(
-                self.model,
-                func_name,
-                callback_closure(func=model_func, callback=callback),
-            )
-        else:
-            raise ValueError(f"model does not have function {func_name}")
+        attach_callback_to_object(
+            parent_object=self.model,
+            func_name=func_name,
+            callback=callback,
+            object_tag="model",
+        )

--- a/src/sparseml/core/model/pytorch.py
+++ b/src/sparseml/core/model/pytorch.py
@@ -55,6 +55,12 @@ class ModifiableModelPyTorch(ModifiableModel[Module, Module, Parameter]):
     ):
         super().__init__(framework=framework, model=model, layer_prefix=layer_prefix)
 
+    def __call__(self, *args, **kwargs):
+        """
+        Forward pass through the model
+        """
+        return self.model(*args, **kwargs)
+
     def get_layers_params(
         self, targets: Union[str, List[str]]
     ) -> Dict[str, ModelParameterizedLayer[Module, Parameter]]:

--- a/src/sparseml/core/optimizer/base.py
+++ b/src/sparseml/core/optimizer/base.py
@@ -100,14 +100,14 @@ class ModifiableOptimizer(Generic[OT, PGT], MultiFrameworkObject):
         """
         raise NotImplementedError()
 
-    def step(self, *args, **kwargs):
-        """
-        Step the optimizer
-        """
-        raise NotImplementedError()
-
     def get_current_optimizer_step(self):
         """
         Get the optimizer step
+        """
+        raise NotImplementedError()
+
+    def attach_optim_callbacks(self, func_name: str, callback):
+        """
+        Attach callbacks to the optimizer
         """
         raise NotImplementedError()

--- a/src/sparseml/core/optimizer/base.py
+++ b/src/sparseml/core/optimizer/base.py
@@ -99,3 +99,15 @@ class ModifiableOptimizer(Generic[OT, PGT], MultiFrameworkObject):
             set to None to set attribute in all groups
         """
         raise NotImplementedError()
+
+    def step(self, *args, **kwargs):
+        """
+        Step the optimizer
+        """
+        raise NotImplementedError()
+
+    def get_current_optimizer_step(self):
+        """
+        Get the optimizer step
+        """
+        raise NotImplementedError()

--- a/src/sparseml/core/optimizer/pytorch.py
+++ b/src/sparseml/core/optimizer/pytorch.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Union
 
 from torch.optim import Optimizer
 
-from sparseml.core.helpers import callback_closure
+from sparseml.core.helpers import attach_callback_to_object
 from sparseml.core.optimizer.base import ModifiableOptimizer
 
 
@@ -128,13 +128,13 @@ class ModifiableOptimizerPyTorch(ModifiableOptimizer[Optimizer, Dict[str, Any]])
     def attach_optim_callbacks(self, func_name: str, callback):
         """
         Attach the callbacks to the optimizer
+
+        :param func_name: the name of the function to attach the callback to
+        :param callback: the callback to attach
         """
-        optim_func = getattr(self.optimizer, func_name, None)
-        if optim_func is not None and callable(optim_func):
-            setattr(
-                self.optimizer,
-                func_name,
-                callback_closure(func=optim_func, callback=callback),
-            )
-        else:
-            raise ValueError(f"Optimizer does not have function {func_name}")
+        attach_callback_to_object(
+            parent_object=self.optimizer,
+            func_name=func_name,
+            callback=callback,
+            object_tag="Optimizer",
+        )

--- a/src/sparseml/core/optimizer/pytorch.py
+++ b/src/sparseml/core/optimizer/pytorch.py
@@ -116,3 +116,16 @@ class ModifiableOptimizerPyTorch(ModifiableOptimizer[Optimizer, Dict[str, Any]])
         else:
             for param_group in self.optimizer.param_groups:
                 param_group[attr_name] = value
+
+    def step(self, *args, **kwargs):
+        """
+        Perform a step of optimization for the wrapped optimizer
+        """
+        self.optimizer.step(*args, **kwargs)
+
+    def get_current_optimizer_step(self):
+        return int(
+            self.optimizer.state[self.get_param_groups()[0]["params"][-1]][
+                "step"
+            ].item()
+        )

--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -308,14 +308,18 @@ class SparseSession:
 
         epoch = self._lifecycle.event_lifecycle.current_index
 
-        if should_log_model_info(
-            model=self.state.model,
-            loggers=self.state.loggers,
-            epoch=epoch,
+        if (
+            should_log_model_info(
+                model=self.state.model,
+                loggers=self.state.loggers,
+                current_log_step=epoch,
+                last_log_step=self.state._last_log_step,
+            )
+            and self.state.loggers.frequency_manager.is_epoch_frequency_manager
         ):
             log_model_info(
                 state=self.state,
-                epoch=epoch,
+                current_log_step=epoch,
             )
             # update last log epoch
             self.state.loggers.log_written(epoch)

--- a/src/sparseml/core/state.py
+++ b/src/sparseml/core/state.py
@@ -113,7 +113,7 @@ class State:
     last_event: Event = None
     loggers: Optional[LoggerManager] = None
     model_log_cadence: Optional[float] = None
-    _last_log_epoch: Optional[float] = None
+    _last_log_step: Union[float, int, None] = None
 
     @property
     def sparsification_ready(self) -> bool:

--- a/tests/sparseml/core/lifecycle/test_session.py
+++ b/tests/sparseml/core/lifecycle/test_session.py
@@ -179,6 +179,7 @@ class TestSparsificationLifecycle:
         monkeypatch.setattr(lifecycle, "_check_create_state", _empty_mock)
         monkeypatch.setattr(lifecycle, "_check_compile_recipe", _empty_mock)
         monkeypatch.setattr(lifecycle, "state", StateMock())
+        monkeypatch.setattr(lifecycle, "_attach_logging_callbacks", _empty_mock)
 
         method = getattr(lifecycle, method_name)
         results = method()

--- a/tests/sparseml/core/test_helpers.py
+++ b/tests/sparseml/core/test_helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import defaultdict
+from types import SimpleNamespace
 
 import pytest
 
@@ -34,6 +35,11 @@ class ModelMock:
 class LoggerManagerMock:
     def __init__(self):
         self.hit_count = defaultdict(int)
+        self.frequency_manager = SimpleNamespace(
+            frequency_type="foo",
+            is_batch_frequency_manager=True,
+            is_optim_frequency_manager=True,
+        )
 
     def epoch_to_step(self, epoch, steps_per_epoch):
         self.hit_count["epoch_to_step"] += 1
@@ -80,7 +86,7 @@ def test__log_epoch_invokes_log_scalar():
     logger_manager = LoggerManagerMock()
     _log_current_step(
         logger_manager=logger_manager,
-        epoch=1,
+        current_log_step=1,
     )
     # log epoch should invoke log_string
     assert logger_manager.hit_count["log_scalar"] == 1
@@ -89,7 +95,7 @@ def test__log_epoch_invokes_log_scalar():
 def test_log_model_info_logs_epoch_and_loggable_items():
     state = StateMock()
     epoch = 3
-    log_model_info(state, epoch=epoch)
+    log_model_info(state, current_log_step=epoch)
 
     # loggable items will invoke log_scalar for each
     # int/float value + 1 for the epoch
@@ -99,7 +105,7 @@ def test_log_model_info_logs_epoch_and_loggable_items():
 @pytest.mark.parametrize(
     "loggable_items", [ModelMock().loggable_items(), [("a", {}), ("b", 2), ("c", {})]]
 )
-def test__log_model_loggable_items_routes_appropriately(loggable_items, monkeypatch):
+def test__log_model_loggable_items_routes_appropriately(loggable_items):
     logger_manager = LoggerManagerMock()
     loggable_items = list(loggable_items)
 

--- a/tests/sparseml/core/test_helpers.py
+++ b/tests/sparseml/core/test_helpers.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 import pytest
 
 from sparseml.core.event import EventType
-from sparseml.core.helpers import _log_epoch, _log_model_loggable_items, log_model_info
+from sparseml.core.helpers import _log_current_step, _log_model_loggable_items, log_model_info
 from sparseml.core.logger import LoggerManager
 
 
@@ -74,7 +74,7 @@ def state_mock():
 
 def test__log_epoch_invokes_log_scalar():
     logger_manager = LoggerManagerMock()
-    _log_epoch(
+    _log_current_step(
         logger_manager=logger_manager,
         epoch=1,
     )

--- a/tests/sparseml/core/test_helpers.py
+++ b/tests/sparseml/core/test_helpers.py
@@ -17,7 +17,11 @@ from collections import defaultdict
 import pytest
 
 from sparseml.core.event import EventType
-from sparseml.core.helpers import _log_current_step, _log_model_loggable_items, log_model_info
+from sparseml.core.helpers import (
+    _log_current_step,
+    _log_model_loggable_items,
+    log_model_info,
+)
 from sparseml.core.logger import LoggerManager
 
 


### PR DESCRIPTION
This PR includes changes from #1916 that were missed when merging into the feature branch

We already had support for epoch based logging on main
This PR adds support for 
- `batch` based logging
- `step` based logging (optim step)

Also makes this generic to different frameworks by using `MultiFrameworkObject(s)` albeit  `ModifiableModel` and `ModifiableOptimizer`


Test Script:
```python
# e2e_test.py
from sparseml.core.logger.logger import LoggerManager
import sparseml.core.session as sml
from sparseml.core.framework import Framework
import torchvision
from torchvision import transforms
import torch
from torch.utils.data import DataLoader
import datasets
import os
from torch.optim import Adam
from torch.nn import CrossEntropyLoss
from sparseml.core.event import EventType
from sparseml.core import PythonLogger
import logging

NUM_LABELS = 3
BATCH_SIZE = 32
NUM_EPOCHS = 1
LOG_FREQUENCY = 10

# "step" or "epoch" or "batch"
# "step" was used for first test
# "batch" was used for second test

FREQUENCY_TYPE = "step"

recipe = "e2e_recipe.yaml"
device = "cuda:0"

# set up SparseML session
sml.create_session()
session = sml.active_session()


# download model
model = torchvision.models.mobilenet_v2(weights=torchvision.models.MobileNet_V2_Weights.DEFAULT)
model.classifier[1] = torch.nn.Linear(model.classifier[1].in_features, NUM_LABELS)
model.to(device)


# download data
beans_dataset = datasets.load_dataset("beans", revision="ff99f4013946ad6c578bd070712b10fa0664fc9f")
train_folder, _ = os.path.split(beans_dataset["train"][0]["image_file_path"])
train_path, _ = os.path.split(train_folder)
val_folder, _ = os.path.split(beans_dataset["validation"][0]["image_file_path"])
val_path, _ = os.path.split(train_folder)


# dataloaders
imagenet_transform = transforms.Compose([
   transforms.Resize(size=256, interpolation=transforms.InterpolationMode.BILINEAR, max_size=None, antialias=None),
   transforms.CenterCrop(size=(224, 224)),
   transforms.ToTensor(),
   transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
])

train_dataset = torchvision.datasets.ImageFolder(
    root=train_path,
    transform=imagenet_transform
)
train_loader = DataLoader(train_dataset, BATCH_SIZE, shuffle=True, pin_memory=True, num_workers=16)

val_dataset = torchvision.datasets.ImageFolder(
    root=val_path,
    transform=imagenet_transform
)
val_loader = DataLoader(val_dataset, BATCH_SIZE, shuffle=False, pin_memory=True, num_workers=16)


# loss and optimizer
criterion = CrossEntropyLoss()
optimizer = Adam(model.parameters(), lr=8e-3)


recipe_args = {}
session_data = session.initialize(
    framework=Framework.pytorch,
    recipe=recipe,
    recipe_args=recipe_args,
    model=model,
    teacher_model=None,
    optimizer=optimizer,
    train_data=train_loader,
    val_data=val_loader,
    start=0.0,
    steps_per_epoch=len(train_loader),
    loggers=LoggerManager(frequency_type=FREQUENCY_TYPE, log_frequency=LOG_FREQUENCY),
)


# loop through batches
for epoch in range(NUM_EPOCHS):
    running_loss = 0.0
    total_correct = 0
    total_predictions = 0
    for step, (inputs, labels) in enumerate(session.state.data.train):
        inputs = inputs.to(device)
        labels = labels.to(device)
        session.state.optimizer.optimizer.zero_grad()
        session.event(event_type=EventType.BATCH_START, batch_data=(inputs, labels))

        outputs = session.state.model.model(inputs)
        loss = criterion(outputs, labels)
        loss.backward()
        session.event(event_type=EventType.LOSS_CALCULATED, loss=loss)

        session.event(event_type=EventType.OPTIM_PRE_STEP)
        session.state.optimizer.optimizer.step()
        session.event(event_type=EventType.OPTIM_POST_STEP)

        running_loss += loss.item()

        predictions = outputs.argmax(dim=1)
        total_correct += torch.sum(predictions == labels).item()
        total_predictions += inputs.size(0)

        session.event(event_type=EventType.BATCH_END)

    loss = running_loss / (step + 1.0)
    accuracy = total_correct / total_predictions
    print("Epoch: {} Loss: {} Accuracy: {}".format(epoch + 1, loss, accuracy))


# finalize session
session.finalize()
```

Recipe File:
```yaml
# e2e_recipe.yaml

test_stage:
  pruning_modifiers:
    MagnitudePruningModifier:
      init_sparsity: 0.0
      final_sparsity: 0.5
      start: 0
      end: 2
      update_frequency: 0.5
      targets:        
          - features.0.0.weight
          - features.1.conv.0.0.weight
          - features.1.conv.1.weight
          - features.2.conv.0.0.weight
          - features.2.conv.1.0.weight
          - features.2.conv.2.weight
          - features.3.conv.0.0.weight
          - features.3.conv.1.0.weight
          - features.3.conv.2.weight
          - features.4.conv.0.0.weight
          - features.4.conv.1.0.weight
          - features.4.conv.2.weight
          - features.5.conv.0.0.weight
          - features.5.conv.1.0.weight
          - features.5.conv.2.weight
          - features.6.conv.0.0.weight
          - features.6.conv.1.0.weight
          - features.6.conv.2.weight
          - features.7.conv.0.0.weight
          - features.7.conv.1.0.weight
          - features.7.conv.2.weight
          - features.8.conv.0.0.weight
          - features.8.conv.1.0.weight
          - features.8.conv.2.weight
          - features.9.conv.0.0.weight
          - features.9.conv.1.0.weight
          - features.9.conv.2.weight
          - features.10.conv.0.0.weight
          - features.10.conv.1.0.weight
          - features.10.conv.2.weight
          - features.11.conv.0.0.weight
          - features.11.conv.1.0.weight
          - features.11.conv.2.weight
          - features.12.conv.0.0.weight
          - features.12.conv.1.0.weight
          - features.12.conv.2.weight
          - features.13.conv.0.0.weight
          - features.13.conv.1.0.weight
          - features.13.conv.2.weight
          - features.14.conv.0.0.weight
          - features.14.conv.1.0.weight
          - features.14.conv.2.weight
          - features.15.conv.0.0.weight
          - features.15.conv.1.0.weight
          - features.15.conv.2.weight
          - features.16.conv.0.0.weight
          - features.16.conv.1.0.weight
          - features.16.conv.2.weight
          - features.17.conv.0.0.weight
          - features.17.conv.1.0.weight
          - features.17.conv.2.weight
          - features.18.0.weight
          - classifier.1.weight
      leave_enabled: True
```

Logs from Test 1 (Truncated):
```
Logging all SparseML modifier-level logs to sparse_logs/22-02-2024_20.05.40.log
manager stage: Modifiers initialized
manager step [1 - 1708650342.4466014]: 1
manager SparsificationSummaries/OperationCounts [1 - 1708650342.4768937]: {'Conv2d': 52, 'BatchNorm2d': 52, 'ReLU6': 35, 'Dropout': 1, 'Linear': 1}
manager SparsificationSummaries/ParameterCounts [1 - 1708650342.48065]: {'features.0.0.weight': 864, 'features.0.1.weight': 32, 'features.0.1.bias': 32, 'features.1.conv.0.0.weight': 288, 'features.1.conv.0.1.weight': 32, 'features.1.conv.0.1.bias': 32, 'features.1.conv.1.weight': 512, 'features.1.conv.2.weight': 16, 'features.1.conv.2.bias': 16, 'features.2.conv.0.0.weight': 1536, 'features.2.conv.0.1.weight': 96, 'features.2.conv.0.1.bias': 96, 'features.2.conv.1.0.weight': 864, 'features.2.conv.1.1.weight': 96, 'features.2.conv.1.1.bias': 96, 'features.2.conv.2.weight': 2304, 'features.2.conv.3.weight': 24, 'features.2.conv.3.bias': 24, 'features.3.conv.0.0.weight': 3456, 'features.3.conv.0.1.weight': 144, 'features.3.conv.0.1.bias': 144, 'features.3.conv.1.0.weight': 1296, 'features.3.conv.1.1.weight': 144, 'features.3.conv.1.1.bias': 144, 'features.3.conv.2.weight': 3456, 'features.3.conv.3.weight': 24, 'features.3.conv.3.bias': 24, 'features.4.conv.0.0.weight': 3456, 'features.4.conv.0.1.weight': 144, 'features.4.conv.0.1.bias': 144, 'features.4.conv.1.0.weight': 1296, 'features.4.conv.1.1.weight': 144, 'features.4.conv.1.1.bias': 144, 'features.4.conv.2.weight': 4608, 'features.4.conv.3.weight': 32, 'features.4.conv.3.bias': 32, 'features.5.conv.0.0.weight': 6144, 'features.5.conv.0.1.weight': 192, 'features.5.conv.0.1.bias': 192, 'features.5.conv.1.0.weight': 1728, 'features.5.conv.1.1.weight': 192, 'features.5.conv.1.1.bias': 192, 'features.5.conv.2.weight': 6144, 'features.5.conv.3.weight': 32, 'features.5.conv.3.bias': 32, 'features.6.conv.0.0.weight': 6144, 'features.6.conv.0.1.weight': 192, 'features.6.conv.0.1.bias': 192, 'features.6.conv.1.0.weight': 1728, 'features.6.conv.1.1.weight': 192, 'features.6.conv.1.1.bias': 192, 'features.6.conv.2.weight': 6144, 'features.6.conv.3.weight': 32, 'features.6.conv.3.bias': 32, 'features.7.conv.0.0.weight': 6144, 'features.7.conv.0.1.weight': 192, 'features.7.conv.0.1.bias': 192, 'features.7.conv.1.0.weight': 1728, 'features.7.conv.1.1.weight': 192, 'features.7.conv.1.1.bias': 192, 'features.7.conv.2.weight': 12288, 'features.7.conv.3.weight': 64, 'features.7.conv.3.bias': 64, 'features.8.conv.0.0.weight': 24576, 'features.8.conv.0.1.weight': 384, 'features.8.conv.0.1.bias': 384, 'features.8.conv.1.0.weight': 3456, 'features.8.conv.1.1.weight': 384, 'features.8.conv.1.1.bias': 384, 'features.8.conv.2.weight': 24576, 'features.8.conv.3.weight': 64, 'features.8.conv.3.bias': 64, 'features.9.conv.0.0.weight': 24576, 'features.9.conv.0.1.weight': 384, 'features.9.conv.0.1.bias': 384, 'features.9.conv.1.0.weight': 3456, 'features.9.conv.1.1.weight': 384, 'features.9.conv.1.1.bias': 384, 'features.9.conv.2.weight': 24576, 'features.9.conv.3.weight': 64, 'features.9.conv.3.bias': 64, 'features.10.conv.0.0.weight': 24576, 'features.10.conv.0.1.weight': 384, 'features.10.conv.0.1.bias': 384, 'features.10.conv.1.0.weight': 3456, 'features.10.conv.1.1.weight': 384, 'features.10.conv.1.1.bias': 384, 'features.10.conv.2.weight': 24576, 'features.10.conv.3.weight': 64, 'features.10.conv.3.bias': 64, 'features.11.conv.0.0.weight': 24576, 'features.11.conv.0.1.weight': 384, 'features.11.conv.0.1.bias': 384, 'features.11.conv.1.0.weight': 3456, 'features.11.conv.1.1.weight': 384, 'features.11.conv.1.1.bias': 384, 'features.11.conv.2.weight': 36864, 'features.11.conv.3.weight': 96, 'features.11.conv.3.bias': 96, 'features.12.conv.0.0.weight': 55296, 'features.12.conv.0.1.weight': 576, 'features.12.conv.0.1.bias': 576, 'features.12.conv.1.0.weight': 5184, 'features.12.conv.1.1.weight': 576, 'features.12.conv.1.1.bias': 576, 'features.12.conv.2.weight': 55296, 'features.12.conv.3.weight': 96, 'features.12.conv.3.bias': 96, 'features.13.conv.0.0.weight': 55296, 'features.13.conv.0.1.weight': 576, 'features.13.conv.0.1.bias': 576, 'features.13.conv.1.0.weight': 5184, 'features.13.conv.1.1.weight': 576, 'features.13.conv.1.1.bias': 576, 'features.13.conv.2.weight': 55296, 'features.13.conv.3.weight': 96, 'features.13.conv.3.bias': 96, 'features.14.conv.0.0.weight': 55296, 'features.14.conv.0.1.weight': 576, 'features.14.conv.0.1.bias': 576, 'features.14.conv.1.0.weight': 5184, 'features.14.conv.1.1.weight': 576, 'features.14.conv.1.1.bias': 576, 'features.14.conv.2.weight': 92160, 'features.14.conv.3.weight': 160, 'features.14.conv.3.bias': 160, 'features.15.conv.0.0.weight': 153600, 'features.15.conv.0.1.weight': 960, 'features.15.conv.0.1.bias': 960, 'features.15.conv.1.0.weight': 8640, 'features.15.conv.1.1.weight': 960, 'features.15.conv.1.1.bias': 960, 'features.15.conv.2.weight': 153600, 'features.15.conv.3.weight': 160, 'features.15.conv.3.bias': 160, 'features.16.conv.0.0.weight': 153600, 'features.16.conv.0.1.weight': 960, 'features.16.conv.0.1.bias': 960, 'features.16.conv.1.0.weight': 8640, 'features.16.conv.1.1.weight': 960, 'features.16.conv.1.1.bias': 960, 'features.16.conv.2.weight': 153600, 'features.16.conv.3.weight': 160, 'features.16.conv.3.bias': 160, 'features.17.conv.0.0.weight': 153600, 'features.17.conv.0.1.weight': 960, 'features.17.conv.0.1.bias': 960, 'features.17.conv.1.0.weight': 8640, 'features.17.conv.1.1.weight': 960, 'features.17.conv.1.1.bias': 960, 'features.17.conv.2.weight': 307200, 'features.17.conv.3.weight': 320, 'features.17.conv.3.bias': 320, 'features.18.0.weight': 409600, 'features.18.1.weight': 1280, 'features.18.1.bias': 1280, 'classifier.1.weight': 3840, 'classifier.1.bias': 3}
manager step [11 - 1708650343.1918993]: 11
manager SparsificationSummaries/OperationCounts [11 - 1708650343.2306745]: {'Conv2d': 52, 'BatchNorm2d': 52, 'ReLU6': 35, 'Dropout': 1, 'Linear': 1}
manager SparsificationSummaries/ParameterCounts [11 - 1708650343.231175]: {'features.0.0.weight': 864, 'features.0.1.weight': 32, 'features.0.1.bias': 32, 'features.1.conv.0.0.weight': 288, 'features.1.conv.0.1.weight': 32, 
.
.
.
```


Logs from second Test using batch freq type (Truncated):
```
Logging all SparseML modifier-level logs to sparse_logs/22-02-2024_20.09.20.log
manager stage: Modifiers initialized
manager batch [0 - 1708650562.82444]: 0
manager SparsificationSummaries/OperationCounts [0 - 1708650562.84949]: {'Conv2d': 52, 'BatchNorm2d': 52, 'ReLU6': 35, 'Dropout': 1, 'Linear': 1}
manager SparsificationSummaries/ParameterCounts [0 - 1708650562.8500898]: {'features.0.0.weight': 864, 'features.0.1.weight': 32, 'features.0.1.bias': 32, 'features.1.conv.0.0.weight': 288, 'features.1.conv.0.1.weight': 32, 'features.1.conv.0.1.bias': 32, 'features.1.conv.1.weight': 512, 'features.1.conv.2.weight': 16, 'features.1.conv.2.bias': 16, 'features.2.conv.0.0.weight': 1536, 'features.2.conv.0.1.weight': 96, 'features.2.conv.0.1.bias': 96, 'features.2.conv.1.0.weight': 864, 'features.2.conv.1.1.weight': 96, 'features.2.conv.1.1.bias': 96, 'features.2.conv.2.weight': 2304, 'features.2.conv.3.weight': 24, 'features.2.conv.3.bias': 24, 'features.3.conv.0.0.weight': 3456, 'features.3.conv.0.1.weight': 144, 'features.3.conv.0.1.bias': 144, 'features.3.conv.1.0.weight': 1296, 'features.3.conv.1.1.weight': 144, 'features.3.conv.1.1.bias': 144, 'features.3.conv.2.weight': 3456, 'features.3.conv.3.weight': 24, 'features.3.conv.3.bias': 24, 'features.4.conv.0.0.weight': 3456, 'features.4.conv.0.1.weight': 144, 'features.4.conv.0.1.bias': 144, 'features.4.conv.1.0.weight': 1296, 'features.4.conv.1.1.weight': 144, 'features.4.conv.1.1.bias': 144, 'features.4.conv.2.weight': 4608, 'features.4.conv.3.weight': 32, 'features.4.conv.3.bias': 32, 'features.5.conv.0.0.weight': 6144, 'features.5.conv.0.1.weight': 192, 'features.5.conv.0.1.bias': 192, 'features.5.conv.1.0.weight': 1728, 'features.5.conv.1.1.weight': 192, 'features.5.conv.1.1.bias': 192, 'features.5.conv.2.weight': 6144, 'features.5.conv.3.weight': 32, 'features.5.conv.3.bias': 32, 'features.6.conv.0.0.weight': 6144, 'features.6.conv.0.1.weight': 192, 'features.6.conv.0.1.bias': 192, 'features.6.conv.1.0.weight': 1728, 'features.6.conv.1.1.weight': 192, 'features.6.conv.1.1.bias': 192, 'features.6.conv.2.weight': 6144, 'features.6.conv.3.weight': 32, 'features.6.conv.3.bias': 32, 'features.7.conv.0.0.weight': 6144, 'features.7.conv.0.1.weight': 192, 'features.7.conv.0.1.bias': 192, 'features.7.conv.1.0.weight': 1728, 'features.7.conv.1.1.weight': 192, 'features.7.conv.1.1.bias': 192, 'features.7.conv.2.weight': 12288, 'features.7.conv.3.weight': 64, 'features.7.conv.3.bias': 64, 'features.8.conv.0.0.weight': 24576, 'features.8.conv.0.1.weight': 384, 'features.8.conv.0.1.bias': 384, 'features.8.conv.1.0.weight': 3456, 'features.8.conv.1.1.weight': 384, 'features.8.conv.1.1.bias': 384, 'features.8.conv.2.weight': 24576, 'features.8.conv.3.weight': 64, 'features.8.conv.3.bias': 64, 'features.9.conv.0.0.weight': 24576, 'features.9.conv.0.1.weight': 384, 'features.9.conv.0.1.bias': 384, 'features.9.conv.1.0.weight': 3456, 'features.9.conv.1.1.weight': 384, 'features.9.conv.1.1.bias': 384, 'features.9.conv.2.weight': 24576, 'features.9.conv.3.weight': 64, 'features.9.conv.3.bias': 64, 'features.10.conv.0.0.weight': 24576, 'features.10.conv.0.1.weight': 384, 'features.10.conv.0.1.bias': 384, 'features.10.conv.1.0.weight': 3456, 'features.10.conv.1.1.weight': 384, 'features.10.conv.1.1.bias': 384, 'features.10.conv.2.weight': 24576, 'features.10.conv.3.weight': 64, 'features.10.conv.3.bias': 64, 'features.11.conv.0.0.weight': 24576, 'features.11.conv.0.1.weight': 384, 'features.11.conv.0.1.bias': 384, 'features.11.conv.1.0.weight': 3456, 'features.11.conv.1.1.weight': 384, 'features.11.conv.1.1.bias': 384, 'features.11.conv.2.weight': 36864, 'features.11.conv.3.weight': 96, 'features.11.conv.3.bias': 96, 'features.12.conv.0.0.weight': 55296, 'features.12.conv.0.1.weight': 576, 'features.12.conv.0.1.bias': 576, 'features.12.conv.1.0.weight': 5184, 'features.12.conv.1.1.weight': 576, 'features.12.conv.1.1.bias': 576, 'features.12.conv.2.weight': 55296, 'features.12.conv.3.weight': 96, 'features.12.conv.3.bias': 96, 'features.13.conv.0.0.weight': 55296, 'features.13.conv.0.1.weight': 576, 'features.13.conv.0.1.bias': 576, 'features.13.conv.1.0.weight': 5184, 'features.13.conv.1.1.weight': 576, 'features.13.conv.1.1.bias': 576, 'features.13.conv.2.weight': 55296, 'features.13.conv.3.weight': 96, 'features.13.conv.3.bias': 96, 'features.14.conv.0.0.weight': 55296, 'features.14.conv.0.1.weight': 576, 'features.14.conv.0.1.bias': 576, 'features.14.conv.1.0.weight': 5184, 'features.14.conv.1.1.weight': 576, 'features.14.conv.1.1.bias': 576, 'features.14.conv.2.weight': 92160, 'features.14.conv.3.weight': 160, 'features.14.conv.3.bias': 160, 'features.15.conv.0.0.weight': 153600, 'features.15.conv.0.1.weight': 960, 'features.15.conv.0.1.bias': 960, 'features.15.conv.1.0.weight': 8640, 'features.15.conv.1.1.weight': 960, 'features.15.conv.1.1.bias': 960, 'features.15.conv.2.weight': 153600, 'features.15.conv.3.weight': 160, 'features.15.conv.3.bias': 160, 'features.16.conv.0.0.weight': 153600, 'features.16.conv.0.1.weight': 960, 'features.16.conv.0.1.bias': 960, 'features.16.conv.1.0.weight': 8640, 'features.16.conv.1.1.weight': 960, 'features.16.conv.1.1.bias': 960, 'features.16.conv.2.weight': 153600, 'features.16.conv.3.weight': 160, 'features.16.conv.3.bias': 160, 'features.17.conv.0.0.weight': 153600, 'features.17.conv.0.1.weight': 960, 'features.17.conv.0.1.bias': 960, 'features.17.conv.1.0.weight': 8640, 'features.17.conv.1.1.weight': 960, 'features.17.conv.1.1.bias': 960, 'features.17.conv.2.weight': 307200, 'features.17.conv.3.weight': 320, 'features.17.conv.3.bias': 320, 'features.18.0.weight': 409600, 'features.18.1.weight': 1280, 'features.18.1.bias': 1280, 'classifier.1.weight': 3840, 'classifier.1.bias': 3}
manager SparsificationSummaries/PrunedParameters/percent [0 - 1708650562.868342]: 0.33544303797468356
manager SparsificationPruning/SparseParameters/features.0.0.weight/percent [0 - 1708650562.8737245]: 0.17708333333333334
.
.
.
manager batch [10 - 1708650563.44318]: 10
manager SparsificationSummaries/OperationCounts [10 - 1708650563.4674299]: {'Conv2d': 52, 'BatchNorm2d': 52, 'ReLU6': 35, 'Dropout': 1, 'Linear': 1}
manager SparsificationSummaries/ParameterCounts [10 - 1708650563.467873]: {'features.0.0.weight': 864, 'features.0.1.weight': 32, 'features.0.1.bias': 32, 'features.1.conv.0.0.weight': 288, 'features.1.conv.0.1.weight': 32, 'features.1.conv.0.1.bias': 32, 'features.1.conv.1.weight': 512, 'features.1.conv.2.weight': 16, 'features.1.conv.2.bias': 16, 'features.2.conv.0.0.weight': 1536, 'features.2.conv.0.1.weight': 96, 'features.2.conv.0.1.bias': 96, 'features.2.conv.1.0.weight': 864, 'features.2.conv.1.1.weight': 96, 'features.2.conv.1.1.bias': 96, 'features.2.conv.2.weight': 2304, 'features.2.conv.3.weight': 24, 'features.2.conv.3.bias': 24, 'features.3.conv.0.0.weight': 3456, 'features.3.conv.0.1.weight': 144, 'features.3.conv.0.1.bias': 144, 'features.3.conv.1.0.weight': 1296, 'features.3.conv.1.1.weight': 144, 'features.3.conv.1.1.bias': 144, 'features.3.conv.2.weight': 3456, 'features.3.conv.3.weight': 24, 'features.3.conv.3.bias': 24, 'features.4.conv.0.0.weight': 3456, 'features.4.conv.0.1.weight': 144, 'features.4.conv.0.1.bias': 144, 'features.4.conv.1.0.weight': 1296, 'features.4.conv.1.1.weight': 144, 'features.4.conv.1.1.bias': 144, 'features.4.conv.2.weight': 4608, 'features.4.conv.3.weight': 32, 'features.4.conv.3.bias': 32, 'features.5.conv.0.0.weight': 6144, 'features.5.conv.0.1.weight': 192, 'features.5.conv.0.1.bias': 192, 'features.5.conv.1.0.weight': 1728, 'features.5.conv.1.1.weight': 192, 'features.5.conv.1.1.bias': 192, 'features.5.conv.2.weight': 6144, 'features.5.conv.3.weight': 32, 'features.5.conv.3.bias': 32, 'features.6.conv.0.0.weight': 6144, 'features.6.conv.0.1.weight': 192, 'features.6.conv.0.1.bias': 192, 'features.6.conv.1.0.weight': 1728, 'features.6.conv.1.1.weight': 192, 'features.6.conv.1.1.bias': 192, 'features.6.conv.2.weight': 6144, 'features.6.conv.3.weight': 32, 'features.6.conv.3.bias': 32, 'features.7.conv.0.0.weight': 6144, 'features.7.conv.0.1.weight': 192, 'features.7.conv.0.1.bias': 192, 'features.7.conv.1.0.weight': 1728, 'features.7.conv.1.1.weight': 192, 'features.7.conv.1.1.bias': 192, 'features.7.conv.2.weight': 12288, 'features.7.conv.3.weight': 64, 'features.7.conv.3.bias': 64, 'features.8.conv.0.0.weight': 24576, 'features.8.conv.0.1.weight': 384, 'features.8.conv.0.1.bias': 384, 'features.8.conv.1.0.weight': 3456, 'features.8.conv.1.1.weight': 384, 'features.8.conv.1.1.bias': 384, 'features.8.conv.2.weight': 24576, 'features.8.conv.3.weight': 64, 'features.8.conv.3.bias': 64, 'features.9.conv.0.0.weight': 24576, 'features.9.conv.0.1.weight': 384, 'features.9.conv.0.1.bias': 384, 'features.9.conv.1.0.weight': 3456, 'features.9.conv.1.1.weight': 384, 'features.9.conv.1.1.bias': 384, 'features.9.conv.2.weight': 24576, 'features.9.conv.3.weight': 64, 'features.9.conv.3.bias': 64, 'features.10.conv.0.0.weight': 24576, 'features.10.conv.0.1.weight': 384, 'features.10.conv.0.1.bias': 384, 'features.10.conv.1.0.weight': 3456, 'features.10.conv.1.1.weight': 384, 'features.10.conv.1.1.bias': 384, 'features.10.conv.2.weight': 24576, 'features.10.conv.3.weight': 64, 'features.10.conv.3.bias': 64, 'features.11.conv.0.0.weight': 24576, 'features.11.conv.0.1.weight': 384, 'features.11.conv.0.1.bias': 384, 'features.11.conv.1.0.weight': 3456, 'features.11.conv.1.1.weight': 384, 'features.11.conv.1.1.bias': 384, 'features.11.conv.2.weight': 36864, 'features.11.conv.3.weight': 96, 'features.11.conv.3.bias': 96, 'features.12.conv.0.0.weight': 55296, 'features.12.conv.0.1.weight': 576, 'features.12.conv.0.1.bias': 576, 'features.12.conv.1.0.weight': 5184, 'features.12.conv.1.1.weight': 576, 'features.12.conv.1.1.bias': 576, 'features.12.conv.2.weight': 55296, 'features.12.conv.3.weight': 96, 'features.12.conv.3.bias': 96, 'features.13.conv.0.0.weight': 55296, 'features.13.conv.0.1.weight': 576, 'features.13.conv.0.1.bias': 576, 'features.13.conv.1.0.weight': 5184, 'features.13.conv.1.1.weight': 576, 'features.13.conv.1.1.bias': 576, 'features.13.conv.2.weight': 55296, 'features.13.conv.3.weight': 96, 'features.13.conv.3.bias': 96, 'features.14.conv.0.0.weight': 55296, 'features.14.conv.0.1.weight': 576, 'features.14.conv.0.1.bias': 576, 'features.14.conv.1.0.weight': 5184, 'features.14.conv.1.1.weight': 576, 'features.14.conv.1.1.bias': 576, 'features.14.conv.2.weight': 92160, 'features.14.conv.3.weight': 160, 'features.14.conv.3.bias': 160, 'features.15.conv.0.0.weight': 153600, 'features.15.conv.0.1.weight': 960, 'features.15.conv.0.1.bias': 960, 'features.15.conv.1.0.weight': 8640, 'features.15.conv.1.1.weight': 960, 'features.15.conv.1.1.bias': 960, 'features.15.conv.2.weight': 153600, 'features.15.conv.3.weight': 160, 'features.15.conv.3.bias': 160, 'features.16.conv.0.0.weight': 153600, 'features.16.conv.0.1.weight': 960, 'features.16.conv.0.1.bias': 960, 'features.16.conv.1.0.weight': 8640, 'features.16.conv.1.1.weight': 960, 'features.16.conv.1.1.bias': 960, 'features.16.conv.2.weight': 153600, 'features.16.conv.3.weight': 160, 'features.16.conv.3.bias': 160, 'features.17.conv.0.0.weight': 153600, 'features.17.conv.0.1.weight': 960, 'features.17.conv.0.1.bias': 960, 'features.17.conv.1.0.weight': 8640, 'features.17.conv.1.1.weight': 960, 'features.17.conv.1.1.bias': 960, 'features.17.conv.2.weight': 307200, 'features.17.conv.3.weight': 320, 'features.17.conv.3.bias': 320, 'features.18.0.weight': 409600, 'features.18.1.weight': 1280, 'features.18.1.bias': 1280, 'classifier.1.weight': 3840, 'classifier.1.bias': 3}
manager SparsificationSummaries/PrunedParameters/percent [10 - 1708650563.4817266]: 0.33544303797468356
.
.
.
```

Complete log files have also been attached with this PR

- [22-02-2024_20.05.40.log](https://github.com/neuralmagic/sparseml/files/14380765/22-02-2024_20.05.40.log)
- [22-02-2024_20.09.20.log](https://github.com/neuralmagic/sparseml/files/14380767/22-02-2024_20.09.20.log)