### PR TITLE
Allow Passing in Instantiated Teacher

### DIFF
--- a/src/sparseml/transformers/finetune/model_args.py
+++ b/src/sparseml/transformers/finetune/model_args.py
@@ -30,6 +30,12 @@ class ModelArguments:
             )
         },
     )
+    distill_teacher: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Teacher model (a trained text generation model)",
+        },
+    )
     config_name: Optional[str] = field(
         default=None,
         metadata={

--- a/src/sparseml/transformers/finetune/text_generation.py
+++ b/src/sparseml/transformers/finetune/text_generation.py
@@ -156,10 +156,10 @@ def intialize_model_from_path(
     )
     teacher_config = (
         AutoConfig.from_pretrained(
-            training_args.distill_teacher,
+            model_args.distill_teacher,
             use_auth_token=True if model_args.use_auth_token else None,
         )
-        if training_args.distill_teacher
+        if model_args.distill_teacher
         else None
     )
 
@@ -209,11 +209,11 @@ def intialize_model_from_path(
 
     teacher = (
         SparseAutoModel.text_generation_from_pretrained(
-            model_name_or_path=training_args.distill_teacher,
+            model_name_or_path=model_args.distill_teacher,
             sequence_length=None,  # use model default
             **teacher_kwargs,
         )
-        if training_args.distill_teacher is not None
+        if model_args.distill_teacher is not None
         else None
     )
 
@@ -290,7 +290,7 @@ def main(
 
     # Detecting last checkpoint.
     last_checkpoint = None
-    teacher = None
+    teacher = model_args.distill_teacher
     model_path = None
     model = model_args.model
     # Load tokenizer

--- a/src/sparseml/transformers/finetune/training_args.py
+++ b/src/sparseml/transformers/finetune/training_args.py
@@ -32,12 +32,6 @@ class TrainingArguments(HFTrainingArgs):
         arguments
     """
 
-    distill_teacher: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": "Teacher model (a trained text generation model)",
-        },
-    )
     best_model_after_epoch: int = field(
         default=None,
         metadata={"help": "Epoch after which best model will be saved."},


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1206109050183159/1206788571042422/f 

We had missed support for passing in an instantiated teacher to the finetuning code, this PR adds in it 

### Testing

script would fail on main, training starts as intended here:
```python
from sparseml.transformers import compress, SparseAutoModelForCausalLM, SparseAutoTokenizer, load_dataset

model = SparseAutoModelForCausalLM.from_pretrained("zoo:llama2-7b-ultrachat200k_llama2_pretrain-base", device_map="auto")
teacher = SparseAutoModelForCausalLM.from_pretrained("zoo:llama2-7b-open_platypus_orca_llama2_pretrain-base", device_map="auto")
tokenizer = SparseAutoTokenizer.from_pretrained("zoo:llama2-7b-ultrachat200k_llama2_pretrain-base")
recipe = "zoo:llama2-7b-ultrachat200k_llama2_pretrain-pruned40"
dataset = load_dataset("garage-bAInd/Open-Platypus")

def format_data(data):
    data["text"] = data["instruction"] + data["output"]
    return data

dataset = dataset.map(format_data)

compress(
    model=model,
    tokenizer=tokenizer,
    distill_teacher=teacher,
    dataset=dataset,
    recipe=recipe,
    num_train_epochs=1,
    output_dir="./output",
)

```