### PR TITLE
[Fix] Resolve Errors When Loading Multiple Quantized Models

### DIFF
--- a/src/sparseml/transformers/sparsification/sparse_model.py
+++ b/src/sparseml/transformers/sparsification/sparse_model.py
@@ -30,6 +30,7 @@ from transformers import (
 )
 from transformers.file_utils import WEIGHTS_NAME
 
+from sparseml.core.utils import session_context_manager
 from sparseml.pytorch.model_load.helpers import (
     apply_recipe_structure_to_model,
     log_model_load,
@@ -131,11 +132,13 @@ class SparseAutoModelForCausalLM(AutoModelForCausalLM):
 
         recipe = resolve_recipe(recipe=recipe, model_path=pretrained_model_name_or_path)
         if recipe:
-            apply_recipe_structure_to_model(
-                model=model,
-                model_path=pretrained_model_name_or_path,
-                recipe_path=recipe,
-            )
+            with session_context_manager():
+
+                apply_recipe_structure_to_model(
+                    model=model,
+                    model_path=pretrained_model_name_or_path,
+                    recipe_path=recipe,
+                )
         return model
 
 


### PR DESCRIPTION
### Description

A bug was discovered in the main branch where loading two or more quantized models sequentially with `SparseAutoModelForCausalLM.from_pretrained(...)` led to errors. This occurred because the `active_session` was not reset between the loads, causing conflicts during subsequent recipe applications.

### Proposed Fix

Implemented a fix by wrapping recipe applications within `session_context_manager()`, ensuring `active_session` is reset before each model's recipe is applied. This change isolates each model loading process, preventing the previously observed errors.

### Testing

Verified the fix by successfully loading multiple quantized models sequentially, which previously resulted in errors. The use of `session_context_manager()` before each recipe application has resolved the issue.


Test script:
```python
import sparseml.core.session as session_manager
from sparseml.transformers import SparseAutoModelForCausalLM

model_path = "mgoin/llama2.c-stories15M-quant-pt"

m1 = SparseAutoModelForCausalLM.from_pretrained(model_path)
m2 = SparseAutoModelForCausalLM.from_pretrained(model_path)
```

Before the fix:
```bash
"/nm/drive0/rahul/projects/sparseml/src/sparseml/modifiers/quantization/utils/quantize.py", line 189, in set_quantization_schemes
    raise_if_already_quantized(submodule_name, submodule)
  File "/nm/drive0/rahul/projects/sparseml/src/sparseml/modifiers/quantization/utils/quantize.py", line 386, in raise_if_already_quantized
    raise RuntimeError(
RuntimeError: Unable to quantize module model.embed_tokens, as it has already been quantized. Ensure your input recipe does not contain multiple QuantizationModifiers that act on the same module.
```

After the fix:

```bash
2024-04-05 18:52:04 sparseml.pytorch.model_load.helpers INFO     Reloaded model state after SparseML recipe structure modifications from /home/rahul/.cache/huggingface/hub/models--mgoin--llama2.c-stories15M-quant-pt/snapshots/aa70fc9dc46615b68f935fb5405ae7875b88b716
```