### PR TITLE
[BugFix] Stronger check for wandb availability

### DIFF
--- a/src/sparseml/utils/helpers.py
+++ b/src/sparseml/utils/helpers.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# flake8: noqa #E501
 
 """
 General utility helper functions.
@@ -20,6 +21,8 @@ Common functions for interfacing with python primitives and directories/files.
 import ast
 import errno
 import fnmatch
+import importlib.metadata
+import importlib.util
 import json
 import logging
 import os
@@ -70,6 +73,7 @@ __all__ = [
     "deprecation_warning",
     "parse_kwarg_tuples",
     "download_zoo_training_dir",
+    "is_package_available",
 ]
 
 
@@ -935,3 +939,38 @@ def download_zoo_training_dir(zoo_stub: str) -> str:
         file_name.path
 
     return training_dir_path
+
+
+def is_package_available(
+    package_name: str,
+    return_version: bool = False,
+) -> Union[Tuple[bool, str], bool]:
+    """
+    A helper function to check if a package is available
+    and optionally return its version. This function enforces
+    a check that the package is available and is not
+    just a directory/file with the same name as the package.
+
+    inspired from:
+    https://github.com/huggingface/transformers/blob/965cf677695dd363285831afca8cf479cf0c600c/src/transformers/utils/import_utils.py#L41
+
+    :param package_name: The package name to check for
+    :param return_version: True to return the version of
+        the package if available
+    :return: True if the package is available, False otherwise or a tuple of
+        (bool, version) if return_version is True
+    """
+
+    package_exists = importlib.util.find_spec(package_name) is not None
+    package_version = "N/A"
+    if package_exists:
+        try:
+            package_version = importlib.metadata.version(package_name)
+            package_exists = True
+        except importlib.metadata.PackageNotFoundError:
+            package_exists = False
+        _LOGGER.debug(f"Detected {package_name} version {package_version}")
+    if return_version:
+        return package_exists, package_version
+    else:
+        return package_exists


### PR DESCRIPTION
# Bug

A bug was revealed where if a `wandb` directory was present (at the level of running script); `WANDBLogger.available()` would return `True` as it only relied on import; this would inturn lead to uninteded creation of this logger object that would fail down the line.

This PR fixes that.


## Contributions

* Utility method to check if a package is available and not just a directory
* Use that function to check for wandb availability

### Test

directory structure (Note has a `wandb` directory):
```bash
$ tree -d -L 1                            
.
├── docker
├── docs
├── integrations
├── local
├── nm_temp_test_logs
├── research
├── sparse_logs
├── src
├── status
├── tensorboard
├── tests
├── utils
└── wandb
```

plain import would still work:

`$ python -c 'import wandb'`

But `WANDBLogger` will not allow instanciation

```bash
$ python -i src/sparseml/core/logger/logger.py 
>>> WANDBLogger.available()
False
>>> WANDBLogger()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/rahul/projects/sparseml/src/sparseml/core/logger/logger.py", line 596, in __init__
    raise wandb_err
ModuleNotFoundError: `wandb` is not installed, use `pip install wandb` to log to Weights and Biases
>>> 
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206776386608816