### PR TITLE
[GHA] Add workflow files to run weekly and nightly tests/run oneshot and finetune llama-7b model tests

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -5,7 +5,7 @@ on:
       - '*'
 jobs:
   test-nightly-tests:
-    runs-on: k8s-eng-gpu-16G-t4-32G # Should have multiple gpus enabled
+    runs-on: k8s-mle-gpu-14-vcpu-116GB-ram-t4-32 # Should have multiple gpus enabled
     env:
       CADENCE: "nightly"
       SPARSEZOO_TEST_MODE: "true"
@@ -33,5 +33,5 @@ jobs:
       - name: Run integration tests 
         run: |
           export CADENCE="nightly"
-          pytest -s tests/sparseml/transformers -m integration
+          pytest -s tests/sparseml/transformers/obcq/test_obcq_completion.py -m integration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Run integration tests 
         run: |
           export CADENCE="nightly"
-          pytest tests/sparseml/transformers -m integeration
+          pytest tests/sparseml/transformers -m integration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev,onnxruntime,torch,torchvision,transformers]
       - name: Run integration tests 
-        run:
+        run: |
           pytest tests/sparseml/pytorch -m integeration
           pytest tests/sparseml/transformers -m integeration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,8 +1,7 @@
 name: Run Nightly Tests
 on:
-  push:
-    branches:
-      - '*'
+  schedule:
+    - cron: '0 8 * * 0'
 jobs:
   test-nightly-tests:
     runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Run integration tests 
         run: |
           export CADENCE="nightly"
-          pytest -s tests/sparseml/transformers -m integration
+          pytest tests/sparseml/transformers -m integration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Run integration tests 
         run: |
           export CADENCE="nightly"
-          pytest -s tests/sparseml/transformers -m integration
+          pytest -v tests/sparseml/transformers/obcq/test_obcq_completion.py -m integration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,10 +1,8 @@
 name: Run Nightly Tests
 on:
-  schedule:
-    - cron: '0 8 * * 0'
   push:
     branches:
-      - '*'
+      - main
 jobs:
   test-nightly-tests:
     runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G
@@ -34,10 +32,8 @@ jobs:
         run: pip3 install .[dev,onnxruntime,torch,torchvision,transformers]
       - name: Run oneshot tests
         run: |
-          export CADENCE="nightly"
           pytest tests/sparseml/transformers/obcq -m integration
       - name: Run finetune tests
         run: |
-          export CADENCE="nightly"
           pytest tests/sparseml/transformers/finetune -m integration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Run integration tests 
         run: |
           export CADENCE="nightly"
-          pytest -s tests/sparseml/transformers/obcq/test_obcq_completion.py -m integration
+          pytest -s tests/sparseml/transformers -m integration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -2,6 +2,9 @@ name: Run Nightly Tests
 on:
   schedule:
     - cron: '0 8 * * 0'
+  push:
+    branches:
+      - '*'
 jobs:
   test-nightly-tests:
     runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G
@@ -29,8 +32,12 @@ jobs:
           fetch-depth: 1
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev,onnxruntime,torch,torchvision,transformers]
-      - name: Run integration tests 
+      - name: Run oneshot tests
         run: |
           export CADENCE="nightly"
-          pytest tests/sparseml/transformers -m integration
+          pytest tests/sparseml/transformers/obcq -m integration
+      - name: Run finetune tests
+        run: |
+          export CADENCE="nightly"
+          pytest tests/sparseml/transformers/finetune -m integration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Run integration tests 
         run: |
           export CADENCE="nightly"
