### PR TITLE
[Bugfix] for saving quantized models trained using fsdp

### DIFF
--- a/src/sparseml/utils/fsdp/helpers.py
+++ b/src/sparseml/utils/fsdp/helpers.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import operator
+from pathlib import Path
 from typing import Optional, Union
 
 
@@ -25,6 +27,7 @@ try:
 except ImportError:
     FullyShardedDataParallel = None
 
+import torch
 from torch.nn import Module
 
 from sparseml.core.model import ModifiableModel
@@ -39,7 +42,10 @@ __all__ = [
     "unwrap_and_export_model",
     "save_pretrained_fsdp",
     "get_fsdp_parent",
+    "find_and_move_state_dicts_to_cpu",
 ]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def is_fsdp_model(model: Module) -> bool:
@@ -111,6 +117,27 @@ def unwrap_and_export_model(model, accelerator, output_dir, tokenizer):
             save_path=output_dir,
             tokenizer=tokenizer,
         )
+
+
+def find_and_move_state_dicts_to_cpu(output_dir: str):
+    """
+    Looks for state dicts in the output directory and overwrites them
+    with cpu state dicts.
+
+    this is needed for quantized models trained with FSDP as the state dict
+    contains device information, which can cause issues when loading the model
+    using transformers AutoModel.from_pretrained(...) if the device information
+    is not removed, assumes the state dicts are named pytorch_model*.bin
+    """
+
+    for model_file in Path(output_dir).rglob("pytorch_model*.bin"):
+        loaded_dict = torch.load(model_file)
+        for key, value in loaded_dict.items():
+            if isinstance(value, torch.Tensor):
+                loaded_dict[key] = value.cpu()
+
+        torch.save(loaded_dict, model_file)
+        _LOGGER.info(f"Moved state dict {model_file} to cpu")
 
 
 def save_pretrained_fsdp(model, accelerator, output_dir, save_safetensors: bool = True):


### PR DESCRIPTION
# Bugfix for Saving Quantized Models Trained Using FSDP

This description details a bugfix for an issue encountered when loading quantized models that were trained using Fully Sharded Data Parallel (FSDP). 

The issue originated from the process of quantization, during which we updated layer names and saved them using our custom implementation instead of `accelerate`. This approach resulted in an incorrectly saved `state_dict`, as each tensor had device information associated with it. Consequently, the model could not be loaded properly using the transformer's `AutoModel.from_pretrained(...)` method.

The modifications in this update address these complications, ensuring that quantized models trained using FSDP can now be saved and loaded correctly.

## Changes
- [Asana Ticket](https://app.asana.com/0/1206109050183159/1206841566630295/f)
- Relevant code modifications have been made to fix the saved state dicts for quantized models trained with FSDP.

The solution includes a post-processing step where we explicitly iterate through the `state_dict` and move each tensor to the CPU. The corrected `state_dict` is then overwritten on the previous, faulty `state_dict`.

## Testing

The saved quantized models can now be loaded by `SparseAutoModel.from_pretrained(...)`. This has been verified manually. The test commands in the ticket work as expected.

## Benefits
- This fix improves compatibility when saving quantized models trained using FSDP.