### PR TITLE
[Bug] Explicitly pass in the tokenizer for non-downloaded zoo stubs

### DIFF
--- a/src/sparseml/evaluation/integrations/lm_evaluation_harness.py
+++ b/src/sparseml/evaluation/integrations/lm_evaluation_harness.py
@@ -34,6 +34,7 @@ try:
     # version is installed for SparseML
     from sparseml.transformers.utils.sparse_config import SparseAutoConfig
     from sparseml.transformers.utils.sparse_model import SparseAutoModelForCausalLM
+    from sparseml.transformers.utils.sparse_tokenizer import SparseAutoTokenizer
 except ImportError as import_error:
     raise ImportError(
         "Install sparseml supported dependencies for lm-eval integration by running "
@@ -69,7 +70,9 @@ def lm_eval_harness(
     """
 
     kwargs["limit"] = int(limit) if (limit := kwargs.get("limit")) else None
-    model = SparseMLLM(pretrained=model_path, **kwargs)
+
+    tokenizer = SparseAutoTokenizer.from_pretrained(model_path)
+    model = SparseMLLM(pretrained=model_path, tokenizer=tokenizer, **kwargs)
 
     if kwargs.get("limit"):
         _LOGGER.warning(


### PR DESCRIPTION
Test Code:
```python
from sparseml import evaluate
stub = "zoo:llama2-7b-llama2_pretrain-base"
dataset=["arc_challenge", "winogrande"]
integration="lm-eval-harness"
res = evaluate(stub, datasets=dataset, integration=integration, limit=10)
print(res)
```


Output:
```bash
 CUDA_VISIBLE_DEVICES=6 python local/scripts/eval.py
2024-03-04 22:58:50 sparseml.evaluation.registry INFO     Auto collected lm-eval-harness integration for eval
2024-03-04:22:58:50,713 INFO     [registry.py:100] Auto collected lm-eval-harness integration for eval
Downloading (…)cial_tokens_map.json: 100%|████████████████████████████████████████████████████| 414/414 [00:00<00:00, 205kB/s]
Downloading (…)okenizer_config.json: 100%|████████████████████████████████████████████████████| 776/776 [00:00<00:00, 848kB/s]
Downloading (…)yment/tokenizer.json: 100%|███████████████████████████████████████████████| 1.76M/1.76M [00:00<00:00, 9.43MB/s]
2024-03-04:22:58:52,393 INFO     [huggingface.py:148] Using device 'cuda'
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████| 2/2 [00:02<00:00,  1.43s/it]
2024-03-04:22:58:58,488 WARNING  [lm_evaluation_harness.py:79] WARNING: --limit SHOULD ONLY BE USED FOR TESTING. REAL METRICS SHOULD NOT BE COMPUTED USING LIMIT.
2024-03-04:22:59:01,312 WARNING  [__init__.py:194] Some tasks could not be loaded due to missing dependencies. Run with `--verbosity DEBUG` for full details.
2024-03-04:22:59:04,012 WARNING  [__init__.py:194] Some tasks could not be loaded due to missing dependencies. Run with `--verbosity DEBUG` for full details.
2024-03-04:22:59:04,012 INFO     [lm_evaluation_harness.py:90] Selected Tasks: ['arc_challenge', 'winogrande']
Downloading readme: 100%|████████████████████████████████████████████████████████████████| 9.00k/9.00k [00:00<00:00, 38.9MB/s]
Downloading data: 100%|█████████████████████████████████████████████████████████████████████| 190k/190k [00:00<00:00, 537kB/s]
Downloading data: 100%|█████████████████████████████████████████████████████████████████████| 204k/204k [00:00<00:00, 615kB/s]
Downloading data: 100%|███████████████████████████████████████████████████████████████████| 55.7k/55.7k [00:00<00:00, 318kB/s]
Downloading data files: 100%|███████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  3.46it/s]
Extracting data files: 100%|██████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 1523.35it/s]
Generating train split: 100%|██████████████████████████████████████████████████| 1119/1119 [00:00<00:00, 230408.75 examples/s]
Generating test split: 100%|███████████████████████████████████████████████████| 1172/1172 [00:00<00:00, 617941.46 examples/s]
Generating validation split: 100%|███████████████████████████████████████████████| 299/299 [00:00<00:00, 245468.17 examples/s]
Downloading builder script: 100%|████████████████████████████████████████████████████████| 5.65k/5.65k [00:00<00:00, 30.7MB/s]
Downloading readme: 100%|████████████████████████████████████████████████████████████████| 9.97k/9.97k [00:00<00:00, 40.0MB/s]
Downloading data: 100%|██████████████████████████████████████████████████████████████████| 3.40M/3.40M [00:00<00:00, 40.3MB/s]
Generating train split: 100%|█████████████████████████████████████████████████| 40398/40398 [00:00<00:00, 41363.16 examples/s]
Generating test split: 100%|████████████████████████████████████████████████████| 1767/1767 [00:00<00:00, 41068.90 examples/s]
Generating validation split: 100%|██████████████████████████████████████████████| 1267/1267 [00:00<00:00, 39451.11 examples/s]
2024-03-04:22:59:09,521 INFO     [task.py:363] Building contexts for task on rank 0...
2024-03-04:22:59:09,530 INFO     [task.py:363] Building contexts for task on rank 0...
2024-03-04:22:59:09,530 INFO     [evaluator.py:324] Running loglikelihood requests
100%|█████████████████████████████████████████████████████████████████████████████████████████| 60/60 [00:05<00:00, 11.96it/s]
formatted=[Evaluation(task='lm-evaluation-harness', dataset=Dataset(type=None, name='arc_challenge', config={'model': '/home/rahul/.cache/sparsezoo/neuralmagic/llama2-7b-llama2_pretrain-base/training/config.json', 'model_args': None, 'batch_size': 1, 'batch_sizes': [], 'device': None, 'use_cache': None, 'limit': 10, 'bootstrap_iters': 100000, 'gen_kwargs': None}, split=None), metrics=[Metric(name='acc,none', value=0.3), Metric(name='acc_stderr,none', value=0.15275252316519464), Metric(name='acc_norm,none', value=0.3), Metric(name='acc_norm_stderr,none', value=0.15275252316519464)], samples=None), Evaluation(task='lm-evaluation-harness', dataset=Dataset(type=None, name='winogrande', config={'model': '/home/rahul/.cache/sparsezoo/neuralmagic/llama2-7b-llama2_pretrain-base/training/config.json', 'model_args': None, 'batch_size': 1, 'batch_sizes': [], 'device': None, 'use_cache': None, 'limit': 10, 'bootstrap_iters': 100000, 'gen_kwargs': None}, split=None), metrics=[Metric(name='acc,none', value=0.8), Metric(name=
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206698210052730