### PR TITLE
Split SparseGPT and GPTQ modifiers

### DIFF
--- a/src/sparseml/modifiers/obcq/base.py
+++ b/src/sparseml/modifiers/obcq/base.py
@@ -12,18 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from sparseml.core import Modifier
-from sparseml.core.factory import ModifierFactory
 from sparseml.core.model.base import ModifiableModel
 from sparseml.core.state import State
 
 
 __all__ = ["SparseGPTModifier"]
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class SparseGPTModifier(Modifier):
@@ -43,6 +39,11 @@ class SparseGPTModifier(Modifier):
             - LayerCompressor.revert_layer_wrappers()
 
     :param sparsity: Sparsity to compress model to
+    :param sparsity_profile: Can be set to 'owl' to use Outlier Weighed
+        Layerwise Sparsity (OWL), more information can be found
+        in the paper https://arxiv.org/pdf/2310.05175
+    :param owl_m: Number of outliers to use for OWL
+    :param owl_lmbda: Lambda value to use for OWL
     :param mask_structure: String to define the structure of the mask to apply.
         Must be of the form N:M where N, M are integers that define a custom block
         shape. Defaults to 0:0 which represents an unstructured mask.
@@ -51,12 +52,11 @@ class SparseGPTModifier(Modifier):
     :param targets: list of layer names to compress during OBCQ, or '__ALL__'
         to compress every layer in the model
     :param block_size: Used to determine number of columns to compress in one pass
-    :param quantize: Whether or not to quantize weights during SparseGPT. Set to
-        True to quantize using an existing quantization modifier, or pass in the
-        configuration for a quantization modifier if one does not already exist
-        in the recipe
     :param dampening_frac: Amount of dampening to apply to H, as a fraction of the
         diagonal norm
+    :param preserve_sparsity_mask: Whether or not to preserve the sparsity mask
+        during when applying sparsegpt, this becomes useful when starting from a
+        previously pruned model, defaults to False.
     """
 
     sparsity: Union[float, List[float]] = 0.0
@@ -66,68 +66,22 @@ class SparseGPTModifier(Modifier):
     mask_structure: str = "0:0"
     sequential_update: Optional[bool] = False
     targets: Union[str, List[str], None] = None
-    compressible_layers_: Optional[List] = None
+    block_size: int = 128
+    dampening_frac: Optional[float] = 0.01
+    preserve_sparsity_mask: bool = False
     prunen_: Optional[int] = None
     prunem_: Optional[int] = None
-    block_size: int = 128
-    quantize: Union[bool, Dict] = False
-    dampening_frac: Optional[float] = 0.01
-    quantization_modifier_: Any = None
+    compressible_layers_: Optional[List] = None
 
     def on_initialize_structure(self, state: State, **kwargs):
         """
-        Check the model's quantization state matches that expected by this modifier,
-        adding a default quantization scheme if needed
+        Initialize the structure of the model for compression.
+        This modifier does not modifiy the model structure, so this method
+        is a no-op.
 
         :param state: session state storing input model and calibration data
         """
-        quantization_already_active = state.model.qat_active()
-        if isinstance(self.quantize, bool):
-            if not self.quantize and quantization_already_active:
-                _LOGGER.warning(
-                    "SparseGPT quantization is set to False, but a "
-                    "quantization modifier is already active on the model "
-                    "resetting quantize to True"
-                )
-                self.quantize = True
-            elif self.quantize and not quantization_already_active:
-                _LOGGER.warning(
-                    "SparseGPT quantization is set to True without an "
-                    "active quantization modifier. Creating a default "
-                    "8-bit quantization modifier"
-                )
-                default_quant_config = {"QuantizationModifier": {}}
-                self._build_quant_modifier_from_dict(
-                    default_quant_config, state.framework
-                )
-            return  # use existing quantization modifier if there is one
-        else:
-            if not isinstance(self.quantize, Dict):
-                raise ValueError(
-                    "SparseGPTModifier.quantize accepts only a single "
-                    "quantization modifier or a boolean. Found "
-                    f"type {type(self.quantize)}"
-                )
-            if len(self.quantize) != 1:
-                raise ValueError(
-                    "SparseGPTModifier.quantize accepts only a single "
-                    "quantization modifier or a boolean. Found "
-                    f"{len(self.quantize)} modifiers"
-                )
-            if quantization_already_active:
-                _LOGGER.warning(
-                    "Attempting to initialize quantization for SparseGPT "
-                    "but a quantization modifier has already been applied. "
-                    "The quantization configuration defined under the "
-                    "SparseGPT modifier will be ignored."
-                )
-                self.quantize = True
-                return
-            self._build_quant_modifier_from_dict(self.quantize, state.framework)
-            self.quantize = True
-
-        if self.quantization_modifier_:
-            self.quantization_modifier_.on_initialize_structure(state, **kwargs)
+        return True
 
     def compressible_layers(self) -> Dict:
         """
