### PR TITLE
Improved Default Targets for SparseGPT

### DIFF
--- a/src/sparseml/core/model/base.py
+++ b/src/sparseml/core/model/base.py
@@ -167,3 +167,6 @@ class ModifiableModel(Generic[MT, LT, PT], MultiFrameworkObject):
         :return: True if QAT is active in any layer, False otherwise
         """
         raise NotImplementedError()
+
+    def get_no_split_params(self) -> Union[str, List[str]]:
+        raise NotImplementedError()

--- a/src/sparseml/core/model/base.py
+++ b/src/sparseml/core/model/base.py
@@ -169,4 +169,9 @@ class ModifiableModel(Generic[MT, LT, PT], MultiFrameworkObject):
         raise NotImplementedError()
 
     def get_no_split_params(self) -> Union[str, List[str]]:
+        """
+        Get list of module classes that shouldn't be split when sharding
+
+        :return: list of class names that shouldn't be split
+        """
         raise NotImplementedError()

--- a/src/sparseml/core/model/pytorch.py
+++ b/src/sparseml/core/model/pytorch.py
@@ -26,6 +26,7 @@ from sparseml.utils.pytorch import (
     get_layers,
     get_layers_params,
     get_matching_layer,
+    get_no_split_params,
     get_param,
     get_params,
     qat_active,
@@ -146,3 +147,6 @@ class ModifiableModelPyTorch(ModifiableModel[Module, Module, Parameter]):
         :return: True if QAT is active in any layer, False otherwise
         """
         return qat_active(self.model)
+
+    def get_no_split_params(self) -> Union[str, List[str]]:
+        return get_no_split_params(self.model)

--- a/src/sparseml/core/model/pytorch.py
+++ b/src/sparseml/core/model/pytorch.py
@@ -149,4 +149,11 @@ class ModifiableModelPyTorch(ModifiableModel[Module, Module, Parameter]):
         return qat_active(self.model)
 
     def get_no_split_params(self) -> Union[str, List[str]]:
+        """
+        Get list of module classes that shouldn't be split when sharding. For
+        Hugging Face Transformer models, this is the decoder layer type. For other
+        types of models, this just returns all module names.
+
+        :return: list of class names that shouldn't be split
+        """
         return get_no_split_params(self.model)

--- a/src/sparseml/modifiers/pruning/wanda/base.py
+++ b/src/sparseml/modifiers/pruning/wanda/base.py
@@ -18,7 +18,6 @@ from typing import Dict, List, Optional, Union
 from sparseml.core import Modifier
 from sparseml.core.model.base import ModifiableModel
 from sparseml.core.state import State
-from sparseml.utils import ALL_TOKEN
 
 
 __all__ = ["WandaPruningModifier"]
@@ -57,7 +56,7 @@ class WandaPruningModifier(Modifier):
     owl_lmbda: Optional[float] = None
     mask_structure: str = "0:0"
     sequential_update: Optional[bool] = False
-    targets: Union[str, List[str], None] = ALL_TOKEN
+    targets: Union[str, List[str], None] = None
     compressible_layers_: Optional[List] = None
     prunen_: Optional[int] = None
     prunem_: Optional[int] = None

--- a/src/sparseml/modifiers/pruning/wanda/pytorch.py
+++ b/src/sparseml/modifiers/pruning/wanda/pytorch.py
@@ -63,6 +63,9 @@ class WandaPruningModifierPyTorch(WandaPruningModifier):
         modifiable_model = state.model
         calibration_dataloader = state.data.calib
 
+        if self.targets is None:
+            self.targets = modifiable_model.get_no_split_params()
+
         self.initialize_compression(modifiable_model, calibration_dataloader)
         self.apply_compression(calibration_dataloader)
 

--- a/src/sparseml/modifiers/pruning/wanda/pytorch.py
+++ b/src/sparseml/modifiers/pruning/wanda/pytorch.py
@@ -64,6 +64,9 @@ class WandaPruningModifierPyTorch(WandaPruningModifier):
         calibration_dataloader = state.data.calib
 
         if self.targets is None:
+            # if no targets are provided, default to the modules that shouldn't be
+            # split by FSDP. For Transformers models this is equivalent to the
+            # decoder layers (ie LlamaDecoderLayer)
             self.targets = modifiable_model.get_no_split_params()
 
         self.initialize_compression(modifiable_model, calibration_dataloader)

--- a/src/sparseml/utils/pytorch/module.py
+++ b/src/sparseml/utils/pytorch/module.py
@@ -98,6 +98,17 @@ def match_targets(name: str, targets: Union[str, List[str]]) -> Tuple[bool, int]
     return False, -1
 
 
