### PR TITLE
Fix Pt. 1 for Multi-Process Zoo Stub Downloads

### DIFF
--- a/src/sparseml/transformers/utils/sparse_model.py
+++ b/src/sparseml/transformers/utils/sparse_model.py
@@ -35,6 +35,7 @@ from sparseml.pytorch.model_load.helpers import (
 )
 from sparseml.transformers.utils.helpers import resolve_recipe
 from sparseml.utils import download_zoo_training_dir
+from sparseml.utils.fsdp.context import main_process_first_context
 
 
 __all__ = ["SparseAutoModel", "SparseAutoModelForCausalLM", "get_shared_tokenizer_src"]
@@ -87,9 +88,10 @@ class SparseAutoModelForCausalLM(AutoModelForCausalLM):
                 "Passed zoo stub to SparseAutoModelForCausalLM object. "
                 "Loading model from SparseZoo training files..."
             )
-            pretrained_model_name_or_path = download_zoo_training_dir(
-                zoo_stub=pretrained_model_name_or_path
-            )
+            with main_process_first_context():
+                pretrained_model_name_or_path = download_zoo_training_dir(
+                    zoo_stub=pretrained_model_name_or_path
+                )
 
         # temporarily set the log level to error, to ignore printing out long missing
         # and unexpected key error messages (these are EXPECTED for quantized models)


### PR DESCRIPTION
When we download a model from the zoo for the first time, all processes are going to try and download it at once. What we want instead is for the main process to download the files and the others to just pull from the cache. This PR uses Accelerator's main_process_first() context manager to do this.

**NOTE:*** Even with this fix, if we have more than 2 processes the download still gets corrupted because all the non-main processes are calling the SparseZoo API at the same time. We have seen this same error in GHA transformers unit tests and it is caused by a concurrency issue with SparseZoo. @horheynm is working on this part of the issue

Asana ticket: https://app.asana.com/0/1206109050183159/1206698210421769/f

### Testing

test.py
```
from sparseml.transformers import compress, SparseAutoModelForCausalLM, SparseAutoTokenizer

model = SparseAutoModelForCausalLM.from_pretrained(
    "zoo:llama2-7b-ultrachat200k_llama2_pretrain-base"
)
tokenizer = SparseAutoTokenizer.from_pretrained("zoo:llama2-7b-ultrachat200k_llama2_pretrain-base")
dataset="open_platypus"
MODEL_STUB="zoo:llama2-7b-ultrachat200k_llama2_pretrain-pruned40.oneshot"

compress(
    model=model,
    tokenizer=tokenizer,
    dataset=dataset,
    recipe=MODEL_STUB,
    output_dir="./output"
)
 ```

To run: `accelerate launch --config_file /nm/drive0/sadkins/sparseml/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml test.py`

This command fails on main, launches oneshot correctly on this branch.