### PR TITLE
Update pydantic support to v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ _deps = [
     "pandas>=0.25.0",
     "packaging>=20.0",
     "psutil>=5.0.0",
-    "pydantic>=1.8.2,<2.0.0",
+    "pydantic>=2.0.0,<2.8.0",
     "requests>=2.0.0",
     "scikit-learn>=0.24.2",
     "scipy<1.9.2,>=1.8; python_version <= '3.9'",

--- a/src/sparseml/core/modifier/modifier.py
+++ b/src/sparseml/core/modifier/modifier.py
@@ -40,9 +40,9 @@ class Modifier(BaseModel, ModifierInterface, MultiFrameworkObject):
     :param update: The update step for the modifier
     """
 
-    index: int = None
-    group: str = None
-    start: float = None
+    index: Optional[int] = None
+    group: Optional[str] = None
+    start: Optional[float] = None
     end: Optional[float] = None
     update: Optional[float] = None
 

--- a/src/sparseml/core/recipe/base.py
+++ b/src/sparseml/core/recipe/base.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from sparseml.core.framework import Framework
 from sparseml.core.recipe.args import RecipeArgs
@@ -36,6 +36,8 @@ class RecipeBase(BaseModel, ABC):
         - create_modifier
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     @abstractmethod
     def calculate_start(self) -> int:
         raise NotImplementedError()
@@ -45,7 +47,7 @@ class RecipeBase(BaseModel, ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def evaluate(self, args: RecipeArgs = None, shift: int = None):
+    def evaluate(self, args: Optional[RecipeArgs] = None, shift: Optional[int] = None):
         raise NotImplementedError()
 
     @abstractmethod

--- a/src/sparseml/core/recipe/modifier.py
+++ b/src/sparseml/core/recipe/modifier.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, Optional
 
-from pydantic import root_validator
+from pydantic import model_validator
 
 from sparseml.core.factory import ModifierFactory
 from sparseml.core.framework import Framework
@@ -99,7 +99,8 @@ class RecipeModifier(RecipeBase):
             **self.args_evaluated,
         )
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def extract_modifier_type(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         modifier = {"group": values.pop("group")}
         assert len(values) == 1, "multiple key pairs found for modifier"

--- a/src/sparseml/core/recipe/recipe.py
+++ b/src/sparseml/core/recipe/recipe.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
-from pydantic import model_validator, Field
+from pydantic import Field, model_validator
 
 from sparseml.core.framework import Framework
 from sparseml.core.modifier import StageModifiers
@@ -152,7 +152,7 @@ class Recipe(RecipeBase):
                 )
                 _LOGGER.debug(f"Input string: {path_or_modifiers}")
                 obj = _load_json_or_yaml_string(path_or_modifiers)
-                return Recipe.parse_obj(obj)
+                return Recipe.model_validate(obj)
         else:
             _LOGGER.info(f"Loading recipe from file {path_or_modifiers}")
 
@@ -534,7 +534,7 @@ class Recipe(RecipeBase):
 
         :return: A dictionary representation of the recipe
         """
-        dict_ = super().dict(*args, **kwargs)
+        dict_ = super().model_dump(*args, **kwargs)
         stages = {}
 
         for stage in dict_["stages"]:

--- a/src/sparseml/core/recipe/recipe.py
+++ b/src/sparseml/core/recipe/recipe.py
@@ -705,7 +705,8 @@ def create_recipe_string_from_modifiers(
     recipe_dict = {
         f"{modifier_group_name}_stage": {
             f"{default_group_name}_modifiers": {
-                modifier.__class__.__name__: modifier.dict() for modifier in modifiers
+                modifier.__class__.__name__: modifier.model_dump()
+                for modifier in modifiers
             }
         }
     }

--- a/src/sparseml/core/recipe/recipe.py
+++ b/src/sparseml/core/recipe/recipe.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
-from pydantic import Field, root_validator
+from pydantic import model_validator, Field
 
 from sparseml.core.framework import Framework
 from sparseml.core.modifier import StageModifiers
@@ -391,7 +391,8 @@ class Recipe(RecipeBase):
 
         return modifiers
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def remap_stages(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         stages = []
 

--- a/src/sparseml/core/recipe/stage.py
+++ b/src/sparseml/core/recipe/stage.py
@@ -15,7 +15,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import model_validator, Field
+from pydantic import ConfigDict, Field, model_validator
 
 from sparseml.core.framework import Framework
 from sparseml.core.modifier import StageModifiers
@@ -45,6 +45,8 @@ class RecipeStage(RecipeBase):
         False otherwise
     :param args_evaluated: the evaluated RecipeArgs for the stage
     """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     group: Optional[str] = None
     run_type: Optional[StageRunType] = None

--- a/src/sparseml/core/recipe/stage.py
+++ b/src/sparseml/core/recipe/stage.py
@@ -15,7 +15,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import Field, root_validator
+from pydantic import model_validator, Field
 
 from sparseml.core.framework import Framework
 from sparseml.core.modifier import StageModifiers
@@ -139,7 +139,8 @@ class RecipeStage(RecipeBase):
 
         return stage_modifiers
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def remap_modifiers(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         modifiers = RecipeStage.extract_dict_modifiers(values)
         values["modifiers"] = modifiers

--- a/src/sparseml/exporters/transforms/kv_cache/configs.py
+++ b/src/sparseml/exporters/transforms/kv_cache/configs.py
@@ -17,7 +17,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-from pydantic import ConfigDict, BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from sparseml.exporters.transforms import OnnxTransform
 from sparseml.exporters.transforms.kv_cache.transforms_codegen import (
@@ -47,8 +47,9 @@ class KeyValueCacheConfig(BaseModel):
     additional_transforms: Union[
         List[Type[OnnxTransform]], Type[OnnxTransform], None
     ] = Field(
-        None, description="A transform class (or list thereof) to use for additional "
-        "transforms to the model required for finalizing the kv cache injection."
+        None,
+        description="A transform class (or list thereof) to use for additional "
+        "transforms to the model required for finalizing the kv cache injection.",
     )
     key_num_attention_heads: str = Field(
         description="The key to use to get the number of attention heads from the "

--- a/src/sparseml/exporters/transforms/kv_cache/configs.py
+++ b/src/sparseml/exporters/transforms/kv_cache/configs.py
@@ -17,7 +17,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, BaseModel, Field
 
 from sparseml.exporters.transforms import OnnxTransform
 from sparseml.exporters.transforms.kv_cache.transforms_codegen import (
@@ -47,7 +47,7 @@ class KeyValueCacheConfig(BaseModel):
     additional_transforms: Union[
         List[Type[OnnxTransform]], Type[OnnxTransform], None
     ] = Field(
-        description="A transform class (or list thereof) to use for additional "
+        None, description="A transform class (or list thereof) to use for additional "
         "transforms to the model required for finalizing the kv cache injection."
     )
     key_num_attention_heads: str = Field(
@@ -59,10 +59,10 @@ class KeyValueCacheConfig(BaseModel):
         "from the transformer's `config.json` file."
     )
     num_attention_heads: Optional[int] = Field(
-        description="The number of attention heads."
+        None, description="The number of attention heads."
     )
     hidden_size_kv_cache: Optional[int] = Field(
-        description="The hidden size of the key/value cache. "
+        None, description="The hidden size of the key/value cache. "
     )
     multiply_batch_by_num_att_heads: bool = Field(
         default=False,
@@ -83,9 +83,7 @@ class KeyValueCacheConfig(BaseModel):
         "the kv cache. If this is not provided, no transpose will "
         "be applied.",
     )
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 OPT_CONFIG = KeyValueCacheConfig(

--- a/src/sparseml/framework/info.py
+++ b/src/sparseml/framework/info.py
@@ -231,13 +231,13 @@ def save_framework_info(framework: Any, path: Optional[str] = None):
         create_parent_dirs(path)
 
         with open(path, "w") as file:
-            file.write(info.json())
+            file.write(info.model_dump_json())
 
         _LOGGER.info(
             "saved framework info for framework %s in file at %s", framework, path
         ),
     else:
-        print(info.json(indent=4))
+        print(info.model_dump_json(indent=4))
         _LOGGER.info("printed out framework info for framework %s", framework)
 
 

--- a/src/sparseml/integration_helper_functions.py
+++ b/src/sparseml/integration_helper_functions.py
@@ -188,7 +188,8 @@ class IntegrationHelperFunctions(RegistryMixin, BaseModel):
         default=export_model,
     )
     apply_optimizations: Optional[Callable[[Any], None]] = Field(
-        None, description="A function that takes:"
+        None,
+        description="A function that takes:"
         " - path to the exported model"
         " - names of the optimizations to apply"
         " and applies the optimizations to the model",
@@ -223,6 +224,7 @@ class IntegrationHelperFunctions(RegistryMixin, BaseModel):
     )
 
     deployment_directory_files_optional: Optional[List[str]] = Field(
-        None, description="A list that describes the "
+        None,
+        description="A list that describes the "
         "optional expected files of the deployment directory",
     )

--- a/src/sparseml/integration_helper_functions.py
+++ b/src/sparseml/integration_helper_functions.py
@@ -188,7 +188,7 @@ class IntegrationHelperFunctions(RegistryMixin, BaseModel):
         default=export_model,
     )
     apply_optimizations: Optional[Callable[[Any], None]] = Field(
-        description="A function that takes:"
+        None, description="A function that takes:"
         " - path to the exported model"
         " - names of the optimizations to apply"
         " and applies the optimizations to the model",
@@ -223,6 +223,6 @@ class IntegrationHelperFunctions(RegistryMixin, BaseModel):
     )
 
     deployment_directory_files_optional: Optional[List[str]] = Field(
-        description="A list that describes the "
+        None, description="A list that describes the "
         "optional expected files of the deployment directory",
     )

--- a/src/sparseml/modifiers/quantization/utils/quantization_scheme.py
+++ b/src/sparseml/modifiers/quantization/utils/quantization_scheme.py
@@ -264,7 +264,7 @@ class QuantizationScheme(BaseModel):
         """
         :return: YAML friendly string serialization
         """
-        dict_repr = self.dict()
+        dict_repr = self.model_dump()
         dict_repr = {
             key: val if val is not None else "null" for key, val in dict_repr.items()
         }

--- a/src/sparseml/modifiers/quantization/utils/quantization_scheme.py
+++ b/src/sparseml/modifiers/quantization/utils/quantization_scheme.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional, Union
 
 import torch
 from packaging import version
-from pydantic import field_validator, BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from torch.nn import Identity
 
 

--- a/src/sparseml/modifiers/quantization/utils/quantization_scheme.py
+++ b/src/sparseml/modifiers/quantization/utils/quantization_scheme.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional, Union
 
 import torch
 from packaging import version
-from pydantic import BaseModel, Field, validator
+from pydantic import field_validator, BaseModel, Field
 from torch.nn import Identity
 
 
@@ -121,7 +121,8 @@ class QuantizationArgs(BaseModel):
             qconfig_kwargs=self.kwargs,
         )
 
-    @validator("strategy")
+    @field_validator("strategy")
+    @classmethod
     def validate_strategy(cls, value):
         valid_scopes = ["tensor", "channel"]
         if value not in valid_scopes:

--- a/src/sparseml/pytorch/sparsification/quantization/quantization_scheme.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantization_scheme.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional, Union
 
 import torch
 from packaging import version
-from pydantic import BaseModel, Field, validator
+from pydantic import field_validator, BaseModel, Field
 from torch.nn import Identity
 
 
@@ -119,7 +119,8 @@ class QuantizationArgs(BaseModel):
             qconfig_kwargs=self.kwargs,
         )
 
-    @validator("strategy")
+    @field_validator("strategy")
+    @classmethod
     def validate_strategy(cls, value):
         valid_scopes = ["tensor", "channel"]
         if value not in valid_scopes:

--- a/src/sparseml/pytorch/sparsification/quantization/quantization_scheme.py
+++ b/src/sparseml/pytorch/sparsification/quantization/quantization_scheme.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional, Union
 
 import torch
 from packaging import version
-from pydantic import field_validator, BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from torch.nn import Identity
 
 

--- a/src/sparseml/pytorch/utils/sparsification_info/configs.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/configs.py
@@ -17,7 +17,7 @@ from collections import Counter, defaultdict
 from typing import Any, Dict, Generator, Tuple, Union
 
 import torch.nn
-from pydantic import ConfigDict, BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from sparseml.pytorch.utils.sparsification_info.helpers import (
     get_leaf_operations,

--- a/src/sparseml/pytorch/utils/sparsification_info/configs.py
+++ b/src/sparseml/pytorch/utils/sparsification_info/configs.py
@@ -17,7 +17,7 @@ from collections import Counter, defaultdict
 from typing import Any, Dict, Generator, Tuple, Union
 
 import torch.nn
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, BaseModel, Field
 
 from sparseml.pytorch.utils.sparsification_info.helpers import (
     get_leaf_operations,
@@ -326,9 +326,7 @@ class SparsificationQuantization(SparsificationInfo):
         description="A dictionary that maps the name of a layer"
         "to the precision of that layer."
     )
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
     def from_module(

--- a/src/sparseml/sparsification/info.py
+++ b/src/sparseml/sparsification/info.py
@@ -235,13 +235,13 @@ def save_sparsification_info(framework: Any, path: Optional[str] = None):
         create_parent_dirs(path)
 
         with open(path, "w") as file:
-            file.write(info.json())
+            file.write(info.model_dump_json())
 
         _LOGGER.info(
             "saved sparsification info for framework %s in file at %s", framework, path
         ),
     else:
-        print(info.json(indent=4))
+        print(info.model_dump_json(indent=4))
         _LOGGER.info("printed out sparsification info for framework %s", framework)
 
 

--- a/src/sparseml/sparsification/model_info.py
+++ b/src/sparseml/sparsification/model_info.py
@@ -25,7 +25,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Union
 
 import numpy
-from pydantic import BaseModel, Field, root_validator
+from pydantic import model_validator, BaseModel, Field
 
 from sparseml.utils import clean_path, create_parent_dirs
 
@@ -87,7 +87,8 @@ class LayerInfo(BaseModel):
         description="dictionary of string attribute names to their values",
     )
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def check_params_if_prunable(_, values):
         prunable = values.get("prunable")
         params = values.get("params")

--- a/src/sparseml/sparsification/model_info.py
+++ b/src/sparseml/sparsification/model_info.py
@@ -25,7 +25,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Union
 
 import numpy
-from pydantic import model_validator, BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from sparseml.utils import clean_path, create_parent_dirs
 

--- a/tests/integrations/image_classification/args.py
+++ b/tests/integrations/image_classification/args.py
@@ -149,7 +149,7 @@ class ImageClassificationTrainArgs(_ImageClassificationBaseArgs):
 
 class ImageClassificationExportArgs(_ImageClassificationBaseArgs):
     model_tag: Optional[str] = Field(
-        Default=None, description="required - tag for model under save_dir"
+        None, Default=None, description="required - tag for model under save_dir"
     )
     onnx_opset: int = Field(
         default=13, description="The onnx opset to use for exporting the model"

--- a/tests/integrations/transformers/args.py
+++ b/tests/integrations/transformers/args.py
@@ -507,7 +507,7 @@ class _TransformersTrainArgs(BaseModel):
     push_to_hub_token: str = Field(
         default=None, description="The token to use to push to the Model Hub."
     )
-    _n_gpu: int = Field(init=False, repr=False, default=-1)
+    n_gpu_: int = Field(init=False, repr=False, default=-1)
     mp_parameters: Optional[str] = Field(
         default=None,
         description="Used by the SageMaker launcher to send mp-specific args. "

--- a/tests/sparseml/core/recipe/test_recipe.py
+++ b/tests/sparseml/core/recipe/test_recipe.py
@@ -38,6 +38,7 @@ def test_recipe_create_instance_accepts_valid_recipe_file(recipe_str):
         assert recipe is not None, "Recipe could not be created from file"
 
 
+@pytest.mark.skip(reason="Currently failing and needs a fix")
 @pytest.mark.parametrize("recipe_str", valid_recipe_strings())
 def test_serialization(recipe_str):
     recipe_instance = Recipe.create_instance(recipe_str)

--- a/tests/sparseml/core/recipe/test_recipe.py
+++ b/tests/sparseml/core/recipe/test_recipe.py
@@ -38,11 +38,11 @@ def test_recipe_create_instance_accepts_valid_recipe_file(recipe_str):
         assert recipe is not None, "Recipe could not be created from file"
 
 
-@pytest.mark.skip(reason="Currently failing and needs a fix")
 @pytest.mark.parametrize("recipe_str", valid_recipe_strings())
 def test_serialization(recipe_str):
     recipe_instance = Recipe.create_instance(recipe_str)
-    recipe_from_serialized = Recipe.create_instance(recipe_instance.yaml())
+    serialized_recipe = recipe_instance.yaml()
+    recipe_from_serialized = Recipe.create_instance(serialized_recipe)
 
     expected_dict = recipe_instance.dict()
     actual_dict = recipe_from_serialized.dict()

--- a/tests/sparseml/framework/test_info.py
+++ b/tests/sparseml/framework/test_info.py
@@ -90,11 +90,11 @@ def test_framework_info_lifecycle(const_args):
     assert info, "No object returned for info constructor"
 
     # test serialization
-    info_str = info.json()
+    info_str = info.model_dump_json()
     assert info_str, "No json returned for info"
 
     # test deserialization
-    info_reconst = FrameworkInfo.parse_raw(info_str)
+    info_reconst = FrameworkInfo.model_validate_json(info_str)
     assert info == info_reconst, "Reconstructed does not equal original"
 
 
@@ -110,7 +110,7 @@ def test_save_load_framework_info():
         framework=Framework.unknown, package_versions={"unknown": "0.0.1"}
     )
     save_framework_info(info)
-    loaded_json = load_framework_info(info.json())
+    loaded_json = load_framework_info(info.model_dump_json())
     assert info == loaded_json
 
     test_path = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name


### PR DESCRIPTION
This PR updates sparseml pydantic support to v2

Steps:
- use pydantic's official bump pydantic tool for pre-liminary migration
- update setup.py
- fix model configs and typing
- update recipe serialization, also fixes a bug with original serialization

Test methodology:
- make test targets=torch passes locally
- sanity check with a dummy recipe containing multiple stages and multiple groups within each stage
- test script attached with description

Sanity Script:
```python
# local/feature/main.py


from sparseml.core import Recipe
import pprint as pp

import yaml

pp = pp.PrettyPrinter(indent=4)

recipe = """

first_oneshot_stage:
    pruning_modifiers:
        ConstantPruningModifier:
            start_epoch: 0
            end_epoch: 5
            targets: __ALL_PRUNABLE__
        
        MagnitudePruningModifier:
            start_epoch: 5
            end_epoch: 10
            init_sparsity: 0.1
            final_sparsity: 0.5
            targets: __ALL_PRUNABLE__
    
    quantization_modifiers:
        QuantizationModifier:
            start_epoch: 10
            end_epoch: 15
            bits: 8
            targets: __ALL_PRUNABLE__

second_oneshot_stage:
    pruning_modifiers:
        ConstantPruningModifier:
            start_epoch: 15
            end_epoch: 20
            targets: __ALL_PRUNABLE__
        
        MagnitudePruningModifier:
            start_epoch: 20
            end_epoch: 25
            init_sparsity: 0.1
            final_sparsity: 0.5
            targets: __ALL_PRUNABLE__
    
    quantization_modifiers:
        QuantizationModifier:
            start_epoch: 25
            end_epoch: 30
            bits: 8
            targets: __ALL_PRUNABLE__
"""

recipe = Recipe.create_instance(recipe)

yaml_str = recipe.yaml()
# print(yaml_str)
# print("++"* 20)

recipe_2 = Recipe.create_instance(yaml_str)
recipe_2_yaml = recipe_2.yaml()
# print(recipe_2_yaml)


assert yaml_str.strip() == recipe_2_yaml.strip()

```


Note: tests on GHA will fail until equivalent sparsezoo diff https://github.com/neuralmagic/sparsezoo/pull/483 lands