-          pytest tests/sparseml/transformers -m integration
+          pytest -s tests/sparseml/transformers -m integration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -15,6 +15,15 @@ jobs:
       CLEARML_FILES_HOST:  ${{ secrets.CLEARML_FILES_HOST }}
       CLEARML_API_SECRET_KEY:  ${{ secrets.CLEARML_API_SECRET_KEY }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: "neuralmagic/compressed-tensors"
+          path: "compressed-tensors"
+          ref: ${{needs.test-setup.outputs.branch}}
+      - name: "⚙️ Install compressed-tensors dependencies"
+        run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
+      - name: "Clean compressed-tensors directory"
+        run: rm -r compressed-tensors/
       - name: Checkout code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,8 +1,8 @@
 name: Run Nightly Tests
 on:
-  push:
-    branches:
-      - '*'
+  schedule:
+    - cron: '0 20 * * *'
+  workflow_dispatch:
 jobs:
   test-nightly-tests:
     runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -36,5 +36,11 @@ jobs:
       - name: Run finetune tests
         if: always()
         run: |
-          pytest tests/sparseml/transformers/finetune -m integration
+          pytest tests/sparseml/transformers/finetune --skiplist test_oneshot_then_finetune -m integration
+      - name: Set env
+        run: echo "CUDA_VISIBLE_DEVICES=0" >> $GITHUB_ENV
+      - name: Run finetune test
+        if: always()
+        run: |
+          pytest tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -5,7 +5,7 @@ on:
       - '*'
 jobs:
   test-nightly-tests:
-    runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48
+    runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G
     env:
       CADENCE: "nightly"
       SPARSEZOO_TEST_MODE: "true"

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -17,6 +17,7 @@ jobs:
         run: pip3 install .[dev,onnxruntime,torch,torchvision,transformers]
       - name: Run integration tests 
         run: |
+          export CADENCE="nightly"
           pytest tests/sparseml/pytorch -m integeration
           pytest tests/sparseml/transformers -m integeration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -5,7 +5,7 @@ on:
       - '*'
 jobs:
   test-nightly-tests:
-    runs-on: k8s-mle-gpu-14-vcpu-116GB-ram-t4-32 # Should have multiple gpus enabled
+    runs-on: k8s-mle-gpu-38-vcpu-168GB-ram-2-v100-32G
     env:
       CADENCE: "nightly"
       SPARSEZOO_TEST_MODE: "true"

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -17,5 +17,6 @@ jobs:
         run: pip3 install .[dev,onnxruntime,torch,torchvision,transformers]
       - name: Run integration tests 
         run:
-          pytest tests -m integeration
+          pytest tests/sparseml/pytorch -m integeration
+          pytest tests/sparseml/transformers -m integeration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -5,10 +5,10 @@ on:
       - '*'
 jobs:
   test-nightly-tests:
-    runs-on: k8s-mle-gpu-38-vcpu-168GB-ram-2-v100-32G
+    runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48
     env:
       CADENCE: "nightly"
-      SPARSEZOO_TEST_MODE: "true"
+      SPARSEZOO_TEST_MODE: "true"ß
       CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}
       CLEARML_API_HOST: ${{ secrets.CLEARML_API_HOST }}
       CLEARML_API_ACCESS_KEY: ${{ secrets.CLEARML_API_ACCESS_KEY }}

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G
     env:
       CADENCE: "nightly"
-      SPARSEZOO_TEST_MODE: "true"
       CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}
       CLEARML_API_HOST: ${{ secrets.CLEARML_API_HOST }}
       CLEARML_API_ACCESS_KEY: ${{ secrets.CLEARML_API_ACCESS_KEY }}

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -2,7 +2,7 @@ name: Run Nightly Tests
 on:
   push:
     branches:
-      - main
+      - '*'
 jobs:
   test-nightly-tests:
     runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G
@@ -34,6 +34,7 @@ jobs:
         run: |
           pytest tests/sparseml/transformers/obcq -m integration
       - name: Run finetune tests
+        if: always()
         run: |
           pytest tests/sparseml/transformers/finetune -m integration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,0 +1,17 @@
+name: Run Nightly Tests
+jobs:
+  test-nightly-tests:
+    runs-on: k8s-eng-gpu-64G-v100-32G # Should have multiple gpus enabled
+    env:
+      CADENCE: "nightly"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: "⚙️ Install dependencies"
+        run: pip3 install .[dev,onnxruntime,torch,torchvision,transformers]
+      - name: Run integration tests 
+        run:
+          pytest tests -m integeration
+      

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48
     env:
       CADENCE: "nightly"