@@ -161,17 +115,6 @@ class SparseGPTModifier(Modifier):
                 f"sparsities. Got {len(target_layers)} layers and "
                 f"{len(self.sparsity)} sparsities"
             )
-
-    def _build_quant_modifier_from_dict(self, quant_config, framework):
-        modifier_type = list(quant_config.keys())[0]
-        modifier_args = quant_config[modifier_type]
-        self.quantization_modifier_ = ModifierFactory.create(
-            modifier_type,
-            framework=framework,
-            allow_registered=True,
-            allow_experimental=True,
-            **modifier_args,
-        )
 
     def on_finalize(self, state: State, **kwargs):
         """

--- a/src/sparseml/modifiers/obcq/utils/sgpt_wrapper.py
+++ b/src/sparseml/modifiers/obcq/utils/sgpt_wrapper.py
@@ -25,7 +25,6 @@ except ImportError as err:
 
 import logging
 import math
-from copy import copy
 
 import torch
 import torch.nn as nn
@@ -85,6 +84,7 @@ class SparseGptWrapper(ModuleCompressionWrapper):
         prunem: int = 0,
         blocksize: int = 128,
         percdamp: float = 0.01,
+        preserve_sparsity_mask: bool = False,
     ):
         """
         Run pruning and quantization(if applicable) on the layer up to the target
@@ -95,7 +95,8 @@ class SparseGptWrapper(ModuleCompressionWrapper):
         :param prunem: M for N:M pruning
         :param blocksize: Number of columns to compress in one pass
         :param percdamp: Amount of dampening to apply to H, as a fraction of the