+def match_class(layer: Module, targets: Union[str, List[str]]) -> Tuple[bool, int]:
+    if isinstance(targets, str):
+        targets = [targets]
+
+    for index, target in enumerate(targets):
+        if layer.__class__.__name__ == target:
+            return True, index
+
+    return False, -1
+
+
 def get_default_params(layers: Dict[str, Module]) -> Dict[str, Parameter]:
     params = {}
     for name, layer in layers.items():
@@ -139,6 +150,11 @@ def match_layers_params(
         if match and not params:
             targets_found[match_index] = True
             resolved[name] = layer
+        else:
+            match, match_index = match_class(layer, targets)
+            if match:
+                targets_found[match_index] = True
+                resolved[name] = layer
 
         for param_name, param in layer.named_parameters():
             if "." in param_name:  # skip parameters of nested layers

--- a/src/sparseml/utils/pytorch/module.py
+++ b/src/sparseml/utils/pytorch/module.py
@@ -335,10 +335,17 @@ def get_matching_layer(
 
 
 def get_no_split_params(module: Module) -> Union[str, List[str]]:
+    """
+    Get list of module classes that shouldn't be split when sharding. For
+    Hugging Face Transformer models, this is the decoder layer type. For other
+    types of models, this just returns all module names.
+
+    :return: list of class names that shouldn't be split
+    """
     # importing here to avoid circular import
     from sparseml.utils.fsdp.helpers import maybe_get_wrapped
 
     model = maybe_get_wrapped(module)
     if hasattr(model, "_no_split_modules"):
         return model._no_split_modules
-    return ALL_PRUNABLE_TARGET
+    return ALL_TARGET

--- a/src/sparseml/utils/pytorch/module.py
+++ b/src/sparseml/utils/pytorch/module.py
@@ -80,7 +80,6 @@ _PARSED_TORCH_VERSION = version.parse(torch.__version__)
 ALL_TARGET = "__ALL__"
 ALL_PRUNABLE_TARGET = "__ALL_PRUNABLE__"
 ALL_QUANTIZABLE_TARGET = "__ALL_QUANTIZABLE__"
-ALL_NO_SPLIT_MODULES = "__ALL_NO_SPLIT_MODULES__"
 
 
 def match_targets(name: str, targets: Union[str, List[str]]) -> Tuple[bool, int]:

--- a/src/sparseml/utils/pytorch/module.py
+++ b/src/sparseml/utils/pytorch/module.py
@@ -70,6 +70,7 @@ __all__ = [
     "qat_active",
     "get_layers_params",
     "get_matching_layer",
+    "get_no_split_params",
 ]
 
 
@@ -79,6 +80,7 @@ _PARSED_TORCH_VERSION = version.parse(torch.__version__)
 ALL_TARGET = "__ALL__"
 ALL_PRUNABLE_TARGET = "__ALL_PRUNABLE__"
 ALL_QUANTIZABLE_TARGET = "__ALL_QUANTIZABLE__"
+ALL_NO_SPLIT_MODULES = "__ALL_NO_SPLIT_MODULES__"
 
 
 def match_targets(name: str, targets: Union[str, List[str]]) -> Tuple[bool, int]:
@@ -314,3 +316,13 @@ def get_matching_layer(
             largest_substring = match_length
 
     return match
+
+
+def get_no_split_params(module: Module) -> Union[str, List[str]]:
+    # importing here to avoid circular import
+    from sparseml.utils.fsdp.helpers import maybe_get_wrapped
+
+    model = maybe_get_wrapped(module)
+    if hasattr(model, "_no_split_modules"):
+        return model._no_split_modules
+    return ALL_PRUNABLE_TARGET


### PR DESCRIPTION
Previously if the `targets` field wasn't filled out, we would default to `ALL_TOKEN`. This default isn't functional because nested modules get run multiple times. A better default is to target all of the decoder layers. The path to these layers varies between models, but we can infer it utilizing `PretrainedModel._no_split_modules`

### Testing
```
from sparseml.core import Framework,ModifiableModel
from sparseml.modifiers.obcq.pytorch import SparseGPTModifierPyTorch
from sparseml.transformers import SparseAutoModelForCausalLM

model = SparseAutoModelForCausalLM.from_pretrained("Xenova/llama2.c-stories15M")
modifiable_model = ModifiableModel(framework=Framework.pytorch, model=model)
targets = modifiable_model.get_no_split_params()
print(targets)

modifier = SparseGPTModifierPyTorch(sparsity=0.5)
modifier.targets = targets
modifier.model = modifiable_model
compressible_layers = modifier.compressible_layers()
print(compressible_layers.keys())
```

```
['LlamaDecoderLayer']
dict_keys(['model.layers.0', 'model.layers.1', 'model.layers.2', 'model.layers.3', 'model.layers.4', 'model.layers.5'])
```