### PR TITLE
Support for OWL Regex Layers

### DIFF
--- a/src/sparseml/modifiers/pruning/wanda/base.py
+++ b/src/sparseml/modifiers/pruning/wanda/base.py
@@ -95,22 +95,11 @@ class WandaPruningModifier(Modifier):
             # single sparsity will be applied to all layers
             return
 
-        if not isinstance(self.targets, List):
-            raise ValueError(
-                "Layer targets must be a list when specifying layer-wise"
-                f" sparsity. Got {type(self.targets)}"
-            )
+        target_layers = list(self.compressible_layers_.keys())
 
-        if len(self.targets) != len(self.sparsity):
+        if len(target_layers) != len(self.sparsity):
             raise ValueError(
                 "Number of layer targets must match the number of "
-                f"sparsities. Got {len(self.targets)} layers and "
+                f"sparsities. Got {len(target_layers)} layers and "
                 f"{len(self.sparsity)} sparsities"
             )
-
-        for layer_name in self.targets:
-            if layer_name.startswith("re:"):
-                raise ValueError(
-                    "Using regular expressions for layer-wise sparsity "
-                    f"profiles is not permitted. Found {layer_name}"
-                )

--- a/tests/sparseml/pytorch/modifiers/obcq/test_pytorch.py
+++ b/tests/sparseml/pytorch/modifiers/obcq/test_pytorch.py
@@ -57,9 +57,11 @@ def test_successful_layerwise_recipe():
     targets = ["seq.fc1", "seq.fc2"]
     kwargs = dict(sparsity=sparsities, block_size=128, quantize=False, targets=targets)
     modifier = SparseGPTModifierPyTorch(**kwargs)
-    modifier._validate_layerwise_sparsity()
+    modifier.compressible_layers_ = {"seq.fc1": None, "seq.fc2": None}
     modifier.model = ModifiableModel(framework=Framework.pytorch, model=model)
     found_compressible_layers = modifier.compressible_layers()
+    modifier.compressible_layers_ = found_compressible_layers
+    modifier._validate_layerwise_sparsity()
 
     # ensure layers names successfully match up with model
     assert len(found_compressible_layers) == len(targets)


### PR DESCRIPTION
Previously we restricted the user from specifying target layers as a regex, so the mapping between sparsities and layers was explicit. This restriction doesn't make sense with OWL, where we are calculating the layer-wise sparsities from the list of layers. This PR removes the regex restriction entirely, we only check that the number of sparsities matches the number of layers

### Test Script 

```python
from sparseml.transformers import (
 SparseAutoModelForCausalLM, SparseAutoTokenizer, load_dataset, compress
)

model = SparseAutoModelForCausalLM.from_pretrained(
 "zoo:llama2-7b-open_platypus_orca_llama2_pretrain-base",
 device_map="auto",
)
tokenizer = SparseAutoTokenizer.from_pretrained(
 "zoo:llama2-7b-open_platypus_orca_llama2_pretrain-base"
)

recipe = """
pruning_stage:
    run_type: oneshot
    pruning_modifiers:
        SparseGPTModifier:
            sparsity: 0.5
            sparsity_profile: owl
            owl_m: 5
            owl_lmbda: 0.08
            block_size: 128
            sequential_update: False
            quantize: False
            targets: ["re:model.layers.\\\d+$"]
"""

compress(
 model=model,
 tokenizer=tokenizer,
 dataset="open_platypus",
 recipe=recipe,
 output_dir="./finetune-example"
)
```

Output: (Added a few additional logs too)
```
2024-03-04 20:14:27 sparseml.modifiers.pruning.wanda.pytorch INFO     Inferring layer-wise sparsities from 512 calibration samples...
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [02:36<00:00,  3.27it/s]
2024-03-04 20:17:23 sparseml.modifiers.pruning.wanda.pytorch INFO     OWL sparsities for sp=0.5 are:
2024-03-04 20:17:23 sparseml.modifiers.pruning.wanda.pytorch INFO     Sparsity for model.layers.0: 0.4766269477159438
2024-03-04 20:17:23 sparseml.modifiers.pruning.wanda.pytorch INFO     Sparsity for model.layers.1: 0.4716676679237136
2024-03-04 20:17:23 sparseml.modifiers.pruning.wanda.pytorch INFO     Sparsity for model.layers.2: 0.44314214073003033
2024-03-04 20:17:23 sparseml.modifiers.pruning.wanda.pytorch INFO     Sparsity for model.layers.3: 0.39729059340236417
```