-      SPARSEZOO_TEST_MODE: "true"ß
+      SPARSEZOO_TEST_MODE: "true"
       CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}
       CLEARML_API_HOST: ${{ secrets.CLEARML_API_HOST }}
       CLEARML_API_ACCESS_KEY: ${{ secrets.CLEARML_API_ACCESS_KEY }}

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Run integration tests 
         run: |
           export CADENCE="nightly"
-          pytest -v tests/sparseml/transformers/obcq/test_obcq_completion.py -m integration
+          pytest -s tests/sparseml/transformers/obcq/test_obcq_completion.py -m integration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -8,6 +8,12 @@ jobs:
     runs-on: k8s-eng-gpu-16G-t4-32G # Should have multiple gpus enabled
     env:
       CADENCE: "nightly"
+      SPARSEZOO_TEST_MODE: "true"
+      CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}
+      CLEARML_API_HOST: ${{ secrets.CLEARML_API_HOST }}
+      CLEARML_API_ACCESS_KEY: ${{ secrets.CLEARML_API_ACCESS_KEY }}
+      CLEARML_FILES_HOST:  ${{ secrets.CLEARML_FILES_HOST }}
+      CLEARML_API_SECRET_KEY:  ${{ secrets.CLEARML_API_SECRET_KEY }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -18,6 +24,5 @@ jobs:
       - name: Run integration tests 
         run: |
           export CADENCE="nightly"
-          pytest tests/sparseml/pytorch -m integeration
           pytest tests/sparseml/transformers -m integeration
       

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -36,11 +36,4 @@ jobs:
       - name: Run finetune tests
         if: always()
         run: |
-          pytest tests/sparseml/transformers/finetune --skiplist test_oneshot_then_finetune -m integration
-      - name: Set env
-        run: echo "CUDA_VISIBLE_DEVICES=0" >> $GITHUB_ENV
-      - name: Run finetune test
-        if: always()
-        run: |
-          pytest tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
-      
+          pytest tests/sparseml/transformers/finetune -m integration

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -1,7 +1,11 @@
 name: Run Nightly Tests
+on:
+  push:
+    branches:
+      - '*'
 jobs:
   test-nightly-tests:
-    runs-on: k8s-eng-gpu-64G-v100-32G # Should have multiple gpus enabled
+    runs-on: k8s-eng-gpu-16G-t4-32G # Should have multiple gpus enabled
     env:
       CADENCE: "nightly"
     steps:

--- a/.github/workflows/test-weekly.yml
+++ b/.github/workflows/test-weekly.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G
     env:
       CADENCE: "weekly"
-      SPARSEZOO_TEST_MODE: "true"
       CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}
       CLEARML_API_HOST: ${{ secrets.CLEARML_API_HOST }}
       CLEARML_API_ACCESS_KEY: ${{ secrets.CLEARML_API_ACCESS_KEY }}

--- a/.github/workflows/test-weekly.yml
+++ b/.github/workflows/test-weekly.yml
@@ -1,8 +1,7 @@
 name: Run Weekly tests
 on:
-  push:
-    branches:
-      - '*'
+  schedule:
+    - cron: '0 8 * * 0'
 
 
 jobs:
@@ -32,7 +31,11 @@ jobs:
           fetch-depth: 1
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev,onnxruntime,torch,torchvision,transformers]
-      - name: Run integration tests 
+      - name: Run oneshot tests
         run: |
           export CADENCE="weekly"
-          pytest tests/sparseml/transformers -m integration
+          pytest tests/sparseml/transformers/obcq -m integration
+      - name: Run finetune tests
+        run: |
+          export CADENCE="weekly"
+          pytest tests/sparseml/transformers/finetune -m integration

--- a/.github/workflows/test-weekly.yml
+++ b/.github/workflows/test-weekly.yml
@@ -6,10 +6,25 @@ on:
 
 jobs:
   run-weekly-tests:
-    runs-on: k8s-eng-gpu-64G-v100-32G # Should have multiple gpus enabled
+    runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G
     env:
       CADENCE: "weekly"
