### PR TITLE
Fix for OOM Errors during Ultrachat200k Finetuning

### DIFF
--- a/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
+++ b/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
@@ -1,7 +1,6 @@
 compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: FSDP
-downcast_bf16: 'no'
 fsdp_config:
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
   fsdp_backward_prefetch_policy: BACKWARD_PRE
@@ -15,7 +14,7 @@ fsdp_config:
 machine_rank: 0
 main_training_function: main
 num_machines: 1
-num_processes: 2
+num_processes: 6
 rdzv_backend: static
 same_network: true
 tpu_env: []

--- a/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
+++ b/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
@@ -1,6 +1,7 @@
 compute_environment: LOCAL_MACHINE
 debug: false
 distributed_type: FSDP
+downcast_bf16: 'no'
 fsdp_config:
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
   fsdp_backward_prefetch_policy: BACKWARD_PRE
@@ -14,7 +15,7 @@ fsdp_config:
 machine_rank: 0
 main_training_function: main
 num_machines: 1
-num_processes: 6
+num_processes: 2
 rdzv_backend: static
 same_network: true
 tpu_env: []

--- a/src/sparseml/modifiers/pruning/constant/pytorch.py
+++ b/src/sparseml/modifiers/pruning/constant/pytorch.py
@@ -71,6 +71,9 @@ class ConstantPruningModifierPyTorch(ConstantPruningModifier, LayerParamMasking)
             def apply_masks(module):
                 mask_name = param_mask_name()
                 if hasattr(module, mask_name):
+                    mask = getattr(module, mask_name)
+                    if mask.device != module.weight.device:
+                        setattr(module, mask_name, mask.to(module.weight.device))
                     module.weight *= getattr(module, mask_name)
 
             state.model.model.apply(apply_masks)

--- a/src/sparseml/transformers/finetune/runner.py
+++ b/src/sparseml/transformers/finetune/runner.py
@@ -40,9 +40,7 @@ from sparseml.transformers.finetune.data.data_helpers import (
 )
 from sparseml.transformers.finetune.model_args import ModelArguments
 from sparseml.transformers.finetune.training_args import TrainingArguments
-from sparseml.utils.fsdp.context import summon_full_params_context
 from sparseml.utils.fsdp.helpers import is_fsdp_model, unwrap_and_export_model
-from sparseml.utils.pytorch import qat_active
 
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -286,12 +284,6 @@ class StageRunner:
             # setup for next stage
             session = session_manager.active_session()
             session.reset_stage()
-
-            # log model sparsity
-            with summon_full_params_context(self.trainer.model):
-                if self.trainer.accelerator.is_main_process:
-                    if not qat_active(self.trainer.model):
-                        self.trainer.log_model_sparsification()
 
             # synchronize and clean up memory
             self.trainer.accelerator.wait_for_everyone()

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -137,7 +137,7 @@ class SessionManagerMixIn:
         train_data = self.get_train_dataloader()
 
         self.accelerator.wait_for_everyone()
-        with summon_full_params_context(self.model):
+        with summon_full_params_context(self.model, offload_to_cpu=True):
             session_manager.initialize(
                 model=self.model,
                 teacher_model=self.teacher,  # TODO: what about for self/disable?

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -40,6 +40,7 @@ from sparseml.transformers.finetune.callbacks import (
 )
 from sparseml.utils.fsdp.context import summon_full_params_context
 from sparseml.utils.fsdp.helpers import is_fsdp_model, save_pretrained_fsdp
+from sparseml.utils.pytorch import qat_active
 
 
 __all__ = [
@@ -370,9 +371,13 @@ class SessionManagerMixIn:
 
         self.accelerator.wait_for_everyone()
 
-        # Need to gather parameters across the GPUs before accessing layer weights
-        with summon_full_params_context(self.model):
-            self.log_model_sparsification()
+        # log model sparsity
+        with summon_full_params_context(self.model, offload_to_cpu=True):
+            if self.accelerator.is_main_process:
+                if not qat_active(self.model):
+                    self.log_model_sparsification()
+
+        self.accelerator.wait_for_everyone()
 
         return output
 
@@ -433,6 +438,12 @@ class SessionManagerMixIn:
             copy_data=False,
             accelerator=self.accelerator,
         )
+
+        # log model sparsity
+        with summon_full_params_context(self.model, offload_to_cpu=True):
+            if self.accelerator.is_main_process:
+                if not qat_active(self.model):
+                    self.log_model_sparsification()
 
         self.accelerator.wait_for_everyone()
 


### PR DESCRIPTION
The following SparseZoo recipes were causing OOM errors even with FSDP:
* "zoo:llama2-7b-ultrachat200k_llama2_pretrain-pruned40"
* "zoo:llama2-7b-ultrachat200k_llama2_pretrain-pruned40_quantized"

The fix was to offload weights to CPU when gathering FSDP params during modifier initialization and finalization

### Test
Tested on 6 48GB GPUs. Example only runs a few training samples for ease of testing.

```python
from sparseml.transformers import compress, SparseAutoModelForCausalLM, SparseAutoTokenizer

model = SparseAutoModelForCausalLM.from_pretrained("zoo:llama2-7b-ultrachat200k_llama2_pretrain-base")
teacher = SparseAutoModelForCausalLM.from_pretrained("zoo:llama2-7b-ultrachat200k_llama2_pretrain-base")
tokenizer = SparseAutoTokenizer.from_pretrained("zoo:llama2-7b-ultrachat200k_llama2_pretrain-base")
dataset="open_platypus"
MODEL_STUB="zoo:llama2-7b-ultrachat200k_llama2_pretrain-pruned40"

compress(
    model=model,
    distill_teacher=teacher,
    tokenizer=tokenizer,
    dataset=dataset,
    recipe=MODEL_STUB,
    output_dir="./output",
    gradient_checkpointing = True,
    num_train_epochs=0.02
)
```

Run with FSDP: `accelerate launch --config_file fsdp_config.yaml test.py`