-        diagonal norm
+            diagonal norm
+        :param preserve_sparsity_mask: Extend or ignore the base sparsity mask
         """
         final_shape = self.layer.weight.shape
         final_dtype = self.layer.weight.dtype
@@ -124,6 +125,13 @@ class SparseGptWrapper(ModuleCompressionWrapper):
         Hinv = self.H
 
         mask = None
+        if preserve_sparsity_mask:
+            # compute existing sparsity mask
+            mask = torch.where(
+                W == 0,
+                torch.tensor(1, dtype=torch.bool),
+                torch.tensor(0, dtype=torch.bool),
+            )
 
         # See section 3.4 of https://arxiv.org/abs/2203.07259
         for i1 in range(0, self.columns, blocksize):
@@ -139,12 +147,32 @@ class SparseGptWrapper(ModuleCompressionWrapper):
             if prunen == 0:
                 if mask is not None:
                     mask1 = mask[:, i1:i2]
+                    if int(W1.numel() * sparsity) > mask1.sum():
+                        # target sparsity is higher than base sparsity, extend mask1
+                        tmp = (
+                            (~mask[:, i1:i2])
+                            * W1**2
+                            / (torch.diag(Hinv1).reshape((1, -1))) ** 2
+                        )
+                        thresh = torch.sort(tmp.flatten())[0][
+                            int(tmp.numel() * sparsity)
+                        ]
+                        mask1 = tmp <= thresh
+                    else:
+                        raise ValueError(
+                            "The target sparsity is lower than the sparsity "
+                            "of the base model. Please retry "
+                            "after turning preserve_sparsity_mask=False"
+                        )
                 else:
                     tmp = W1**2 / (torch.diag(Hinv1).reshape((1, -1))) ** 2
                     thresh = torch.sort(tmp.flatten())[0][int(tmp.numel() * sparsity)]
                     mask1 = tmp <= thresh
             else:
-                mask1 = torch.zeros_like(W1) == 1
+                if mask is not None:
+                    mask1 = mask[:, i1:i2]
+                else:
+                    mask1 = torch.zeros_like(W1) == 1
 
             for i in range(count):
                 w = W1[:, i]
@@ -155,72 +183,15 @@ class SparseGptWrapper(ModuleCompressionWrapper):
                         W1[:, i : (i + prunem)] ** 2
                         / (torch.diag(Hinv1)[i : (i + prunem)].reshape((1, -1))) ** 2
                     )
+                    if mask is not None:
+                        tmp = tmp * (~mask[:, i : (i + prunem)])
+
                     mask1.scatter_(
                         1, i + torch.topk(tmp, prunen, dim=1, largest=False)[1], True
                     )
 
                 q = w.clone()
                 q[mask1[:, i]] = 0
-
-                if hasattr(self.layer, "weight_fake_quant"):
-                    scale = self.layer.weight_fake_quant.scale
-                    zero_point = self.layer.weight_fake_quant.zero_point
-                    dtype = self.layer.weight_fake_quant.dtype
-                    qscheme = self.layer.weight_fake_quant.qscheme
-                    if qscheme in [torch.per_tensor_affine, torch.per_tensor_symmetric]:
-                        q = torch.quantize_per_tensor(q, scale, zero_point, dtype)
-                    else:
-                        q = torch.quantize_per_channel(q, scale, zero_point, 0, dtype)
-                    q = torch.dequantize(q)
-                elif hasattr(self.layer, "quantization_scheme"):
-                    quant_scheme = self.layer.quantization_scheme
-                    if quant_scheme.weights is not None:
-                        scale = self.layer.weight_scale
-                        zero_point = self.layer.weight_zero_point
-                        from compressed_tensors.quantization import QuantizationStrategy
-                        from compressed_tensors.quantization.lifecycle.forward import (
-                            fake_quantize,
-                        )
-
-                        strategy = quant_scheme.weights.strategy
-
-                        if strategy == QuantizationStrategy.TENSOR:
-                            q = fake_quantize(
-                                q,
-                                scale,
-                                zero_point,
-                                self.layer.quantization_scheme.weights,
-                            )
-                        elif strategy == QuantizationStrategy.CHANNEL:
-                            # TODO: for channelwise why isn't this just a 1d tensor?
-                            q = fake_quantize(
-                                q,
-                                scale[:, 0],
-                                zero_point[:, 0],
-                                quant_scheme.weights,
-                            )
-                        else:  # strategy == QuantizationStrategy.GROUP
-                            # TODO: for grouped quantization its always 3d but the last
-                            # dim is always 1. Can we just make it 2d instead and avoid?
-                            scale = scale[:, :, 0]
-                            zero_point = zero_point[:, :, 0]
-
-                            # get the group index for the current column
-                            column_idx = i1 + i
-                            input_dim_group = (
-                                column_idx // quant_scheme.weights.group_size
-                            )
-
-                            # Since we're only applying quantization to a slice, this
-                            # ends up being a channelwise application
-                            altered_qargs = copy(quant_scheme.weights)
-                            altered_qargs.strategy = QuantizationStrategy.CHANNEL
-                            q = fake_quantize(
-                                q,
-                                scale[:, input_dim_group],
-                                zero_point[:, input_dim_group],
-                                altered_qargs,
-                            )
 
                 Q1[:, i] = q
                 Losses1[:, i] = (w - q) ** 2 / d**2
@@ -232,7 +203,12 @@ class SparseGptWrapper(ModuleCompressionWrapper):
             W[:, i1:i2] = Q1
             Losses += torch.sum(Losses1, 1) / 2
 
-            W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
+            if preserve_sparsity_mask:
+                # respect the sparsity of other groups
+                # really not needed, but kept for explicitness
+                W[:, i2:] -= (~mask[:, i2:]) * Err1.matmul(Hinv[i1:i2, i2:])
+            else:
+                W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
 
         _LOGGER.info("time %.2f" % (time.time() - tick))
         _LOGGER.info("error %.2f" % torch.sum(Losses).item())

--- a/src/sparseml/modifiers/quantization/gptq/__init__.py
+++ b/src/sparseml/modifiers/quantization/gptq/__init__.py
@@ -14,4 +14,4 @@
 
 # flake8: noqa
 
-from .constants import *
+from .base import *

--- a/src/sparseml/modifiers/quantization/gptq/base.py
+++ b/src/sparseml/modifiers/quantization/gptq/base.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any, Dict, List, Optional, Union
+
+from sparseml.core import Modifier
+from sparseml.core.factory import ModifierFactory
+from sparseml.core.model.base import ModifiableModel
+from sparseml.core.state import State
+
+
+__all__ = ["GPTQModifier"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GPTQModifier(Modifier):
+    """
+    Modifier for applying the one-shot OBCQ algorithm to a model
+
+    Lifecycle:
+        - on_initialize
+            - initialize_compression()
+                - compressible_layers()
+                - LayerCompressor.pre_compress()
+            - apply_compression()
+                - run_calibration_forward()
+                - LayerCompressor.compress()
+                - LayerCompressor.post_compress()
+        - on_finalize
+            - LayerCompressor.revert_layer_wrappers()
+
+
+    :param sequential_update: Whether or not to update weights sequentially by layer,
+        True saves on GPU memory
+    :param targets: list of layer names to compress during GPTQ, or '__ALL__'
+        to compress every layer in the model
+    :param block_size: Used to determine number of columns to compress in one pass
+    :param quantize: Set to True to quantize using an existing quantization modifier,
+        or pass in the configuration for a quantization modifier if one does not
+        already exist in the recipe
+    :param dampening_frac: Amount of dampening to apply to H, as a fraction of the
+        diagonal norm
+    """
+
+    sequential_update: Optional[bool] = False
+    targets: Union[str, List[str], None] = None
+    block_size: int = 128
+    quantize: Union[bool, Dict] = True
+    dampening_frac: Optional[float] = 0.01
+    compressible_layers_: Optional[List] = None
+    quantization_modifier_: Any = None
+
+    def on_initialize_structure(self, state: State, **kwargs):
+        """
+        Check the model's quantization state matches that expected by this modifier,
+        adding a default quantization scheme if needed
+
+        :param state: session state storing input model and calibration data
+        """
+        quantization_already_active = state.model.qat_active()
+        if isinstance(self.quantize, bool):
+            if not self.quantize and quantization_already_active:
+                _LOGGER.warning(
+                    "SparseGPT quantization is set to False, but a "
+                    "quantization modifier is already active on the model "
+                    "resetting quantize to True"
+                )
+                self.quantize = True
+            elif self.quantize and not quantization_already_active:
+                _LOGGER.warning(
+                    "SparseGPT quantization is set to True without an "
+                    "active quantization modifier. Creating a default "
+                    "8-bit quantization modifier"
+                )
+                default_quant_config = {"QuantizationModifier": {}}
+                self._build_quant_modifier_from_dict(
+                    default_quant_config, state.framework
+                )
+            return  # use existing quantization modifier if there is one
+        else:
+            if not isinstance(self.quantize, Dict):
+                raise ValueError(
+                    "SparseGPTModifier.quantize accepts only a single "
+                    "quantization modifier or a boolean. Found "
+                    f"type {type(self.quantize)}"
+                )
+            if len(self.quantize) != 1:
+                raise ValueError(
+                    "SparseGPTModifier.quantize accepts only a single "
+                    "quantization modifier or a boolean. Found "
+                    f"{len(self.quantize)} modifiers"
+                )
+            if quantization_already_active:
+                _LOGGER.warning(
+                    "Attempting to initialize quantization for SparseGPT "
+                    "but a quantization modifier has already been applied. "
+                    "The quantization configuration defined under the "
+                    "SparseGPT modifier will be ignored."
+                )
+                self.quantize = True
+                return
+            self._build_quant_modifier_from_dict(self.quantize, state.framework)
+            self.quantize = True
+
+        if self.quantization_modifier_:
+            self.quantization_modifier_.on_initialize_structure(state, **kwargs)
+
+    def compressible_layers(self) -> Dict:
+        """
+        Retrieves the modules corresponding to a list of
+        compressible layer names
+
+        :precondition: self.model is set and is a `ModifiableModel`
+        :precondition: The `ModifiableModel` implements a `get_layers`
+            method
+        :return: dictionary of modules to compress
+        """
+        if not isinstance(self.model, ModifiableModel):
+            raise ValueError(
+                "`self.model` must be a ModifiableModel to use "
+                f"the {self.__class__.__qualname__} modifier but got "
+                f"{type(self.model)} instead"
+            )
+
+        return self.model.get_layers(self.targets)
+
+    def _build_quant_modifier_from_dict(self, quant_config, framework):
+        modifier_type = list(quant_config.keys())[0]
+        modifier_args = quant_config[modifier_type]
+        self.quantization_modifier_ = ModifierFactory.create(
+            modifier_type,
+            framework=framework,
+            allow_registered=True,
+            allow_experimental=True,
+            **modifier_args,
+        )
+
+    def on_finalize(self, state: State, **kwargs):
+        """
+        Nothing to do on finalize, on this level.
+        Quantization Modifier if any will be finalized in the subclass
+
+        :param state: session state storing input model and calibration data
+        :param kwargs: additional arguments
+        :return: True
+        """
+        return True

--- a/src/sparseml/modifiers/quantization/gptq/pytorch.py
+++ b/src/sparseml/modifiers/quantization/gptq/pytorch.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import torch
+
+from sparseml.core.model import ModifiableModel
+from sparseml.core.state import State
+from sparseml.modifiers.quantization.gptq.base import GPTQModifier
+from sparseml.modifiers.utils.layer_compressor import LayerCompressor
+from sparseml.modifiers.utils.pytorch_helpers import run_calibration_forward
+from src.sparseml.modifiers.quantization.gptq.utils.gptq_wrapper import GPTQWrapper
+
+
+__all__ = ["GPTQModifierPyTorch"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GPTQModifierPyTorch(GPTQModifier):
+    """
+    Pytorch implementation of GPTQ
+    Lifecycle:
+        - on_initialize
+            - initialize_compression()
+                - compressible_layers()
+                - LayerCompressor.pre_compress()
+            - apply_compression()
+                - run_calibration_forward()
+                - LayerCompressor.compress()
+                - LayerCompressor.post_compress()
+                - LayerCompressor.revert_layer_wrappers()
+    | Sample yaml:
+    |   test_stage:
+    |       obcq_modifiers:
+    |           GPTQModifier:
+    |               sequential_update: True
+    |               dampening_frac: 0.001
+    |               block_size: 128
+
+    :param model: Pytorch model to perform GPTQ on, in place.
+    """
+
+    model: Optional[ModifiableModel] = None
+    layer_compressors_: Optional[List[Any]] = None
+
+    def on_initialize(self, state: "State", **kwargs) -> bool:
+        """
+        Initialize and run the OBCQ algorithm on the current state
+
+        :param state: session state storing input model and calibration data
+        """
+        if not self.initialized_structure_:
+            self.on_initialize_structure(state, **kwargs)
+        if self.quantization_modifier_:
+            self.quantization_modifier_.initialize(state, **kwargs)
+        if not self.quantize:
+            raise ValueError("To use the GPTQModifier, quantization must be enabled.")
+
+        modifiable_model = state.model
+        calibration_dataloader = state.data.calib
+
+        if self.targets is None:
+            # if no targets are provided, default to the modules that shouldn't be
+            # split by FSDP. For Transformers models this is equivalent to the
+            # decoder layers (ie LlamaDecoderLayer)
+            self.targets = modifiable_model.get_no_split_params()
+
+        self.initialize_compression(modifiable_model, calibration_dataloader)
+        self.apply_compression(calibration_dataloader)
+
+        return True
+
+    def initialize_compression(
+        self,
+        model: ModifiableModel,
+        dataloader: Optional[Iterable[Tuple[List, Dict[str, Any]]]] = None,
+    ):
+        """
+        Setup for GPTQ, initializes the model
+        and other parameters, also initilializes the
+        compressible layers of model, and sets the device
+
+        :param model: model to initialize for compression
+        :param dataloader: calibration data for GPTQ
+        """
+        self.model = model
+        self.compressible_layers_ = self.compressible_layers()
+        self.model = self.model.model
+        self.layer_compressors_ = []
+
+        for idx, (name, layer) in enumerate(self.compressible_layers_.items()):
+            _LOGGER.info(f"Preparing {name} for compression")
+            if isinstance(self.sparsity, Dict):
+                layer_sparsity = self.sparsity[name]
+            elif isinstance(self.sparsity, List):
+                layer_sparsity = self.sparsity[idx]
+            else:  # float
+                layer_sparsity = self.sparsity
+            args = self._pruning_arguments(layer_sparsity)
+            comp_cls = self._compression_class()
+            compressor = LayerCompressor(comp_cls, self.model, layer, idx, name, args)
+            if not self.sequential_update:
+                # add all batch processing hooks before the forward pass
+                compressor.pre_compress()
+            self.layer_compressors_.append(compressor)
+
+    @torch.no_grad()
+    def apply_compression(
+        self, dataloader: Optional[Iterable[Tuple[List, Dict[str, Any]]]] = None
+    ) -> Dict:
+        """
+        Run GPTQ on the loaded model, using dataloader as calibration data
+
+        :param dataloader: calibration data for GPTQ
+        """
+        class_name = self.__class__.__name__.replace("PyTorch", "")
+        _LOGGER.info(
+            f"Running {class_name} calibration with " f"{len(dataloader)} samples..."
+        )
+        if not self.sequential_update:
+            # in non-sequential mode we run one forward batch for all modules
+            run_calibration_forward(self.model, dataloader, mask_padding=True)
+
+        num_layers = len(self.compressible_layers_)
+        for idx, layer_compressor in enumerate(self.layer_compressors_):
+            _LOGGER.info(f"\n===== Compressing layer {idx+1}/{num_layers} " " =====")
+
+            # Prune/quantize using GPTQ
+            if self.sequential_update:
+                # in sequential mode we run one forward pass for each module we
+                # want to compress, this will be really slow but allows compression in
+                # earlier layers to affect later layers
+                layer_compressor.pre_compress()
+                _LOGGER.info(f"Calibrating {layer_compressor.name}...")
+                run_calibration_forward(self.model, dataloader, mask_padding=True)
+            layer_compressor.compress()
+            layer_compressor.post_compress()
+            layer_compressor.revert_layer_wrappers()
+            torch.cuda.empty_cache()
+
+    def on_finalize(self, state: "State", **kwargs) -> bool:
+        """
+        disable the quantization observers used by the OBCQ algorithm
+
+        :param state: session state storing input model and calibration data
+        """
+        if self.quantization_modifier_:
+            self.quantization_modifier_.finalize(state, **kwargs)
+
+        return super(GPTQModifierPyTorch, self).on_finalize(state, **kwargs)
+
+    def _pruning_arguments(self):
+        """
+        Gather the parameters needed for root module compression in a dict
+
+        :param sparsity: target sparsity
+        :return: dict of params for pruning
+        """
+        return {
+            "blocksize": self.block_size,
+            "percdamp": self.dampening_frac,
+        }
+
+    def _compression_class(self):
+        """
+        :return: wrapper class used for root modules of this compression class
+        """
+        return GPTQWrapper

--- a/src/sparseml/modifiers/quantization/gptq/utils/__init__.py
+++ b/src/sparseml/modifiers/quantization/gptq/utils/__init__.py
@@ -11,7 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# flake8: noqa
-
-from .constants import *

--- a/src/sparseml/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/sparseml/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+from sparseml.modifiers.utils import SPARSITY_THRESHOLD
+from sparseml.modifiers.utils.compression_wrapper import ModuleCompressionWrapper
+
+
+try:
+    import transformers
+except ImportError as err:
+    transformers = None
+    transformers_err = err
+
+import logging
+import math
+from copy import copy
+
+import torch
+import torch.nn as nn
+
+
+__all__ = ["GPTQWrapper"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GPTQWrapper(ModuleCompressionWrapper):
+    """
+    Runs GPTQ on a single module that contains no sub-modules
+
+    Lifecycle:
+        - add_batch
+        - fasterprune
+        - free
+
+    :param name: name of module to run compression on
+    :param layer: module to run compression on
+    """
+
+    def __init__(self, name, layer):
+        super().__init__(name=name, layer=layer)
+
+        # for Hessian calculation
+        self.register_buffer(
+            "H", torch.zeros((self.columns, self.columns), device=self.dev)
+        )
+
+    def add_batch(self, inp: torch.Tensor, out: torch.Tensor):
+        """
+        Add a batch of layer input and output data to the Hessian calculation
+
+        :param inp: tensor containing layer input
+        :param out: tensor containing layer output
+        """
+        if len(inp.shape) == 2:
+            inp = inp.unsqueeze(0)
+        tmp = inp.shape[0]
+        if isinstance(self.layer, nn.Linear) or isinstance(
+            self.layer, transformers.Conv1D
+        ):
+            if len(inp.shape) == 3:
+                inp = inp.reshape((-1, inp.shape[-1]))
+            inp = inp.t()
+        self.H *= self.nsamples / (self.nsamples + tmp)
+        self.nsamples += tmp
+        inp = math.sqrt(2 / self.nsamples) * inp.float()
+        self.H += inp.matmul(inp.t()).to(self.dev)
+
+    def fasterprune(
+        self,
+        blocksize: int = 128,
+        percdamp: float = 0.01,
+    ):
+        """
+        Run pruning and quantization(if applicable) on the layer up to the target
+        sparsity value.
+
+        :param blocksize: Number of columns to compress in one pass
+        :param percdamp: Amount of dampening to apply to H, as a fraction of the
+            diagonal norm
+        """
+        final_shape = self.layer.weight.shape
+        final_dtype = self.layer.weight.dtype
+        W = self.layer.weight.data.clone()
+        from sparseml.pytorch.utils.helpers import tensor_sparsity
+
+        if isinstance(self.layer, nn.Conv2d):
+            W = W.flatten(1)
+        if isinstance(self.layer, transformers.Conv1D):
+            W = W.t()
+        W = W.float()
+
+        tick = time.time()
+
+        dead = torch.diag(self.H) == 0
+        self.H[dead, dead] = 1
+        W[:, dead] = 0
+
+        Losses = torch.zeros(self.rows, device=self.dev)
+
+        damp = percdamp * torch.mean(torch.diag(self.H))
+        diag = torch.arange(self.columns, device=self.dev)
+        self.H[diag, diag] += damp
+        self.H = torch.linalg.cholesky(self.H)
+        self.H = torch.cholesky_inverse(self.H)
+        self.H = torch.linalg.cholesky(self.H, upper=True)
+        Hinv = self.H
+
+        sparsity = tensor_sparsity(W)
+        mask = (
+            torch.where(
+                W == 0,
+                torch.tensor(1, dtype=torch.bool),
+                torch.tensor(0, dtype=torch.bool),
+            )
+            if sparsity >= SPARSITY_THRESHOLD
+            else None
+        )
+
+        # See section 3.4 of https://arxiv.org/abs/2203.07259
+        for i1 in range(0, self.columns, blocksize):
+            i2 = min(i1 + blocksize, self.columns)
+            count = i2 - i1
+
+            W1 = W[:, i1:i2].clone()
+            Q1 = torch.zeros_like(W1)
+            Err1 = torch.zeros_like(W1)
+            Losses1 = torch.zeros_like(W1)
+            Hinv1 = Hinv[i1:i2, i1:i2]
+
+            if sparsity >= SPARSITY_THRESHOLD:
+                tmp = (
+                    (~mask[:, i1:i2])
+                    * W1**2
+                    / (torch.diag(Hinv1).reshape((1, -1))) ** 2
+                )
+                thresh = torch.sort(tmp.flatten())[0][int(tmp.numel() * sparsity)]
+                mask1 = tmp <= thresh
+
+            for i in range(count):
+                w = W1[:, i]
+                d = Hinv1[i, i]
+                q = w.clone()
+                if sparsity >= SPARSITY_THRESHOLD:
+                    q[mask1[:, i]] = 0
+
+                if hasattr(self.layer, "weight_fake_quant"):
+                    scale = self.layer.weight_fake_quant.scale
+                    zero_point = self.layer.weight_fake_quant.zero_point
+                    dtype = self.layer.weight_fake_quant.dtype
+                    qscheme = self.layer.weight_fake_quant.qscheme
+                    if qscheme in [torch.per_tensor_affine, torch.per_tensor_symmetric]:
+                        q = torch.quantize_per_tensor(q, scale, zero_point, dtype)
+                    else:
+                        q = torch.quantize_per_channel(q, scale, zero_point, 0, dtype)
+                    q = torch.dequantize(q)
+                elif hasattr(self.layer, "quantization_scheme"):
+                    quant_scheme = self.layer.quantization_scheme
+                    if quant_scheme.weights is not None:
+                        scale = self.layer.weight_scale
+                        zero_point = self.layer.weight_zero_point
+                        from compressed_tensors.quantization import QuantizationStrategy
+                        from compressed_tensors.quantization.lifecycle.forward import (
+                            fake_quantize,
+                        )
+
+                        strategy = quant_scheme.weights.strategy
+
+                        if strategy == QuantizationStrategy.TENSOR:
+                            q = fake_quantize(
+                                q,
+                                scale,
+                                zero_point,
+                                self.layer.quantization_scheme.weights,
+                            )
+                        elif strategy == QuantizationStrategy.CHANNEL:
+                            # TODO: for channelwise why isn't this just a 1d tensor?
+                            q = fake_quantize(
+                                q,
+                                scale[:, 0],
+                                zero_point[:, 0],
+                                quant_scheme.weights,
+                            )
+                        else:  # strategy == QuantizationStrategy.GROUP
+                            # TODO: for grouped quantization its always 3d but the last
+                            # dim is always 1. Can we just make it 2d instead and avoid?
+                            scale = scale[:, :, 0]
+                            zero_point = zero_point[:, :, 0]
+
+                            # get the group index for the current column
+                            column_idx = i1 + i
+                            input_dim_group = (
+                                column_idx // quant_scheme.weights.group_size
+                            )
+
+                            # Since we're only applying quantization to a slice, this
+                            # ends up being a channelwise application
+                            altered_qargs = copy(quant_scheme.weights)
+                            altered_qargs.strategy = QuantizationStrategy.CHANNEL
+                            q = fake_quantize(
+                                q,
+                                scale[:, input_dim_group],
+                                zero_point[:, input_dim_group],
+                                altered_qargs,
+                            )
+
+                Q1[:, i] = q
+                Losses1[:, i] = (w - q) ** 2 / d**2
+
+                err1 = (w - q) / d
+                W1[:, i:] -= err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
+                Err1[:, i] = err1
+
+            W[:, i1:i2] = Q1
+            Losses += torch.sum(Losses1, 1) / 2
+
+            W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
+
+        _LOGGER.info("time %.2f" % (time.time() - tick))
+        _LOGGER.info("error %.2f" % torch.sum(Losses).item())
+
+        if isinstance(self.layer, transformers.Conv1D):
+            W = W.t()
+        W = W.reshape(final_shape).to(final_dtype)
+
+        # This is a bit hacky, but FSDP updates only work if we change the weight in
+        # place, clone() or direct assignment won't work
+        self.layer.weight -= self.layer.weight
+        self.layer.weight += W
+
+    def free(self):
+        """
+        Free the Hessian memory after the layer is complete
+        """
+        delattr(self, "H")
+        super().free()

--- a/src/sparseml/modifiers/utils/contants.py
+++ b/src/sparseml/modifiers/utils/contants.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# flake8: noqa
 
-from .constants import *
+__all__ = ["SPARSITY_THRESHOLD"]
+
+SPARSITY_THRESHOLD: float = 0.05


### PR DESCRIPTION
This PR introduces a structural change by separating concerns between quantization and sparsification. A new `GPTQModifier` is extracted from the existing `SparseGPTModifier`. This ensures that each class now has a focused responsibility — `GPTQModifier` manages quantization, while `SparseGPTModifier` is dedicated to sparsification.

### Changes

- **Extraction of `GPTQModifier`**: Carved out from `SparseGPTModifier`, this new class handles all aspects related to quantization, including arguments specifically for quantization processes.
  
- **Refinement of `SparseGPTModifier` and `SparseGPTWrapper`**: These have been updated to solely focus on sparsification. All quantization-related functionalities have been removed.
  
- **Creation of `GPTQWrapper`**: Implemented to apply quantization using  OBQ
  
- **Update on Test Recipes**: Modified the OBCQ test recipes to align with the new Modifiers.
  
- **Addition of Tests**: Introduced new tests specifically for `GPTQModifier` to ensure functionality and stability.

### Test Plan

- **Automated Tests**: The changes have been covered by automated tests, which are currently passing without issues (green status).