+      SPARSEZOO_TEST_MODE: "true"
+      CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}
+      CLEARML_API_HOST: ${{ secrets.CLEARML_API_HOST }}
+      CLEARML_API_ACCESS_KEY: ${{ secrets.CLEARML_API_ACCESS_KEY }}
+      CLEARML_FILES_HOST:  ${{ secrets.CLEARML_FILES_HOST }}
+      CLEARML_API_SECRET_KEY:  ${{ secrets.CLEARML_API_SECRET_KEY }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: "neuralmagic/compressed-tensors"
+          path: "compressed-tensors"
+          ref: ${{needs.test-setup.outputs.branch}}
+      - name: "⚙️ Install compressed-tensors dependencies"
+        run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
+      - name: "Clean compressed-tensors directory"
+        run: rm -r compressed-tensors/
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -17,6 +32,6 @@ jobs:
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev,onnxruntime,torch,torchvision,transformers]
       - name: Run integration tests 
-        run:
-          pytest tests -m integeration
-      
+        run: |
+          export CADENCE="weekly"
+          pytest tests/sparseml/transformers -m integration

--- a/.github/workflows/test-weekly.yml
+++ b/.github/workflows/test-weekly.yml
@@ -1,7 +1,8 @@
 name: Run Weekly tests
 on:
-  schedule:
-    - cron: '0 8 * * 0'
+  push:
+    branches:
+      - '*'
 
 
 jobs:

--- a/.github/workflows/test-weekly.yml
+++ b/.github/workflows/test-weekly.yml
@@ -1,9 +1,8 @@
 name: Run Weekly tests
 on:
-  schedule:
-    - cron: '0 8 * * 0'
-
-
+  push:
+    branches:
+      - '*'
 jobs:
   run-weekly-tests:
     runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G

--- a/.github/workflows/test-weekly.yml
+++ b/.github/workflows/test-weekly.yml
@@ -32,9 +32,8 @@ jobs:
         run: pip3 install .[dev,onnxruntime,torch,torchvision,transformers]
       - name: Run oneshot tests
         run: |
-          export CADENCE="weekly"
           pytest tests/sparseml/transformers/obcq -m integration
       - name: Run finetune tests
+        if: always()
         run: |
-          export CADENCE="weekly"
           pytest tests/sparseml/transformers/finetune -m integration

--- a/.github/workflows/test-weekly.yml
+++ b/.github/workflows/test-weekly.yml
@@ -1,0 +1,22 @@
+name: Run Weekly tests
+on:
+  schedule:
+    - cron: '0 8 * * 0'
+
+
+jobs:
+  run-weekly-tests:
+    runs-on: k8s-eng-gpu-64G-v100-32G # Should have multiple gpus enabled
+    env:
+      CADENCE: "weekly"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: "⚙️ Install dependencies"
+        run: pip3 install .[dev,onnxruntime,torch,torchvision,transformers]
+      - name: Run integration tests 
+        run:
+          pytest tests -m integeration
+      

--- a/.github/workflows/test-weekly.yml
+++ b/.github/workflows/test-weekly.yml
@@ -1,8 +1,8 @@
 name: Run Weekly tests
 on:
-  push:
-    branches:
-      - '*'
+  schedule:
+    - cron: '0 20 * * 0'
+  workflow_dispatch:
 jobs:
   run-weekly-tests:
     runs-on: k8s-mle-gpu-12-vcpu-225GB-ram-2-a6000-48G

--- a/tests/sparseml/transformers/finetune/finetune_custom/config1.yaml
+++ b/tests/sparseml/transformers/finetune/finetune_custom/config1.yaml
@@ -2,4 +2,4 @@ cadence: "commit"
 test_type: "sanity"
 model: "Xenova/llama2.c-stories15M"
 file_extension: json
-num_train_epochs: 2
+num_train_epochs: 1

--- a/tests/sparseml/transformers/finetune/finetune_custom/config2.yaml
+++ b/tests/sparseml/transformers/finetune/finetune_custom/config2.yaml
@@ -2,4 +2,4 @@ cadence: "commit"
 test_type: "sanity"
 model: "Xenova/llama2.c-stories15M"
 file_extension: csv
