### PR TITLE
FakeQuant 1.9 Compatibility

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: "Checking if sparseml.pytorch was changed"
         id: pytorch-check
         run: >
-          ((git diff --name-only origin/main HEAD | grep -E "[src|tests]/sparseml/pytorch|setup.py|.github")
+          ((git diff --name-only origin/main HEAD | grep -E "[src|tests]/sparseml/modifiers|pytorch|setup.py|.github")
           || (echo $GITHUB_REF | grep -E "refs/heads/[release/|main]"))
           && echo "::set-output name=output::1" || echo "::set-output name=output::0"
       - name: "Checking if sparseml.export was changed"

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ _dev_deps = [
     "flake8==3.9.2",
     "isort==5.8.0",
     "wheel>=0.36.2",
-    "pytest>=6.0.0",
+    "pytest>=6.0.0,<8.1.0",
     "pytest-mock>=3.6.0",
     "flaky~=3.7.0",
     "tensorboard>=1.0,<2.9",

--- a/src/sparseml/modifiers/quantization/utils/fake_quant_wrapper.py
+++ b/src/sparseml/modifiers/quantization/utils/fake_quant_wrapper.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 
 import torch
-from torch.ao.quantization import FakeQuantize
+from packaging import version
+
+
+_PARSED_TORCH_VERSION = version.parse(torch.__version__)
+if _PARSED_TORCH_VERSION < version.parse("2"):
+    from torch.quantization import FakeQuantize
+else:
+    from torch.ao.quantization import FakeQuantize
 
 
 class FakeQuantizeWrapper(FakeQuantize):


### PR DESCRIPTION
The FakeQuantizeWrapper had an import error in pytorch 1.9. Fixing this error, and also updating the GHA checks to check for changes in sparseml/modifiers before running the pytorch test suite.