### PR TITLE
Fix Distill Teacher Eval Mode

### DIFF
--- a/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
+++ b/integrations/huggingface-transformers/finetuning/example_fsdp_config.yaml
@@ -15,7 +15,7 @@ fsdp_config:
 machine_rank: 0
 main_training_function: main
 num_machines: 1
-num_processes: 2
+num_processes: 4
 rdzv_backend: static
 same_network: true
 tpu_env: []

--- a/src/sparseml/modifiers/distillation/utils/pytorch/model_wrapper.py
+++ b/src/sparseml/modifiers/distillation/utils/pytorch/model_wrapper.py
@@ -49,7 +49,6 @@ class KDModelWrapper(Module):
         self.register_load_state_dict_post_hook(_clear_missing_keys)
 
     def forward(self, *args, **kwargs):
-        self.teacher_model.eval()
         if not self.kd_enabled:
             return self.student_model(*args, **kwargs)
 
@@ -117,6 +116,13 @@ class KDModelWrapper(Module):
         return self.student_model.named_modules(
             memo=memo, prefix=prefix, remove_duplicate=remove_duplicate
         )
+
+    def named_children(self):
+        return self.student_model.named_children()
+    
+    def train(self, mode: bool = True):
+        self.student_model.train(mode)
+        return self
 
     def __getattr__(self, name: str) -> Any:
         try:

--- a/src/sparseml/modifiers/distillation/utils/pytorch/model_wrapper.py
+++ b/src/sparseml/modifiers/distillation/utils/pytorch/model_wrapper.py
@@ -119,7 +119,7 @@ class KDModelWrapper(Module):
 
     def named_children(self):
         return self.student_model.named_children()
-    
+
     def train(self, mode: bool = True):
         self.student_model.train(mode)
         return self

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -515,6 +515,8 @@ class SessionManagerMixIn:
 
         if self.teacher is not None:
             self.teacher.to("cpu")
+            for n, p in self.teacher.named_parameters():
+                p.requires_grad = False
             self.teacher = self.accelerator.prepare(self.teacher)
             self.teacher.eval()
             self.accelerator.wait_for_everyone()


### PR DESCRIPTION
We were previously having to set the teacher to eval mode on each forward pass in distillation. This ended up being caused by how we were wrapping the teacher model into the student. By overwriting the train() function in `KDModelWrapper` to only affect the student, we keep the teacher in eval_mode for the whole run.

This gives a minor speed boost but doesn't fully fix the runtime discrepancies between llama-recipes and SparseML. Running bf16 distillation on a llama1.1b model on GPU6(4 active GPUs, device batch size 8) we get:
* 1.6sec/batch on main
* 1.5sec/batch on this branch
* 1.1sec/batch on llama-recipes