-num_train_epochs: 2
+num_train_epochs: 1

--- a/tests/sparseml/transformers/finetune/finetune_custom/gpu/gpu_config.yaml
+++ b/tests/sparseml/transformers/finetune/finetune_custom/gpu/gpu_config.yaml
@@ -1,5 +1,5 @@
-cadence: "weekly"
+cadence: "nightly"
 test_type: "regression"
 model: "zoo:llama2-7b-ultrachat200k_llama2_pretrain-base"
 file_extension: json
-num_train_epochs: 1
+num_train_epochs: 0.5

--- a/tests/sparseml/transformers/finetune/finetune_oneshot_configs/config.yaml
+++ b/tests/sparseml/transformers/finetune/finetune_oneshot_configs/config.yaml
@@ -4,5 +4,5 @@ model: "Xenova/llama2.c-stories15M"
 dataset: wikitext
 dataset_config_name: "wikitext-2-raw-v1"
 recipe: "tests/sparseml/transformers/finetune/test_alternate_recipe.yaml"
-num_train_epochs: 2
+num_train_epochs: 1
 concat_txt: False

--- a/tests/sparseml/transformers/finetune/finetune_oneshot_configs/gpu/gpu_config.yaml
+++ b/tests/sparseml/transformers/finetune/finetune_oneshot_configs/gpu/gpu_config.yaml
@@ -3,5 +3,5 @@ test_type: "regression"
 model: "zoo:llama2-7b-ultrachat200k_llama2_pretrain-base"
 dataset: "ultrachat-200k"
 recipe: "tests/sparseml/transformers/finetune/test_alternate_recipe.yaml"
-num_train_epochs: 1
+num_train_epochs: 0.25
 concat_txt: False

--- a/tests/sparseml/transformers/finetune/finetune_oneshot_configs/gpu/gpu_config.yaml
+++ b/tests/sparseml/transformers/finetune/finetune_oneshot_configs/gpu/gpu_config.yaml
@@ -3,5 +3,5 @@ test_type: "regression"
 model: "zoo:llama2-7b-ultrachat200k_llama2_pretrain-base"
 dataset: "ultrachat-200k"
 recipe: "tests/sparseml/transformers/finetune/test_alternate_recipe.yaml"
-num_train_epochs: 0.25
+num_train_epochs: 0.05
 concat_txt: False

--- a/tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
+++ b/tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import shutil
 import unittest
 from pathlib import Path
@@ -22,10 +23,14 @@ from tests.testing_utils import requires_torch
 
 @pytest.mark.integration
 @requires_torch
+@pytest.mark.skipif(
+    os.environ["CADENCE"] == "weekly" or os.environ["CADENCE"] == "nightly",
+    reason="Don't run for weekly and nightly tests as those use multi gpu "
+    "runners and this test fails when ngpu>1",
+)
 class TestOneshotThenFinetune(unittest.TestCase):
     def setUp(self):
         self.output = Path("./finetune_output")
-        # TODO: temprarily only expose one gpu; seems to have trouble with multiple
 
     def test_oneshot_then_finetune(self):
         import torch

--- a/tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
+++ b/tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
@@ -24,7 +24,8 @@ from tests.testing_utils import requires_torch
 @pytest.mark.integration
 @requires_torch
 @pytest.mark.skipif(
-    os.environ["CADENCE"] == "weekly" or os.environ["CADENCE"] == "nightly",
+    "CADENCE" in os.environ
+    and (os.environ["CADENCE"] == "weekly" or os.environ["CADENCE"] == "nightly"),
     reason="Don't run for weekly and nightly tests as those use multi gpu "
     "runners and this test fails when ngpu>1",
 )

--- a/tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
+++ b/tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import shutil
 import unittest
 from pathlib import Path
@@ -27,7 +26,6 @@ class TestOneshotThenFinetune(unittest.TestCase):
     def setUp(self):
         self.output = Path("./finetune_output")
         # TODO: temprarily only expose one gpu; seems to have trouble with multiple
-        os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
     def test_oneshot_then_finetune(self):
         import torch
