### PR TITLE
[Update] better error message for sparseml evaluate

### DIFF
--- a/src/sparseml/evaluation/registry.py
+++ b/src/sparseml/evaluation/registry.py
@@ -99,9 +99,8 @@ def collect_integrations(
             spec.loader.exec_module(module)
             _LOGGER.info(f"Auto collected {name} integration for eval")
         except ImportError as import_error:
-            raise ImportError(
-                f"Collection of {name} integration for eval failed"
-            ) from import_error
+            _LOGGER.warning(f"Collection of {name} integration for eval failed")
+            raise import_error
     else:
         raise ValueError(f"No registered integrations found for the given name {name}")
 


### PR DESCRIPTION
# Better Error Message

Before this PR the error messages for `sparseml.evaluate` were somewhat obscure, the user had to scroll through the error message to find the missing package error.

```bash
$ sparseml.evaluate \                                                                                     (update-lm-eval-to-0.4.1↑1|…3⚑5)
    "mgoin/llama2.c-stories15M-quant-pt" \
    --dataset hellaswag \
    --integration lm-evaluation-harness \
    --limit 1 # for a quicker test
2024-02-23 15:42:47 sparseml.evaluation.cli INFO     Datasets to evaluate on: hellaswag
Batch size: 1
Additional integration arguments supplied: {}
2024-02-23 15:42:47 sparseml.evaluation.registry WARNING  Collection of lm-evaluation-harness integration for eval failed
Traceback (most recent call last):
  File "/home/rahul/projects/sparseml/src/sparseml/evaluation/integrations/lm_evaluation_harness.py", line 23, in <module>
    from lm_eval import evaluator, tasks, utils
ModuleNotFoundError: No module named 'lm_eval'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/rahul/venvs/sparseml-venv/bin/sparseml.evaluate", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/rahul/venvs/sparseml-venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/venvs/sparseml-venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/rahul/venvs/sparseml-venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/venvs/sparseml-venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/projects/sparseml/src/sparseml/evaluation/cli.py", line 154, in main
    result: Result = evaluate(
                     ^^^^^^^^^
  File "/home/rahul/projects/sparseml/src/sparseml/evaluation/evaluator.py", line 47, in evaluate
    eval_integration = SparseMLEvaluationRegistry.resolve(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rahul/projects/sparseml/src/sparseml/evaluation/registry.py", line 53, in resolve
    collect_integrations(
  File "/home/rahul/projects/sparseml/src/sparseml/evaluation/registry.py", line 103, in collect_integrations
    raise import_error
  File "/home/rahul/projects/sparseml/src/sparseml/evaluation/registry.py", line 99, in collect_integrations
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/rahul/projects/sparseml/src/sparseml/evaluation/integrations/lm_evaluation_harness.py", line 27, in <module>
    raise ImportError(
ImportError: package `lm_eval` not found. Please install it via `pip install lm-eval==0.4.1;pip uninstall transformers && pip install sparseml[transformers,torch]`

```

The shown error messages were displayed on top of #2110 but that is not required for this diff to be merged in