### PR TITLE
[Logger] Preliminary changes that were missed

### DIFF
--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -638,7 +638,8 @@ class WANDBLogger(LambdaLogger):
                 values = {f"{tag}/{key}": val for key, val in values.items()}
             params.update(values)
 
-        # wandb.log(params, step=step)
+        params.update({"Step": step})
+        wandb.log(params)
 
         return True
 

--- a/src/sparseml/core/logger/utils/frequency_manager.py
+++ b/src/sparseml/core/logger/utils/frequency_manager.py
@@ -26,7 +26,10 @@ __all__ = [
 
 LogStepType = Union[int, float, None]
 LoggingModeType = Literal["on_change", "exact"]
-FrequencyType = Literal["epoch", "step", "batch"]
+FrequencyType = Literal["epoch", "step"]
+
+DEFAULT_FREQUENCY_TYPE = "epoch"
+DEFAULT_LOGGING_MODE = "exact"
 
 
 class FrequencyManager:
@@ -47,14 +50,14 @@ class FrequencyManager:
     def __init__(
         self,
         log_frequency: LogStepType = None,
-        mode: LoggingModeType = "exact",
-        frequency_type: FrequencyType = "epoch",
+        mode: LoggingModeType = DEFAULT_LOGGING_MODE,
+        frequency_type: FrequencyType = DEFAULT_FREQUENCY_TYPE,
     ):
         # sets self._logging_mode and self._check_model_update
         self._logging_mode = self._set_logging_mode(mode=mode)
 
         # sets self._frequency_type and self._valid_python_types
-        self._frequency_type = self._set_frequency_type(frequency_type=frequency_type)
+        self.frequency_type = self._set_frequency_type(frequency_type=frequency_type)
 
         self._validate_log_frequency(log_frequency=log_frequency)
         self._log_frequency = log_frequency
@@ -65,7 +68,7 @@ class FrequencyManager:
     def __repr__(self):
         return (
             f"{self.__class__.__name__}(log_frequency={self.log_frequency}, "
-            f"mode={self._logging_mode}, frequency_type={self._frequency_type})"
+            f"mode={self._logging_mode}, frequency_type={self.frequency_type})"
         )
 
     def log_ready(
@@ -144,6 +147,22 @@ class FrequencyManager:
         self._validate_log_frequency(log_frequency=log_frequency)
         self._log_frequency = log_frequency
 
+    @property
+    def is_optim_frequency_manager(self) -> bool:
+        """
+        :return: True if the frequency manager is tracking optimizer steps,
+            False otherwise
+        """
+        return self.frequency_type == "step"
+
+    @property
+    def is_epoch_frequency_manager(self) -> bool:
+        """
+        :return: True if the frequency manager is tracking epochs,
+            False otherwise
+        """
+        return self.frequency_type == "epoch"
+
     def _validate_log_frequency(self, log_frequency):
         # checks that log frequency is a positive number or None
         # raise TypeError if not a number or None
@@ -219,25 +238,25 @@ class FrequencyManager:
             for the given frequency type, e.g. (int, float, type(None)) for "epoch"
             and (int, type(None)) for "step" or "batch"
         :raises ValueError: If the given frequency type is not one of "epoch",
-            "step", or "batch"
+            "step"
+        :raises NotImplementedError: If the given frequency type is "batch"
         :return: The frequency type that was set
         """
         frequency_type = _basic_normalization(frequency_type)
         if frequency_type == "epoch":
-            self._frequency_type = "epoch"
+            self.frequency_type = "epoch"
             self._valid_python_types = (int, float, type(None))
         elif frequency_type == "step":
-            self._frequency_type = "step"
+            self.frequency_type = "step"
             self._valid_python_types = (int, type(None))
         elif frequency_type == "batch":
-            self._frequency_type = "batch"
-            self._valid_python_types = (int, type(None))
+            raise NotImplementedError
         else:
             raise ValueError(
                 f"Invalid frequency type {frequency_type}, must be one of "
-                "'epoch', 'step', 'batch'"
+                "'epoch', 'step'"
             )
-        return self._frequency_type
+        return self.frequency_type
 
 
 def log_ready(

--- a/src/sparseml/core/optimizer/base.py
+++ b/src/sparseml/core/optimizer/base.py
@@ -99,3 +99,9 @@ class ModifiableOptimizer(Generic[OT, PGT], MultiFrameworkObject):
             set to None to set attribute in all groups
         """
         raise NotImplementedError()
+
+    def attach_optim_callbacks(self, func_name: str, callback):
+        """
+        Attach callbacks to the optimizer
+        """
+        raise NotImplementedError()

--- a/src/sparseml/core/optimizer/pytorch.py
+++ b/src/sparseml/core/optimizer/pytorch.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Union
 
 from torch.optim import Optimizer
 
+from sparseml.core.helpers import attach_callback_to_object
 from sparseml.core.optimizer.base import ModifiableOptimizer
 
 
@@ -116,3 +117,17 @@ class ModifiableOptimizerPyTorch(ModifiableOptimizer[Optimizer, Dict[str, Any]])
         else:
             for param_group in self.optimizer.param_groups:
                 param_group[attr_name] = value
+
+    def attach_optim_callbacks(self, func_name: str, callback):
+        """
+        Attach the callbacks to the optimizer
+
+        :param func_name: the name of the function to attach the callback to
+        :param callback: the callback to attach
+        """
+        attach_callback_to_object(
+            parent_object=self.optimizer,
+            func_name=func_name,
+            callback=callback,
+            object_tag="Optimizer",
+        )

--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -22,7 +22,6 @@ from sparseml.core.framework import Framework
 from sparseml.core.helpers import log_model_info, should_log_model_info
 from sparseml.core.lifecycle import SparsificationLifecycle
 from sparseml.core.logger import BaseLogger, LoggerManager
-from sparseml.core.logger.utils import log_ready
 from sparseml.core.recipe import Recipe
 from sparseml.core.state import ModifiedState, State
 

--- a/src/sparseml/core/state.py
+++ b/src/sparseml/core/state.py
@@ -113,7 +113,7 @@ class State:
     last_event: Event = None
     loggers: Optional[LoggerManager] = None
     model_log_cadence: Optional[float] = None
-    _last_log_epoch: Optional[float] = None
+    _last_log_step: Union[float, int, None] = None
 
     @property
     def sparsification_ready(self) -> bool:

--- a/tests/sparseml/core/lifecycle/test_session.py
+++ b/tests/sparseml/core/lifecycle/test_session.py
@@ -179,6 +179,7 @@ class TestSparsificationLifecycle:
         monkeypatch.setattr(lifecycle, "_check_create_state", _empty_mock)
         monkeypatch.setattr(lifecycle, "_check_compile_recipe", _empty_mock)
         monkeypatch.setattr(lifecycle, "state", StateMock())
+        monkeypatch.setattr(lifecycle, "_attach_logging_callbacks", _empty_mock)
 
         method = getattr(lifecycle, method_name)
         results = method()

--- a/tests/sparseml/core/test_helpers.py
+++ b/tests/sparseml/core/test_helpers.py
@@ -13,11 +13,16 @@
 # limitations under the License.
 
 from collections import defaultdict
+from types import SimpleNamespace
 
 import pytest
 
 from sparseml.core.event import EventType
-from sparseml.core.helpers import _log_epoch, _log_model_loggable_items, log_model_info
+from sparseml.core.helpers import (
+    _log_current_step,
+    _log_model_loggable_items,
+    log_model_info,
+)
 from sparseml.core.logger import LoggerManager
 
 
@@ -30,6 +35,11 @@ class ModelMock:
 class LoggerManagerMock:
     def __init__(self):
         self.hit_count = defaultdict(int)
+        self.frequency_manager = SimpleNamespace(
+            frequency_type="foo",
+            is_batch_frequency_manager=True,
+            is_optim_frequency_manager=True,
+        )
 
     def epoch_to_step(self, epoch, steps_per_epoch):
         self.hit_count["epoch_to_step"] += 1
@@ -74,9 +84,9 @@ def state_mock():
 
 def test__log_epoch_invokes_log_scalar():
     logger_manager = LoggerManagerMock()
-    _log_epoch(
+    _log_current_step(
         logger_manager=logger_manager,
-        epoch=1,
+        current_log_step=1,
     )
     # log epoch should invoke log_string
     assert logger_manager.hit_count["log_scalar"] == 1
@@ -85,7 +95,7 @@ def test__log_epoch_invokes_log_scalar():
 def test_log_model_info_logs_epoch_and_loggable_items():
     state = StateMock()
     epoch = 3
-    log_model_info(state, epoch=epoch)
+    log_model_info(state, current_log_step=epoch)
 
     # loggable items will invoke log_scalar for each
     # int/float value + 1 for the epoch
@@ -95,7 +105,7 @@ def test_log_model_info_logs_epoch_and_loggable_items():
 @pytest.mark.parametrize(
     "loggable_items", [ModelMock().loggable_items(), [("a", {}), ("b", 2), ("c", {})]]
 )
-def test__log_model_loggable_items_routes_appropriately(loggable_items, monkeypatch):
+def test__log_model_loggable_items_routes_appropriately(loggable_items):
     logger_manager = LoggerManagerMock()
     loggable_items = list(loggable_items)
 


### PR DESCRIPTION
This PR adds some preliminary changes from #1931 that were missed

- Also fixes a bug to propagate step to loss logging
- Fixes WANDB logging
- Always logs losses now (remove filter for cadence)

test script:
```python
from sparseml.core.logger.logger import LoggerManager
import sparseml.core.session as sml
from sparseml.core.framework import Framework
import torchvision
from torchvision import transforms
import torch
from torch.utils.data import DataLoader
import datasets
import os
from torch.optim import Adam
from torch.nn import CrossEntropyLoss
from sparseml.core.event import EventType
from sparseml.core import PythonLogger
import logging

NUM_LABELS = 3
BATCH_SIZE = 32
NUM_EPOCHS = 2
LOG_FREQUENCY = 100

# "step" or "epoch"
# "step" was used for first test

FREQUENCY_TYPE = "step"
# FREQUENCY_TYPE = "epoch"

recipe = "e2e_recipe.yaml"
device = "cuda:0"

# set up SparseML session
sml.create_session()
session = sml.active_session()


# download model
model = torchvision.models.mobilenet_v2(weights=torchvision.models.MobileNet_V2_Weights.DEFAULT)
model.classifier[1] = torch.nn.Linear(model.classifier[1].in_features, NUM_LABELS)
model.to(device)


# download data
beans_dataset = datasets.load_dataset("beans", revision="ff99f4013946ad6c578bd070712b10fa0664fc9f")
train_folder, _ = os.path.split(beans_dataset["train"][0]["image_file_path"])
train_path, _ = os.path.split(train_folder)
val_folder, _ = os.path.split(beans_dataset["validation"][0]["image_file_path"])
val_path, _ = os.path.split(train_folder)


# dataloaders
imagenet_transform = transforms.Compose([
   transforms.Resize(size=256, interpolation=transforms.InterpolationMode.BILINEAR, max_size=None, antialias=None),
   transforms.CenterCrop(size=(224, 224)),
   transforms.ToTensor(),
   transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
])

train_dataset = torchvision.datasets.ImageFolder(
    root=train_path,
    transform=imagenet_transform
)
train_loader = DataLoader(train_dataset, BATCH_SIZE, shuffle=True, pin_memory=True, num_workers=16)

val_dataset = torchvision.datasets.ImageFolder(
    root=val_path,
    transform=imagenet_transform
)
val_loader = DataLoader(val_dataset, BATCH_SIZE, shuffle=False, pin_memory=True, num_workers=16)


# loss and optimizer
criterion = CrossEntropyLoss()
optimizer = Adam(model.parameters(), lr=8e-3)


recipe_args = {}
session_data = session.initialize(
    framework=Framework.pytorch,
    recipe=recipe,
    recipe_args=recipe_args,
    model=model,
    teacher_model=None,
    optimizer=optimizer,
    train_data=train_loader,
    val_data=val_loader,
    start=0.0,
    steps_per_epoch=len(train_loader),
    loggers=LoggerManager(frequency_type=FREQUENCY_TYPE, log_frequency=LOG_FREQUENCY),
)


# loop through batches
for epoch in range(NUM_EPOCHS):
    running_loss = 0.0
    total_correct = 0
    total_predictions = 0
    for step, (inputs, labels) in enumerate(session.state.data.train):
        inputs = inputs.to(device)
        labels = labels.to(device)
        session.state.optimizer.optimizer.zero_grad()
        session.event(event_type=EventType.BATCH_START, batch_data=(inputs, labels))

        outputs = session.state.model.model(inputs)
        loss = criterion(outputs, labels)
        loss.backward()
        session.event(event_type=EventType.LOSS_CALCULATED, loss=loss)

        session.event(event_type=EventType.OPTIM_PRE_STEP)
        session.state.optimizer.optimizer.step()
        session.event(event_type=EventType.OPTIM_POST_STEP)

        running_loss += loss.item()

        predictions = outputs.argmax(dim=1)
        total_correct += torch.sum(predictions == labels).item()
        total_predictions += inputs.size(0)

        session.event(event_type=EventType.BATCH_END)

    loss = running_loss / (step + 1.0)
    accuracy = total_correct / total_predictions
    print("Epoch: {} Loss: {} Accuracy: {}".format(epoch + 1, loss, accuracy))


# finalize session
session.finalize()
```


Test recipe:
```yaml
test_stage:
  pruning_modifiers:
    MagnitudePruningModifier:
      init_sparsity: 0.0
      final_sparsity: 0.5
      start: 0
      end: 2
      update_frequency: 0.5
      targets:        
          - features.0.0.weight
          - features.1.conv.0.0.weight
          - features.1.conv.1.weight
          - features.2.conv.0.0.weight
          - features.2.conv.1.0.weight
          - features.2.conv.2.weight
          - features.3.conv.0.0.weight
          - features.3.conv.1.0.weight
          - features.3.conv.2.weight
          - features.4.conv.0.0.weight
          - features.4.conv.1.0.weight
          - features.4.conv.2.weight
          - features.5.conv.0.0.weight
          - features.5.conv.1.0.weight
          - features.5.conv.2.weight
          - features.6.conv.0.0.weight
          - features.6.conv.1.0.weight
          - features.6.conv.2.weight
          - features.7.conv.0.0.weight
          - features.7.conv.1.0.weight
          - features.7.conv.2.weight
          - features.8.conv.0.0.weight
          - features.8.conv.1.0.weight
          - features.8.conv.2.weight
          - features.9.conv.0.0.weight
          - features.9.conv.1.0.weight
          - features.9.conv.2.weight
          - features.10.conv.0.0.weight
          - features.10.conv.1.0.weight
          - features.10.conv.2.weight
          - features.11.conv.0.0.weight
          - features.11.conv.1.0.weight
          - features.11.conv.2.weight
          - features.12.conv.0.0.weight
          - features.12.conv.1.0.weight
          - features.12.conv.2.weight
          - features.13.conv.0.0.weight
          - features.13.conv.1.0.weight
          - features.13.conv.2.weight
          - features.14.conv.0.0.weight
          - features.14.conv.1.0.weight
          - features.14.conv.2.weight
          - features.15.conv.0.0.weight
          - features.15.conv.1.0.weight
          - features.15.conv.2.weight
          - features.16.conv.0.0.weight
          - features.16.conv.1.0.weight
          - features.16.conv.2.weight
          - features.17.conv.0.0.weight
          - features.17.conv.1.0.weight
          - features.17.conv.2.weight
          - features.18.0.weight
          - classifier.1.weight
      leave_enabled: True
```