### PR TITLE
Custom Dataset Bug Fixes

### DIFF
--- a/src/sparseml/transformers/finetune/data/custom.py
+++ b/src/sparseml/transformers/finetune/data/custom.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from copy import deepcopy
-from typing import List
+from typing import Dict, List, Union
 
-from datasets.dataset_dict import DatasetDict
+from datasets.dataset_dict import Dataset, DatasetDict
 
 from sparseml.transformers.finetune.data import TextGenerationDataset
 
@@ -43,24 +43,16 @@ class CustomDataset(TextGenerationDataset):
         self.preprocessing_func = data_args.preprocessing_func
         self.remove_columns = data_args.remove_columns
 
-    def get_raw_dataset(self, *_ignore, **__ignore) -> DatasetDict:
+    def get_raw_dataset(self, *_ignore, **__ignore) -> Union[DatasetDict, Dataset]:
         """Get the raw dataset and apply preprocessing func if provided"""
 
-        dataset = (
-            self.data_args.dataset
-            if hasattr(self.data_args, "dataset")
-            else self.data_args.dataset_name
-        )
-        if isinstance(dataset, DatasetDict):
+        dataset = self.data_args.dataset
+        if isinstance(dataset, DatasetDict) or isinstance(dataset, Dataset):
             # user passed in an already instantiated dataset, just use it directly
             raw_dataset = dataset
         else:
             # dataset must be loaded from file or HF Hub
             raw_dataset = super().get_raw_dataset()
-
-        self.remove_columns = (
-            self.remove_columns or self.get_remove_columns_from_dataset(raw_dataset)
-        )
 
         if self.preprocessing_func is not None:
             raw_dataset = self.map(
@@ -71,10 +63,14 @@ class CustomDataset(TextGenerationDataset):
                 desc="Applying custom func to the custom dataset",
             )
 
+        self.remove_columns = (
+            self.remove_columns or self.get_remove_columns_from_dataset(raw_dataset)
+        )
+
         if self.remove_columns is not None:
             raw_dataset = self.map(
                 raw_dataset,
-                batched=False,
+                batched=True,
                 remove_columns=self.remove_columns,
                 num_proc=self.data_args.preprocessing_num_workers,
                 desc="Removing unneeded columns",
@@ -82,13 +78,18 @@ class CustomDataset(TextGenerationDataset):
 
         return raw_dataset
 
-    def get_remove_columns_from_dataset(self, raw_dataset: DatasetDict) -> List[str]:
+    def get_remove_columns_from_dataset(
+        self, raw_dataset: Union[DatasetDict, Dataset]
+    ) -> List[str]:
         """Remove redandant columns from the dataset for processing"""
-        remove_columns = set()
-        for datasets in raw_dataset.values():
-            for feature in datasets.features.keys():
-                remove_columns.add(feature)
+        remove_columns = raw_dataset.column_names
+        if isinstance(remove_columns, Dict):
+            remove_columns = raw_dataset[list(raw_dataset.keys())[0]].column_names
 
-        remove_columns.remove(self.text_column)
+        remove_columns = set(remove_columns)
+        if self.text_column in remove_columns:
+            remove_columns.remove(self.text_column)
+        if self.PROMPT_KEY in remove_columns:
+            remove_columns.remove(self.PROMPT_KEY)
 
         return list(remove_columns)

--- a/src/sparseml/transformers/finetune/data/data_helpers.py
+++ b/src/sparseml/transformers/finetune/data/data_helpers.py
@@ -121,6 +121,8 @@ def make_dataset_splits(
     # handles case where all splits are contained in a single dataset
     if "all" in tokenized_datasets and len(tokenized_datasets) == 1:
         tokenized_datasets = tokenized_datasets.get("all")
+        if isinstance(tokenized_datasets, Dataset):
+            tokenized_datasets = {"train": tokenized_datasets}
 
     train_split = eval_split = predict_split = calib_split = None
     if do_train:

--- a/src/sparseml/transformers/finetune/data/evolcodealpaca.py
+++ b/src/sparseml/transformers/finetune/data/evolcodealpaca.py
@@ -56,7 +56,7 @@ class EvolCodeAlpacaDataset(TextGenerationDataset):
             sample["text"] = self.EVOL_ALPACA_TEMPLATE.format(
                 instruction=sample["instruction"]
             )
-            sample["prompt"] = sample["text"]
+            sample[self.PROMPT_KEY] = sample["text"]
             if "output" in sample:
                 sample["text"] += sample["output"]
             return sample

--- a/src/sparseml/transformers/finetune/data/gsm8k.py
+++ b/src/sparseml/transformers/finetune/data/gsm8k.py
@@ -50,7 +50,7 @@ class GSM8KDataset(TextGenerationDataset):
         # helper fn for restructuring each dataset entry using the gsm template
         def restructure_fn(sample):
             sample["text"] = self.GSM_TEMPLATE.format(question=sample["question"])
-            sample["prompt"] = sample["text"]
+            sample[self.PROMPT_KEY] = sample["text"]
             if "answer" in sample:
                 sample["text"] += " " + sample["answer"]
             return sample

--- a/src/sparseml/transformers/finetune/data/open_platypus.py
+++ b/src/sparseml/transformers/finetune/data/open_platypus.py
@@ -65,7 +65,7 @@ class OpenPlatypusDataset(TextGenerationDataset):
                     instruction=sample["instruction"]
                 )
 
-            sample["prompt"] = sample["text"]
+            sample[self.PROMPT_KEY] = sample["text"]
             if "output" in sample:
                 sample["text"] += sample["output"]
             return sample

--- a/src/sparseml/transformers/finetune/runner.py
+++ b/src/sparseml/transformers/finetune/runner.py
@@ -118,12 +118,7 @@ class StageRunner:
                 tokenizer=tokenizer,
             )
 
