### PR TITLE
Fix GSM template

### DIFF
--- a/src/sparseml/transformers/finetune/data/gsm8k.py
+++ b/src/sparseml/transformers/finetune/data/gsm8k.py
@@ -28,7 +28,7 @@ class GSM8KDataset(TextGenerationDataset):
     :param tokenizer: tokenizer to use on dataset
     """
 
-    GSM_TEMPLATE = "Question: {question}.\nAnswer:"
+    GSM_TEMPLATE = "Question: {question}\nAnswer:"
 
     def __init__(self, data_args, split, tokenizer):
         data_args = deepcopy(data_args)


### PR DESCRIPTION
There's no need of a period between the question and the line break since the question will contain its own punctuation (normally interrogation mark). The period also doesn't match the lm-evaluation-harness template and can lead to lower accuracy.