### PR TITLE
relax nm-yolov5 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ _transformers_deps = _pytorch_deps + [
 ]
 _llm_deps = _transformers_deps + ["sentencepiece"]
 _yolov5_deps = _pytorch_vision_deps + [
-    f"{'nm-yolov5' if is_release else 'nm-yolov5-nightly'}~={version_nm_deps}"
+    f"{'nm-yolov5' if is_release else 'nm-yolov5-nightly'}<={version_nm_deps}"
 ]
 _notebook_deps = [
     "jupyter>=1.0.0",


### PR DESCRIPTION
future releases of nm-yolov5 are not currently planned, moving forward the version requirement will be changed to `<=` so we do not need to create empty releases for compatibility