@@ -82,4 +80,3 @@ class TestOneshotThenFinetune(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.output)
-        os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"

--- a/tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
+++ b/tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
@@ -75,6 +75,7 @@ class TestOneshotThenFinetune(unittest.TestCase):
                 concatenate_data=concatenate_data,
                 splits=splits,
                 max_steps=max_steps,
+                oneshot_device=device,
             )
 
     def tearDown(self):

--- a/tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
+++ b/tests/sparseml/transformers/finetune/test_oneshot_then_finetune.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 import shutil
 import unittest
 from pathlib import Path
@@ -26,6 +26,8 @@ from tests.testing_utils import requires_torch
 class TestOneshotThenFinetune(unittest.TestCase):
     def setUp(self):
         self.output = Path("./finetune_output")
+        # TODO: temprarily only expose one gpu; seems to have trouble with multiple
+        os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
     def test_oneshot_then_finetune(self):
         import torch
@@ -80,3 +82,4 @@ class TestOneshotThenFinetune(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.output)
+        os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"

--- a/tests/sparseml/transformers/obcq/obcq_configs/completion/gpu/llama_7b_quant.yaml
+++ b/tests/sparseml/transformers/obcq/obcq_configs/completion/gpu/llama_7b_quant.yaml
@@ -1,4 +1,4 @@
-cadence: "nightly"
+cadence: "weekly"
 test_type: "regression"
 model: "zoo:llama2-7b-llama2_pretrain-base"
 dataset: open_platypus

--- a/tests/sparseml/transformers/obcq/obcq_configs/completion/gpu/llama_7b_quant_and_sparse.yaml
+++ b/tests/sparseml/transformers/obcq/obcq_configs/completion/gpu/llama_7b_quant_and_sparse.yaml
@@ -2,7 +2,7 @@ cadence: "weekly"
 test_type: "regression"
 model: "zoo:llama2-7b-llama2_pretrain-base"
 dataset: open_platypus
-recipe: "tests/sparseml/transformers/obcq/recipes/quant_and_sparse.yaml"
+recipe: "tests/sparseml/transformers/obcq/recipes/sparse.yaml"
 device: "cuda:0"
 num_samples: 512
 perplexity: 20

--- a/tests/sparseml/transformers/obcq/obcq_configs/completion/gpu/llama_7b_quant_and_sparse.yaml
+++ b/tests/sparseml/transformers/obcq/obcq_configs/completion/gpu/llama_7b_quant_and_sparse.yaml
@@ -1,4 +1,4 @@
-cadence: "nightly"
+cadence: "weekly"
 test_type: "regression"
 model: "zoo:llama2-7b-llama2_pretrain-base"
 dataset: open_platypus

--- a/tests/sparseml/transformers/obcq/obcq_configs/completion/gpu/llama_7b_sparse.yml
+++ b/tests/sparseml/transformers/obcq/obcq_configs/completion/gpu/llama_7b_sparse.yml
@@ -2,7 +2,7 @@ cadence: "weekly"
 test_type: "regression"
 model: "zoo:llama2-7b-llama2_pretrain-base"
 dataset: open_platypus
-recipe: "tests/sparseml/transformers/obcq/recipes/quant_and_sparse.yaml"
-device: "cuda:0"
+recipe: "tests/sparseml/transformers/obcq/recipes/sparse.yaml"
+device: "auto"
 num_samples: 512
 perplexity: 20

--- a/tests/sparseml/transformers/obcq/obcq_configs/completion/gpu/llama_7b_sparse.yml
+++ b/tests/sparseml/transformers/obcq/obcq_configs/completion/gpu/llama_7b_sparse.yml
@@ -3,6 +3,6 @@ test_type: "regression"
 model: "zoo:llama2-7b-llama2_pretrain-base"
 dataset: open_platypus
 recipe: "tests/sparseml/transformers/obcq/recipes/sparse.yaml"
-device: "auto"
+device: "cuda:1"
 num_samples: 512
 perplexity: 20

