### PR TITLE
Support for Decompressing Models from HF Hub

### DIFF
--- a/src/sparseml/export/validators.py
+++ b/src/sparseml/export/validators.py
@@ -17,8 +17,9 @@ import logging
 import os.path
 from collections import OrderedDict
 from pathlib import Path
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional
 from typing import OrderedDict as OrderedDictType
+from typing import Union
 
 import numpy
 import onnx

--- a/src/sparseml/transformers/compression/compressors/base.py
+++ b/src/sparseml/transformers/compression/compressors/base.py
@@ -74,7 +74,7 @@ class ModelCompressor(RegistryMixin):
         """
         Overwrites the weights in model with weights decompressed from model_path
 
-        :param pretrained_model_path: path to compressed weights
+        :param model_path: path to compressed weights
         :param model: pytorch model to load decompressed weights into
         """
         dense_gen = self.decompress(model_path)

--- a/src/sparseml/transformers/compression/compressors/base.py
+++ b/src/sparseml/transformers/compression/compressors/base.py
@@ -70,15 +70,14 @@ class ModelCompressor(RegistryMixin):
         model_device = operator.attrgetter(param_name)(model).device
         set_layer(param_name, Parameter(data.to(model_device)), model)
 
-    def overwrite_weights(self, pretrained_model_name_or_path: str, model: Module):
+    def overwrite_weights(self, model_path: str, model: Module):
         """
-        Overwrites the weights in model with weights decompressed from
-        pretrained_model_name_or_path
+        Overwrites the weights in model with weights decompressed from model_path
 
-        :param pretrained_model_name_or_path: path to compressed weights
+        :param pretrained_model_path: path to compressed weights
         :param model: pytorch model to load decompressed weights into
         """
-        dense_gen = self.decompress(pretrained_model_name_or_path)
+        dense_gen = self.decompress(model_path)
         for name, data in tqdm(dense_gen, desc="Decompressing model"):
             ModelCompressor.replace_layer(name, data, model)
         setattr(model, SPARSITY_CONFIG_NAME, self.config)

--- a/src/sparseml/transformers/compression/utils/safetensors_load.py
+++ b/src/sparseml/transformers/compression/utils/safetensors_load.py
@@ -34,6 +34,15 @@ __all__ = [
 def get_safetensors_folder(
     pretrained_model_name_or_path: str, cache_dir: Optional[str] = None
 ) -> str:
+    """
+    Given a Hugging Face stub or a local path, return the folder containing the
+    safetensors weight files
+
+    :param pretrained_model_name_or_path: local path to model or HF stub
+    :param cache_dir: optional cache dir to search through, if none is specified the
+    model will be searched for in the default TRANSFORMERS_CACHE
+    :return: local folder containing model data
+    """
     if os.path.exists(pretrained_model_name_or_path):
         # argument is a path to a local folder
         return pretrained_model_name_or_path
@@ -51,12 +60,15 @@ def get_safetensors_folder(
         _raise_exceptions_for_missing_entries=False,
     )
     if safetensors_path is not None:
+        # found a single cached safetensors file
         return os.path.split(safetensors_path)[0]
     if index_path is not None:
+        # found a cached safetensors weight index file
         return os.path.split(index_path)[0]
 
+    # model weights could not be found locally or cached from HF Hub
     raise ValueError(
-        "Could not find a safetensors weight or index file at "
+        "Could not locate safetensors weight or index file from "
         f"{pretrained_model_name_or_path}."
     )
 

--- a/src/sparseml/transformers/sparsification/sparse_model.py
+++ b/src/sparseml/transformers/sparsification/sparse_model.py
@@ -129,12 +129,14 @@ class SparseAutoModelForCausalLM(AutoModelForCausalLM):
 
         # If model is compressed on disk, decompress and load the weights
         if compressor is not None:
+            # if we loaded from a HF stub, find the cached model
             model_path = get_safetensors_folder(
                 pretrained_model_name_or_path, cache_dir=kwargs.get("cache_dir", None)
             )
-            compressor.overwrite_weights(
-                pretrained_model_name_or_path=model_path, model=model
-            )
+
+            # decompress weights
+            compressor.overwrite_weights(model_path=model_path, model=model)
+
         recipe = resolve_recipe(recipe=recipe, model_path=pretrained_model_name_or_path)
         if recipe:
             apply_recipe_structure_to_model(

--- a/src/sparseml/transformers/sparsification/sparse_model.py
+++ b/src/sparseml/transformers/sparsification/sparse_model.py
@@ -35,6 +35,7 @@ from sparseml.pytorch.model_load.helpers import (
     log_model_load,
 )
 from sparseml.transformers.compression.utils import (
+    get_safetensors_folder,
     infer_compressor_from_model_config,
     modify_save_pretrained,
 )
@@ -128,8 +129,11 @@ class SparseAutoModelForCausalLM(AutoModelForCausalLM):
 
         # If model is compressed on disk, decompress and load the weights
         if compressor is not None:
+            model_path = get_safetensors_folder(
+                pretrained_model_name_or_path, cache_dir=kwargs.get("cache_dir", None)
+            )
             compressor.overwrite_weights(
-                pretrained_model_name_or_path=pretrained_model_name_or_path, model=model
+                pretrained_model_name_or_path=model_path, model=model
             )
         recipe = resolve_recipe(recipe=recipe, model_path=pretrained_model_name_or_path)
         if recipe:


### PR DESCRIPTION
The original compression PR neglected to test loading a compressed model from the hub, and was only working with local compression loads. This PR adds support for loading a compressed model from the hub with `SparseAutoModelForCausalLM.from_pretrained`. 

### Test
Loads the compressed model from the hub, checks the decompressed weights match the original
```python
from sparseml.transformers import SparseAutoModelForCausalLM, SparseAutoTokenizer
import torch

ORIG_MODEL_PATH = "neuralmagic/TinyLlama-1.1B-Chat-v1.0-pruned2.4"
COMPRESSED_MODEL_PATH = "mgoin/TinyLlama-1.1B-Chat-v1.0-pruned2.4-compressed"

# Compress and export the model
model = SparseAutoModelForCausalLM.from_pretrained(ORIG_MODEL_PATH, device_map="auto", torch_dtype="auto")
tokenizer = SparseAutoTokenizer.from_pretrained(ORIG_MODEL_PATH)

model_compressed = SparseAutoModelForCausalLM.from_pretrained(COMPRESSED_MODEL_PATH, device_map="auto", torch_dtype="auto")

og_state_dict = model.state_dict()
reconstructed_state_dict = model_compressed.state_dict()
assert(len(og_state_dict) == len(reconstructed_state_dict))
for key in og_state_dict.keys():
    dense_tensor = og_state_dict[key]
    reconstructed_tensor = reconstructed_state_dict[key]
    assert torch.equal(dense_tensor.cpu(), reconstructed_tensor.cpu())
```