### PR TITLE
Preserve sparsity GPTQ

### DIFF
--- a/src/sparseml/modifiers/utils/constants.py
+++ b/src/sparseml/modifiers/utils/constants.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# flake8: noqa
 
-from .constants import *
+__all__ = ["SPARSITY_THRESHOLD"]
+
+SPARSITY_THRESHOLD: float = 0.05

--- a/tests/sparseml/transformers/obcq/test_consecutive_runs.py
+++ b/tests/sparseml/transformers/obcq/test_consecutive_runs.py
@@ -114,7 +114,7 @@ class TestConsecutiveRunsSmall(TestConsecutiveRuns):
         self.output_second = Path(self.output) / "test_2"
 
     def test_consecutive_runs_small(self):
-        self._test_consecutive_runs(tolerance=1e-1)
+        self._test_consecutive_runs(tolerance=1e-3)
 
 
 @requires_gpu


### PR DESCRIPTION
Recently a bug was revealed, where if GPTQ modifier was applied consecutively after SparseGPT, the weight sparsity mask was not being respected, this PR fixes that by preserving the mask, we do this automatically if the weight sparsity is greater than `SPARSITY_THRESHOLD` which has been set to `5%` for now.

Credits to @Satrat and @abhinavnmagic for proposing the fix

The unit test for consecutive application now runs w/o having to increase the relative tolerance which was done as a part of #2272 