### PR TITLE
[Logger] Use lifecycle callbacks for logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -799,3 +799,5 @@ integrations/pytorch/pytorch_vision*
 # local log files
 nm_temp_test_logs/*
 sparse_logs/*
+wandb/
+output_finetune/

--- a/src/sparseml/core/helpers.py
+++ b/src/sparseml/core/helpers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Any, Generator, Tuple
+from typing import Any, Generator, Optional, Tuple, Union
 
 from sparseml.core.logger import LoggerManager
 from sparseml.core.model.base import ModifiableModel
@@ -29,7 +29,8 @@ __all__ = [
 def should_log_model_info(
     model: ModifiableModel,
     loggers: LoggerManager,
-    epoch: float,
+    current_log_step: float,
+    last_log_step: Optional[float] = None,
 ) -> bool:
     """
     Check if we should log model level info
@@ -40,17 +41,20 @@ def should_log_model_info(
 
     :param model: The model whose info we want to log
     :param loggers: The logger manager to log to
-    :param epoch: The current epoch
+    :param current_log_step: The current epoch
+    :param last_log_step: The last step we logged model info at
     :return: True if we should log model level info, False otherwise
     """
     return (
         hasattr(model, "loggable_items")
         and isinstance(loggers, LoggerManager)
-        and loggers.log_ready(current_log_step=epoch)
+        and loggers.log_ready(
+            current_log_step=current_log_step, last_log_step=last_log_step
+        )
     )
 
 
-def log_model_info(state: State, epoch):
+def log_model_info(state: State, current_log_step):
     """
     Log model level info to the logger
     Relies on `state.model` having a `loggable_items` method
@@ -59,25 +63,28 @@ def log_model_info(state: State, epoch):
     `LoggerManager` instance.
 
     :param state: The current state of sparsification
-    :param epoch: The epoch number to log model info
-        at
+    :param current_log_step: The current log step to log
+        model info at
     """
-    _log_epoch(logger_manager=state.loggers, epoch=epoch)
+    _log_current_step(logger_manager=state.loggers, current_log_step=current_log_step)
     _log_model_loggable_items(
         logger_manager=state.loggers,
         loggable_items=state.model.loggable_items(),
-        epoch=epoch,
+        epoch=current_log_step,
     )
 
 
-def _log_epoch(logger_manager: LoggerManager, epoch: int):
+def _log_current_step(
+    logger_manager: LoggerManager, current_log_step: Union[float, int]
+):
     """
-    Log the epoch to the logger_manager
+    Log the Current Log Step to the logger_manager
 
     :param logger_manager: The logger manager to log to
-    :param epoch: The epoch to log
+    :param current_log_step: The logging step
     """
-    logger_manager.log_scalar(tag="Epoch", value=float(epoch), step=epoch)
+    tag = logger_manager.frequency_manager.frequency_type
+    logger_manager.log_scalar(tag=tag, value=current_log_step, step=current_log_step)
 
 
 def _log_model_loggable_items(

--- a/src/sparseml/core/logger/logger.py
+++ b/src/sparseml/core/logger/logger.py
@@ -638,7 +638,8 @@ class WANDBLogger(LambdaLogger):
                 values = {f"{tag}/{key}": val for key, val in values.items()}
             params.update(values)
 
-        # wandb.log(params, step=step)
+        params.update({"Step": step})
+        wandb.log(params)
 
         return True
 

--- a/src/sparseml/core/logger/utils/frequency_manager.py
+++ b/src/sparseml/core/logger/utils/frequency_manager.py
@@ -26,7 +26,10 @@ __all__ = [
 
 LogStepType = Union[int, float, None]
 LoggingModeType = Literal["on_change", "exact"]
-FrequencyType = Literal["epoch", "step", "batch"]
+FrequencyType = Literal["epoch", "step"]
+
+DEFAULT_FREQUENCY_TYPE = "epoch"
+DEFAULT_LOGGING_MODE = "exact"
 
 
 class FrequencyManager:
@@ -47,14 +50,14 @@ class FrequencyManager:
     def __init__(
         self,
         log_frequency: LogStepType = None,
-        mode: LoggingModeType = "exact",
-        frequency_type: FrequencyType = "epoch",
+        mode: LoggingModeType = DEFAULT_LOGGING_MODE,
+        frequency_type: FrequencyType = DEFAULT_FREQUENCY_TYPE,
     ):
         # sets self._logging_mode and self._check_model_update
         self._logging_mode = self._set_logging_mode(mode=mode)
 
         # sets self._frequency_type and self._valid_python_types
-        self._frequency_type = self._set_frequency_type(frequency_type=frequency_type)
+        self.frequency_type = self._set_frequency_type(frequency_type=frequency_type)
 
         self._validate_log_frequency(log_frequency=log_frequency)
         self._log_frequency = log_frequency
@@ -65,7 +68,7 @@ class FrequencyManager:
     def __repr__(self):
         return (
             f"{self.__class__.__name__}(log_frequency={self.log_frequency}, "
-            f"mode={self._logging_mode}, frequency_type={self._frequency_type})"
+            f"mode={self._logging_mode}, frequency_type={self.frequency_type})"
         )
 
     def log_ready(
@@ -144,6 +147,22 @@ class FrequencyManager:
         self._validate_log_frequency(log_frequency=log_frequency)
         self._log_frequency = log_frequency
 
+    @property
+    def is_optim_frequency_manager(self) -> bool:
+        """
+        :return: True if the frequency manager is tracking optimizer steps,
+            False otherwise
+        """
+        return self.frequency_type == "step"
+
+    @property
+    def is_epoch_frequency_manager(self) -> bool:
+        """
+        :return: True if the frequency manager is tracking epochs,
+            False otherwise
+        """
+        return self.frequency_type == "epoch"
+
     def _validate_log_frequency(self, log_frequency):
         # checks that log frequency is a positive number or None
         # raise TypeError if not a number or None
@@ -219,25 +238,25 @@ class FrequencyManager:
             for the given frequency type, e.g. (int, float, type(None)) for "epoch"
             and (int, type(None)) for "step" or "batch"
         :raises ValueError: If the given frequency type is not one of "epoch",
-            "step", or "batch"
+            "step"
+        :raises NotImplementedError: If the given frequency type is "batch"
         :return: The frequency type that was set
         """
         frequency_type = _basic_normalization(frequency_type)
         if frequency_type == "epoch":
-            self._frequency_type = "epoch"
+            self.frequency_type = "epoch"
             self._valid_python_types = (int, float, type(None))
         elif frequency_type == "step":
-            self._frequency_type = "step"
+            self.frequency_type = "step"
             self._valid_python_types = (int, type(None))
         elif frequency_type == "batch":
-            self._frequency_type = "batch"
-            self._valid_python_types = (int, type(None))
+            raise NotImplementedError
         else:
             raise ValueError(
                 f"Invalid frequency type {frequency_type}, must be one of "
-                "'epoch', 'step', 'batch'"
+                "'epoch', 'step'"
             )
-        return self._frequency_type
+        return self.frequency_type
 
 
 def log_ready(

--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -22,7 +22,6 @@ from sparseml.core.framework import Framework
 from sparseml.core.helpers import log_model_info, should_log_model_info
 from sparseml.core.lifecycle import SparsificationLifecycle
 from sparseml.core.logger import BaseLogger, LoggerManager
-from sparseml.core.logger.utils import log_ready
 from sparseml.core.recipe import Recipe
 from sparseml.core.state import ModifiedState, State
 
@@ -66,7 +65,6 @@ class SparseSession:
 
     def __init__(self):
         self._lifecycle = SparsificationLifecycle()
-        self._last_loss_log_step = None
 
     @property
     def lifecycle(self) -> SparsificationLifecycle:
@@ -263,9 +261,6 @@ class SparseSession:
         mod_data = self._lifecycle.event(
             event_type=event_type, batch_data=batch_data, loss=loss, **kwargs
         )
-
-        self.log(event_type=event_type, loss=self.state.loss)
-
         return ModifiedState(
             model=self.state.model.model if self.state.model else None,
             optimizer=self.state.optimizer.optimizer if self.state.optimizer else None,
@@ -308,14 +303,18 @@ class SparseSession:
 
         epoch = self._lifecycle.event_lifecycle.current_index
 
-        if should_log_model_info(
-            model=self.state.model,
-            loggers=self.state.loggers,
-            epoch=epoch,
+        if (
+            should_log_model_info(
+                model=self.state.model,
+                loggers=self.state.loggers,
+                current_log_step=epoch,
+                last_log_step=self.state._last_log_step,
+            )
+            and self.state.loggers.frequency_manager.is_epoch_frequency_manager
         ):
             log_model_info(
                 state=self.state,
-                epoch=epoch,
+                current_log_step=epoch,
             )
             # update last log epoch
             self.state.loggers.log_written(epoch)
@@ -325,22 +324,25 @@ class SparseSession:
             # only log loss when loss is calculated
             return
 
-        current_step = self._lifecycle.event_lifecycle.current_index
+        epoch = self._lifecycle.event_lifecycle.current_index
+        if self.state.loggers.frequency_manager.is_optim_frequency_manager:
+            # log integer step for optimizer frequency manager
+            current_step = int(
+                self.state.loggers.epoch_to_step(
+                    epoch=epoch,
+                    steps_per_epoch=len(self.state.data.train),
+                )
+            )
+        else:
+            # log float epoch for epoch frequency manager
+            current_step = epoch
 
-        # No need to check model update for loss logging
-        check_model_update = False
-
-        if loss is not None and log_ready(
-            current_log_step=current_step,
-            last_log_step=self._last_loss_log_step,
-            log_frequency=self.state.loggers.log_frequency,
-            check_model_update=check_model_update,
-        ):
-            loss = loss if isinstance(loss, dict) else {"loss": loss}
+        # always log loss if available
+        if loss is not None:
+            loss = loss if isinstance(loss, dict) else {"Loss": loss}
             self.state.loggers.metric.log_scalars(
                 tag="Loss", values=loss, step=current_step
             )
-            self._last_loss_log_step = current_step
 
 
 _global_session = SparseSession()
@@ -566,6 +568,8 @@ class LifecycleCallbacks:
         :param kwargs: additional kwargs to pass to the current session's event method
         :return: the modified state of the active session after invoking the event
         """
+        # log loss if loss calculated
+        active_session()._log_loss(event_type=EventType.LOSS_CALCULATED, loss=loss)
         return cls.event(EventType.LOSS_CALCULATED, loss=loss, **kwargs)
 
     @classmethod
@@ -596,6 +600,7 @@ class LifecycleCallbacks:
         :param kwargs: additional kwargs to pass to the current session's event method
         :return: the modified state of the active session after invoking the event
         """
+        active_session()._log_model_info()
         return cls.event(EventType.BATCH_END, **kwargs)
 
 

--- a/src/sparseml/core/session.py
+++ b/src/sparseml/core/session.py
@@ -339,7 +339,7 @@ class SparseSession:
 
         # always log loss if available
         if loss is not None:
-            loss = loss if isinstance(loss, dict) else {"Loss": loss}
+            loss = loss if isinstance(loss, dict) else {"loss": loss}
             self.state.loggers.metric.log_scalars(
                 tag="Loss", values=loss, step=current_step
             )

--- a/src/sparseml/core/state.py
+++ b/src/sparseml/core/state.py
@@ -113,7 +113,7 @@ class State:
     last_event: Event = None
     loggers: Optional[LoggerManager] = None
     model_log_cadence: Optional[float] = None
-    _last_log_epoch: Optional[float] = None
+    _last_log_step: Union[float, int, None] = None
 
     @property
     def sparsification_ready(self) -> bool:

--- a/tests/sparseml/core/logger/utils/test_frequency_manager.py
+++ b/tests/sparseml/core/logger/utils/test_frequency_manager.py
@@ -146,11 +146,9 @@ def test_log_ready(
         (0.1, "epoch", does_not_raise()),
         # batch and step frequency types need
         # log_frequency to be an integer
-        (0.1, "batch", pytest.raises(TypeError)),
         (0.1, "step", pytest.raises(TypeError)),
         # negative log_frequency is invalid
         (-1, "epoch", pytest.raises(ValueError)),
-        (-1, "batch", pytest.raises(ValueError)),
         (-1, "step", pytest.raises(ValueError)),
     ],
 )

--- a/tests/sparseml/core/test_helpers.py
+++ b/tests/sparseml/core/test_helpers.py
@@ -13,11 +13,16 @@
 # limitations under the License.
 
 from collections import defaultdict
+from types import SimpleNamespace
 
 import pytest
 
 from sparseml.core.event import EventType
-from sparseml.core.helpers import _log_epoch, _log_model_loggable_items, log_model_info
+from sparseml.core.helpers import (
+    _log_current_step,
+    _log_model_loggable_items,
+    log_model_info,
+)
 from sparseml.core.logger import LoggerManager
 
 
@@ -30,6 +35,11 @@ class ModelMock:
 class LoggerManagerMock:
     def __init__(self):
         self.hit_count = defaultdict(int)
+        self.frequency_manager = SimpleNamespace(
+            frequency_type="foo",
+            is_batch_frequency_manager=True,
+            is_optim_frequency_manager=True,
+        )
 
     def epoch_to_step(self, epoch, steps_per_epoch):
         self.hit_count["epoch_to_step"] += 1
@@ -74,9 +84,9 @@ def state_mock():
 
 def test__log_epoch_invokes_log_scalar():
     logger_manager = LoggerManagerMock()
-    _log_epoch(
+    _log_current_step(
         logger_manager=logger_manager,
-        epoch=1,
+        current_log_step=1,
     )
     # log epoch should invoke log_string
     assert logger_manager.hit_count["log_scalar"] == 1
@@ -85,7 +95,7 @@ def test__log_epoch_invokes_log_scalar():
 def test_log_model_info_logs_epoch_and_loggable_items():
     state = StateMock()
     epoch = 3
-    log_model_info(state, epoch=epoch)
+    log_model_info(state, current_log_step=epoch)
 
     # loggable items will invoke log_scalar for each
     # int/float value + 1 for the epoch
@@ -95,7 +105,7 @@ def test_log_model_info_logs_epoch_and_loggable_items():
 @pytest.mark.parametrize(
     "loggable_items", [ModelMock().loggable_items(), [("a", {}), ("b", 2), ("c", {})]]
 )
-def test__log_model_loggable_items_routes_appropriately(loggable_items, monkeypatch):
+def test__log_model_loggable_items_routes_appropriately(loggable_items):
     logger_manager = LoggerManagerMock()
     loggable_items = list(loggable_items)
 

--- a/tests/sparseml/core/test_session.py
+++ b/tests/sparseml/core/test_session.py
@@ -321,6 +321,8 @@ class TestLifecycleCallbacks:
         self, method_name, expected_event_type, monkeypatch, setup_active_session
     ):
         monkeypatch.setattr(setup_active_session, "event", active_session_event_mock)
+        monkeypatch.setattr(setup_active_session, "_log_loss", empty_mock)
+        monkeypatch.setattr(setup_active_session, "_log_model_info", empty_mock)
         setup_active_session.lifecycle.recipe_container.recipes = ["dummy_recipe.yaml"]
         method = getattr(session_module.LifecycleCallbacks, method_name)
         result = method()


### PR DESCRIPTION
- Add preliminary changes that were missed
- Propagate step while logging loss
- Fix WANDB logging
- Use LifeCycleCallbacks for logging loss and model info
- Update tests

Test Script:
```python
from sparseml.transformers import train

model = "Xenova/llama2.c-stories15M"
teacher_model = "Xenova/llama2.c-stories15M"
dataset_name = "open_platypus"
concatenate_data = False
output_dir = "./output_finetune"
recipe = "/home/ubuntu/projects/sparseml/local/recipes/llama_gmp.yaml"
num_train_epochs=2
overwrite_output_dir = True
splits = {
    "train": "train[:10%]",
}

train(
    model=model,
    distill_teacher=teacher_model,
    dataset=dataset_name,
    output_dir=output_dir,
    recipe=recipe,
    num_train_epochs=num_train_epochs,
    overwrite_output_dir=overwrite_output_dir,
    concatenate_data = concatenate_data,
    splits = splits
)
```

Recipe: 
```yaml
# llama_gmp.yaml
test_oneshot_stage:
  obcq_modifiers:
    SparseGPTModifier:
      sparsity: 0.7
      block_size: 128
      sequential_update: False
      quantize: False
      percdamp: 0.01
      prunen: 0
      prunem: 0
      targets: [
        "model.layers.0"
      ]
      target_ids: ["attention_mask", "position_ids"]  
test_train_stage:
  pruning_modifiers:
    ConstantPruningModifier:
      targets: [
        "re:.*self_attn.q_proj",
        "re:.*self_attn.k_proj",
        "re:.*self_attn.v_proj",
        "re:.*self_attn.o_proj",
        "re:.*mlp.gate_proj",
        "re:.*mlp.up_proj"
      ]
      start: 0
```

WANDB run: wandb: 🚀 View run laced-sponge-38 at: https://wandb.ai/neuralmagicml/sparseml-local_scripts/runs/5ak0wzdk

Log file has been attached with the description:
[27-02-2024_12.38.02.log](https://github.com/neuralmagic/sparseml/files/14419596/27-02-2024_12.38.02.log)

