### PR TITLE
[Fix] dataset arg

### DIFF
--- a/src/sparseml/evaluation/cli.py
+++ b/src/sparseml/evaluation/cli.py
@@ -24,7 +24,7 @@ Usage: sparseml.evaluate [OPTIONS] MODEL_PATH [INTEGRATION_ARGS]...
   all the auxiliary files) or a SparseZoo/HugginFace stub
 
 Options:
-  -d, --dataset TEXT              The name of dataset to evaluate on
+  -d, --datasets TEXT              The name of dataset to evaluate on
   -i, --integration TEXT          Name of the evaluation integration to use.
                                   Must be a valid integration name that is
                                   registered in the evaluation registry
@@ -79,7 +79,7 @@ _LOGGER = logging.getLogger(__name__)
 )
 @click.option(
     "-d",
-    "--dataset",
+    "--datasets",
     type=str,
     default=None,
     help="The name of dataset to evaluate on",
@@ -126,7 +126,7 @@ _LOGGER = logging.getLogger(__name__)
 @click.argument("integration_args", nargs=-1, type=click.UNPROCESSED)
 def main(
     model_path,
-    dataset,
+    datasets,
     integration,
     save_path,
     type_serialization,
@@ -146,14 +146,14 @@ def main(
     integration_args: Dict[str, Any] = parse_kwarg_tuples(integration_args)
 
     _LOGGER.info(
-        f"Datasets to evaluate on: {dataset}\n"
+        f"Datasets to evaluate on: {datasets}\n"
         f"Batch size: {batch_size}\n"
         f"Additional integration arguments supplied: {integration_args}"
     )
 
     result: Result = evaluate(
         model_path=model_path,
-        datasets=dataset,
+        datasets=datasets,
         integration=integration,
         batch_size=batch_size,
         limit=limit,


### PR DESCRIPTION
`dataset` cli arg updated to `datasets`

```bash
(.venv) ➜  sparseml git:(main) ✗ sparseml.evaluate \
          "roneneldan/TinyStories-1M" \
          --datasets "openai_humaneval" \
          --integration "perplexity" \
--text_column_name prompt
2024-03-01 12:54:14 sparseml.evaluation.cli INFO     Datasets to evaluate on: openai_humaneval
Batch size: 1
Additional integration arguments supplied: {'text_column_name': 'prompt'}
2024-03-01 12:54:15 sparseml.evaluation.registry INFO     Auto collected perplexity integration for eval
2024-03-01 12:54:15 sparseml.transformers.utils.helpers INFO     model_path is a huggingface model id. Attempting to download recipe from https://huggingface.co/
2024-03-01 12:54:15 sparseml.transformers.utils.helpers INFO     Found recipe: recipe.yaml for model id: roneneldan/TinyStories-1M. Downloading...
2024-03-01 12:54:15 sparseml.transformers.utils.helpers INFO     Unable to to find recipe recipe.yaml for model id: roneneldan/TinyStories-1M: 404 Client Error. (Request ID: Root=1-65e21647-3d41f20672a334477e01f6a2;e188d76a-7682-44c8-82aa-890dd8241cda)

Entry Not Found for url: https://huggingface.co/roneneldan/TinyStories-1M/resolve/main/recipe.yaml.. Skipping recipe resolution.
2024-03-01 12:54:15 sparseml.transformers.utils.helpers INFO     Failed to infer the recipe from the model_path
Attempting to cast a BatchEncoding to type None. This is not supported.
  4%|███▉                                                                                                      | 6/164 [00:13<05:57,  2.26s/it]
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206739177230427