### PR TITLE
[GHA] Swap aws runners; remove internal pypi step

### DIFF
--- a/.github/workflows/build-wheel-and-container.yml
+++ b/.github/workflows/build-wheel-and-container.yml
@@ -59,7 +59,7 @@ jobs:
     needs: build-wheel-and-push
     uses: ./.github/workflows/test-wheel-push-to-internal.yml
     with:
-      build-label: aws-avx2-64G
+      build-label: ubuntu-20.04
       whl: ${{ needs.build-wheel-and-push.outputs.wheel }}
       python: '3.10'
     secrets: inherit
@@ -70,7 +70,7 @@ jobs:
     needs: [set-outputs, test-wheel-and-push-internal]
     uses: ./.github/workflows/build-container.yml
     with:
-      build-label: aws-avx2-64G
+      build-label: k8s-eng-gpu-64G-v100-32G
       dev: ${{ needs.set-outputs.outputs.dev }}
       release: ${{ needs.set-outputs.outputs.release  }}
       name: ${{ github.event.number }}

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -140,7 +140,7 @@ jobs:
       - name: "🔬 Running onnx tests"
         run: make test TARGETS=onnx
   pytorch-tests:
-    runs-on: aws-avx2-64G
+    runs-on: k8s-eng-gpu-64G-v100-32G
     env:
       SPARSEZOO_TEST_MODE: "true"
       CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}
@@ -169,7 +169,7 @@ jobs:
       - name: "🔬 Running pytorch tests"
         run: make test TARGETS=pytorch
   compat-pytorch-1_9-pytorch-tests:
-    runs-on: aws-avx2-64G
+    runs-on: k8s-eng-gpu-64G-v100-32G
     env:
       SPARSEZOO_TEST_MODE: "true"
       CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}
@@ -222,7 +222,7 @@ jobs:
       - name: "🔬 Running onnx tests"
         run: make test TARGETS=onnx
   transformers-tests:
-    runs-on: aws-avx2-64G
+    runs-on: k8s-eng-gpu-64G-v100-32G
     env:
       SPARSEZOO_TEST_MODE: "true"
       CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}

--- a/.github/workflows/test-wheel-push-to-internal.yml
+++ b/.github/workflows/test-wheel-push-to-internal.yml
@@ -45,15 +45,6 @@ jobs:
     - name: Fetch name of whl
       run: |
           echo "FILENAME=$(echo dist_s3/*.whl)" >> $GITHUB_ENV
-          
-    - name: Push to internal pypi
-      uses: neuralmagic/nm-actions/actions/nm-upload-whl@main
-      with:
-        server: ${{ secrets.NM_PRIVATE_PYPI_LOCATION }}
-        username: ${{ secrets.NM_PRIVATE_PYPI_USER }}
-        password: ${{ secrets.NM_PRIVATE_PYPI_AUTH }}
-        whl: ./$FILENAME
-        port: 8080
 
     - name: Install whl
       run: |


### PR DESCRIPTION
- Continuing issues with aws so swapping testing and build runners to use k8
- Removing the internal pypi step as will be replaced with dumbpypi