-            if isinstance(self._data_args.dataset, str):
-                raw_dataset = dataset_manager.get_raw_dataset(
-                    self._model_args.cache_dir
-                )
-            else:
-                raw_dataset = self._data_args.dataset
+            raw_dataset = dataset_manager.get_raw_dataset(self._model_args.cache_dir)
             tokenized_dataset = dataset_manager.tokenize_and_process(raw_dataset)
             tokenized_datasets[split_name] = tokenized_dataset
 


### PR DESCRIPTION
There were a few issues:
* Not checking if columns exist before removing them
* Weren't handling the case of Dataset, only DatasetDict
* Don't remove prompt column from custom dataset

Asana ticket: https://app.asana.com/0/1206109050183159/1206717149982745/f

### Testing
Preprocessing function now working as intended, and training starts
```
from sparseml.transformers import (
    SparseAutoModelForCausalLM, SparseAutoTokenizer, load_dataset, compress
)

model = SparseAutoModelForCausalLM.from_pretrained(
    "/nm/drive0/sadkins/models/llama2-7b-open_platypus_orca_llama2_pretrain-pruned40/training",
    device_map="auto",
)
tokenizer = SparseAutoTokenizer.from_pretrained(
    "/nm/drive0/sadkins/models/llama2-7b-open_platypus_orca_llama2_pretrain-pruned40/training"
)
dataset = load_dataset("HuggingFaceH4/helpful_instructions")

def preprocessing(data):
    data["text"] = data["prompt"] + data["completion"]
    return data

recipe = """
finetune_stage:
    run_type: train
    finetune_modifiers:
        ConstantPruningModifier:
            targets: ["re:.*q_proj.weight", "re:.*k_proj.weight", "re:.*v_proj.weight", "re:.*o_proj.weight", "re:.*gate_proj.weight", "re:.*up_proj.weight", "re:.*down_proj.weight"]
            start: 0

quantization_stage:
    run_type: oneshot
    quantize_modifiers:
        QuantizationModifier:
            ignore: [LlamaRotaryEmbedding, LlamaRMSNorm, SiLUActivation, MatMulOutput_QK, MatMulOutput_PV]
            post_oneshot_calibration: true
            scheme_overrides:
                Linear:
                    weights:
                        num_bits: 8
                        symmetric: true
                        strategy: channel
                MatMulLeftInput_QK:
                    input_activations:
                        num_bits: 8
                        symmetric: true
                Embedding:
                    input_activations: null
                    weights:
                        num_bits: 8
                        symmetric: false
        SparseGPTModifier:
            quantize: True
            targets: [model.layers.0, model.layers.1, model.layers.2, model.layers.3, model.layers.4, model.layers.5, model.layers.6, model.layers.7, model.layers.8, model.layers.9, model.layers.10, model.layers.11, model.layers.12, model.layers.13, model.layers.14, model.layers.15, model.layers.16, model.layers.17, model.layers.18, model.layers.19, model.layers.20, model.layers.21, model.layers.22, model.layers.23, model.layers.24, model.layers.25, model.layers.26, model.layers.27, model.layers.28, model.layers.29, model.layers.30, model.layers.31, lm_head]
"""

compress(
    model=model,
    tokenizer=tokenizer,
    dataset=dataset,
    recipe=recipe,
    preprocessing_func=preprocessing,
    output_dir="./transfer-example"
)
```