### PR TITLE
Fix Python 3.8 Compatibility 

### DIFF
--- a/src/sparseml/export/validators.py
+++ b/src/sparseml/export/validators.py
@@ -17,8 +17,9 @@ import logging
 import os.path
 from collections import OrderedDict
 from pathlib import Path
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional
 from typing import OrderedDict as OrderedDictType
+from typing import Union
 
 import numpy
 import onnx

--- a/src/sparseml/transformers/compression/compressors/sparse_bitmask.py
+++ b/src/sparseml/transformers/compression/compressors/sparse_bitmask.py
@@ -70,7 +70,7 @@ class BitmaskCompressor(ModelCompressor):
                         f"found an existing entry for {key}. The existing entry will "
                         "be replaced."
                     )
-            compressed_dict |= bitmask_dict
+            compressed_dict.update(bitmask_dict)
 
         return compressed_dict
 


### PR DESCRIPTION
Changing dictionary update from `|=` to `.update`