### PR TITLE
Fix One-Shot FSDP Memory Spike

### DIFF
--- a/src/sparseml/modifiers/utils/layer_compressor.py
+++ b/src/sparseml/modifiers/utils/layer_compressor.py
@@ -122,8 +122,7 @@ class LayerCompressor:
         Reverts wrapped root modules back to their original structure
         """
         for name, module_wrapper in self.modules.items():
-            full_name = self._get_full_submodule_name(name)
-            set_layer(full_name, module_wrapper.layer, self.model)
+            set_layer(name, module_wrapper.layer, self.layer)
             module_wrapper.free()
         self.modules = None
 


### PR DESCRIPTION
On main we were getting a spike in GPU memory when cleaning up compression for a transformer layer. This was causing an OOM error with FSDP oneshot: https://app.asana.com/0/1206109050183159/1206698210421769/f 

This was caused because the set_layer function triggers a parameter gather. We were calling set_layer on the whole model when it should only be called on the current transformer layer. Fixing this resolved the memory spike, now the process can complete on 48GB GPUs

### Test Script
```
from sparseml.transformers import compress, SparseAutoModelForCausalLM, SparseAutoTokenizer, load_dataset

model = SparseAutoModelForCausalLM.from_pretrained("zoo:llama2-7b-ultrachat200k_llama2_pretrain-base")
tokenizer = SparseAutoTokenizer.from_pretrained("zoo:llama2-7b-ultrachat200k_llama2_pretrain-base")
dataset="open_platypus"
MODEL_STUB="zoo:llama2-7b-ultrachat200k_llama2_pretrain-pruned40.oneshot"

compress(
    model=model,
    tokenizer=tokenizer,
    dataset=dataset,
    recipe=MODEL_STUB,
    output_dir="./output"
)
```

Launch with FSDP: `accelerate launch --config_file fsdp_config.yaml test.py`