### PR TITLE
One shot user flow tweaks

### DIFF
--- a/src/sparseml/transformers/finetune/data/custom.py
+++ b/src/sparseml/transformers/finetune/data/custom.py
@@ -20,7 +20,7 @@ from sparseml.transformers.finetune.data import TextGenerationDataset
 from sparseml.transformers.utils.preprocessing_functions import (
     PreprocessingFunctionRegistry,
 )
-from sparsezoo.utils.helpers import import_from_path
+# from sparsezoo.utils.helpers import import_from_path
 
 
 @TextGenerationDataset.register(name="custom", alias=["json", "csv"])

--- a/src/sparseml/transformers/finetune/runner.py
+++ b/src/sparseml/transformers/finetune/runner.py
@@ -154,7 +154,6 @@ class StageRunner:
         tokenized_dataset = self.get_dataset_split("calibration")
         if "labels" in tokenized_dataset.column_names:
             tokenized_dataset = tokenized_dataset.remove_columns("labels")
-    
         calib_data = format_calibration_data(
             tokenized_dataset=tokenized_dataset,
             num_calibration_samples=self._data_args.num_calibration_samples,

--- a/src/sparseml/transformers/finetune/runner.py
+++ b/src/sparseml/transformers/finetune/runner.py
@@ -151,8 +151,12 @@ class StageRunner:
         """
         _LOGGER.info("*** One Shot ***")
 
+        tokenized_dataset = self.get_dataset_split("calibration")
+        if "labels" in tokenized_dataset.column_names:
+            tokenized_dataset = tokenized_dataset.remove_columns("labels")
+    
         calib_data = format_calibration_data(
-            tokenized_dataset=self.get_dataset_split("calibration"),
+            tokenized_dataset=tokenized_dataset,
             num_calibration_samples=self._data_args.num_calibration_samples,
             accelerator=self.trainer.accelerator,
         )

--- a/src/sparseml/transformers/integration_helper_functions.py
+++ b/src/sparseml/transformers/integration_helper_functions.py
@@ -47,6 +47,7 @@ from sparseml.transformers.utils.initializers import (
 from sparseml.transformers.utils.load_task_dataset import load_task_dataset
 from sparseml.transformers.utils.optimizations import apply_kv_cache_injection
 
+MAXIMUM_SEQUENCE_LENGTH = 32000
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,10 +145,14 @@ def create_data_loader(
     source_path = source_path or model.name_or_path
     if tokenizer is None:
         if sequence_length is None:
-            raise ValueError(
-                "Sequence length for the transformer model export missing. "
-                "Provide it manually using sequence_length argument"
-            )
+            if hasattr(model.config, "max_position_embeddings"):
+                sequence_length = model.config.max_position_embeddings
+            else:
+                raise ValueError(
+                    "Sequence length for the transformer model export missing and "
+                    "could not detect using model.config.max_position_embeddings"
+                    "Provide it manually using sequence_length argument"
+                )
         tokenizer = initialize_tokenizer(config.name_or_path, sequence_length, task)
     data_args = _parse_data_args(data_args or {})
 

--- a/src/sparseml/transformers/integration_helper_functions.py
+++ b/src/sparseml/transformers/integration_helper_functions.py
@@ -47,6 +47,7 @@ from sparseml.transformers.utils.initializers import (
 from sparseml.transformers.utils.load_task_dataset import load_task_dataset
 from sparseml.transformers.utils.optimizations import apply_kv_cache_injection
 
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/sparseml/transformers/integration_helper_functions.py
+++ b/src/sparseml/transformers/integration_helper_functions.py
@@ -47,8 +47,6 @@ from sparseml.transformers.utils.initializers import (
 from sparseml.transformers.utils.load_task_dataset import load_task_dataset
 from sparseml.transformers.utils.optimizations import apply_kv_cache_injection
 
-MAXIMUM_SEQUENCE_LENGTH = 32000
-
 _LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION


Enables:
- applying one shot to BERT (previously would fail b/c `labels` are not allowed to be passed to BERT)
- calling export on a model rather than on a file path (previously would fail during `helper_functions.create_data_loader` b/c `sequence_length` is calculated during `helper_functions.create_model`, which does not run if a `model` is passed to `export`

Also, there seems to be a stray import from sparsezoo which is failing

- Note: need to check whether the labels change impacts the LLMs (though I don't think the labels are used here)