--- a/tests/sparseml/transformers/obcq/obcq_configs/sparse/gpu/llama_7b_sparse.yaml
+++ b/tests/sparseml/transformers/obcq/obcq_configs/sparse/gpu/llama_7b_sparse.yaml
@@ -1,4 +1,4 @@
-cadence: "weekly"
+cadence: "nightly"
 test_type: "regression"
 model: "zoo:llama2-7b-llama2_pretrain-base"
 dataset: open_platypus

--- a/tests/sparseml/transformers/obcq/obcq_configs/sparse/gpu/llama_7b_sparse.yaml
+++ b/tests/sparseml/transformers/obcq/obcq_configs/sparse/gpu/llama_7b_sparse.yaml
@@ -4,4 +4,4 @@ model: "zoo:llama2-7b-llama2_pretrain-base"
 dataset: open_platypus
 recipe: "tests/sparseml/transformers/obcq/recipes/sparse.yaml"
 sparsity: 0.3
-device: "cuda:0"
+device: "cuda:1"

--- a/tests/sparseml/transformers/obcq/obcq_configs/sparse/gpu/llama_7b_sparse.yaml
+++ b/tests/sparseml/transformers/obcq/obcq_configs/sparse/gpu/llama_7b_sparse.yaml
@@ -1,4 +1,4 @@
-cadence: "nightly"
+cadence: "weekly"
 test_type: "regression"
 model: "zoo:llama2-7b-llama2_pretrain-base"
 dataset: open_platypus

--- a/tests/sparseml/transformers/obcq/test_obcq_completion.py
+++ b/tests/sparseml/transformers/obcq/test_obcq_completion.py
@@ -148,6 +148,7 @@ class TestOBCQCompletionGPU(TestOBCQCompletion):
 
     def setUp(self):
         from sparseml.transformers import SparseAutoModelForCausalLM
+        import torch
 
         self.model_name = None
         self.output = "./oneshot_output"

--- a/tests/sparseml/transformers/obcq/test_obcq_completion.py
+++ b/tests/sparseml/transformers/obcq/test_obcq_completion.py
@@ -147,8 +147,9 @@ class TestOBCQCompletionGPU(TestOBCQCompletion):
     perplexity = None
 
     def setUp(self):
-        from sparseml.transformers import SparseAutoModelForCausalLM
         import torch
+
+        from sparseml.transformers import SparseAutoModelForCausalLM
 
         self.model_name = None
         self.output = "./oneshot_output"

--- a/tests/sparseml/transformers/obcq/test_obcq_completion.py
+++ b/tests/sparseml/transformers/obcq/test_obcq_completion.py
@@ -77,6 +77,8 @@ class TestOBCQCompletion(unittest.TestCase):
             pad_to_max_length=False,
             output_dir=self.output,
             clear_sparse_session=False,
+            precision="bfloat16",
+            bf16=True,
         )
 
         first_tiny_model = get_session_model()
@@ -155,7 +157,7 @@ class TestOBCQCompletionGPU(TestOBCQCompletion):
         if "zoo:" in self.model:
             self.model_name = self.model
             self.model = SparseAutoModelForCausalLM.from_pretrained(
-                self.model, device_map=self.device
+                self.model, device_map=self.device, torch_dtype=torch.bfloat16
             )
 
     def test_oneshot_completion_gpu(self):

--- a/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
@@ -69,6 +69,7 @@ class TestSparsities(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.output)
+        torch.cuda.empty_cache()
 
 
 @requires_gpu
@@ -103,7 +104,7 @@ class TestSparsitiesGPU(unittest.TestCase):
             oneshot_device=self.device,
             recipe=self.recipe,
             max_seq_length=128,
-            num_calibration_samples=64,
+            num_calibration_samples=32,
             pad_to_max_length=False,
             clear_sparse_session=False,
             output_dir=self.output,

--- a/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
@@ -115,6 +115,7 @@ class TestSparsitiesGPU(unittest.TestCase):
             precision="bfloat16",
             bf16=True,
         )
+        
 
         model = get_session_model()
 

--- a/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
@@ -68,6 +68,8 @@ class TestSparsities(unittest.TestCase):
         assert math.isclose(layer_2_dense.item(), 0.0, rel_tol=1e-4)
 
     def tearDown(self):
+        import torch
+
         shutil.rmtree(self.output)
         torch.cuda.empty_cache()
 

--- a/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
@@ -106,7 +106,7 @@ class TestSparsitiesGPU(unittest.TestCase):
             oneshot_device=self.device,
             recipe=self.recipe,
             max_seq_length=128,
-            num_calibration_samples=32,
+            num_calibration_samples=64,
             pad_to_max_length=False,
             clear_sparse_session=False,
             output_dir=self.output,

--- a/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
@@ -86,13 +86,15 @@ class TestSparsitiesGPU(unittest.TestCase):
     device = None
 
     def setUp(self):
+        import torch
+
         from sparseml.transformers import SparseAutoModelForCausalLM
 
         self.output = "./oneshot_output"
 
         if "zoo:" in self.model:
             self.model = SparseAutoModelForCausalLM.from_pretrained(
-                self.model, device_map=self.device
+                self.model, device_map=self.device, torch_dtype=torch.bfloat16
             )
 
     def test_sparsities_gpu(self):
@@ -110,6 +112,8 @@ class TestSparsitiesGPU(unittest.TestCase):
             pad_to_max_length=False,
             clear_sparse_session=False,
             output_dir=self.output,
+            precision="bfloat16",
+            bf16=True,
         )
 
         model = get_session_model()

--- a/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/sparseml/transformers/obcq/test_obcq_sparsity.py
@@ -115,7 +115,6 @@ class TestSparsitiesGPU(unittest.TestCase):
             precision="bfloat16",
             bf16=True,
         )
-        
 
         model = get_session_model()
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -53,6 +53,7 @@ def requires_torch(test_case):
 
 
 def requires_gpu(test_case):
+    print("GPU", is_gpu_available())
     return unittest.skipUnless(is_gpu_available(), "test requires GPU")(test_case)
 
 
@@ -97,6 +98,8 @@ def parse_params(
 
         cadence = os.environ.get("CADENCE", "commit")
         expected_cadence = config.get("cadence")
+
+        print("CADENCE", cadence, expected_cadence)
 
         if not isinstance(expected_cadence, list):
             expected_cadence = [expected_cadence]

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -53,9 +53,6 @@ def requires_torch(test_case):
 
 
 def requires_gpu(test_case):
-    import torch 
-
-    print("GPU", is_gpu_available(), torch.cuda.is_available())
     return unittest.skipUnless(is_gpu_available(), "test requires GPU")(test_case)
 
 
@@ -101,7 +98,6 @@ def parse_params(
         cadence = os.environ.get("CADENCE", "commit")
         expected_cadence = config.get("cadence")
 
-        print("CADENCE", cadence, expected_cadence)
 
         if not isinstance(expected_cadence, list):
             expected_cadence = [expected_cadence]

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -98,7 +98,6 @@ def parse_params(
         cadence = os.environ.get("CADENCE", "commit")
         expected_cadence = config.get("cadence")
 
-
         if not isinstance(expected_cadence, list):
             expected_cadence = [expected_cadence]
         if cadence in expected_cadence:

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -53,7 +53,9 @@ def requires_torch(test_case):
 
 
 def requires_gpu(test_case):
-    print("GPU", is_gpu_available())
+    import torch 
+
+    print("GPU", is_gpu_available(), torch.cuda.is_available())
     return unittest.skipUnless(is_gpu_available(), "test requires GPU")(test_case)
 
 


### PR DESCRIPTION
# Summary
- Adds workflows which run weekly and nightly tests 
- Currently set-up to run integration tests under the `transformers` folder. Specifically for oneshot and finetune
- Any test with a config file where the cadence has been set to nightly or weekly will run
- Using 2 `A6000` GPUS
- Weekly tests take about 1.5 hours
- Nightly tests take half hour to run
- Nightly test will soon be triggered by the nightly build workflow, set-up here:  https://github.com/neuralmagic/sparseml/pull/2270
- Nightly tests will run daily at 8 pm
- Weekly tests will run weekly on Sunday at 8 pm
