### PR TITLE
[1.7] Enable one-shot flow for non-LLMs

### DIFF
--- a/src/sparseml/transformers/finetune/data/base.py
+++ b/src/sparseml/transformers/finetune/data/base.py
@@ -195,7 +195,12 @@ class TextGenerationDataset(RegistryMixin):
         column_names = dataset.column_names
         if isinstance(column_names, dict):
             column_names = column_names[list(column_names)[0]]
-        if "labels" not in dataset.features:
+
+        if hasattr(dataset, "features") and "labels" in dataset.features:
+            # labels are already in the dataset,
+            # we don't need to add them
+            pass
+        else:
             _LOGGER.info(
                 "The dataset does not have labels in the dataset. "
                 "Assuming that the model is a text-generation "

--- a/src/sparseml/transformers/utils/sparse_model.py
+++ b/src/sparseml/transformers/utils/sparse_model.py
@@ -122,6 +122,7 @@ class SparseAutoModel:
     def masked_language_modeling_from_pretrained(
         model_name_or_path: str,
         model_type: str,
+        recipe: Optional[Union[str, Path]] = None,
         **kwargs,
     ) -> Module:
         """
@@ -148,6 +149,14 @@ class SparseAutoModel:
             model = AutoModelForMaskedLM.from_pretrained(
                 model_name_or_path,
                 **kwargs,
+            )
+
+        recipe = resolve_recipe(recipe, model_name_or_path)
+        if recipe:
+            apply_recipe_structure_to_model(
+                model=model,
+                model_path=model_name_or_path,
+                recipe_path=recipe,
             )
 
         log_model_load(model, model_name_or_path, model_type, delayed)
@@ -192,6 +201,7 @@ class SparseAutoModel:
     def question_answering_from_pretrained(
         model_name_or_path: str,
         model_type: str,
+        recipe: Optional[Union[str, Path]] = None,
         **kwargs,
     ) -> Module:
         """
@@ -214,6 +224,13 @@ class SparseAutoModel:
             model_name_or_path,
             **kwargs,
         )
+        recipe = resolve_recipe(recipe, model_name_or_path)
+        if recipe:
+            apply_recipe_structure_to_model(
+                model=model,
+                model_path=model_name_or_path,
+                recipe_path=recipe,
+            )
         log_model_load(model, model_name_or_path, model_type, delayed)
 
         return model
@@ -254,6 +271,7 @@ class SparseAutoModel:
     def text_classification_from_pretrained(
         model_name_or_path: str,
         model_type: str = "model",
+        recipe: Optional[Union[str, Path]] = None,
         **kwargs,
     ) -> Module:
         """
@@ -276,6 +294,15 @@ class SparseAutoModel:
             model_name_or_path,
             **kwargs,
         )
+
+        recipe = resolve_recipe(recipe, model_name_or_path)
+        if recipe:
+            apply_recipe_structure_to_model(
+                model=model,
+                model_path=model_name_or_path,
+                recipe_path=recipe,
+            )
+
         log_model_load(model, model_name_or_path, model_type, delayed)
 
         return model
@@ -351,6 +378,7 @@ class SparseAutoModel:
     def token_classification_from_pretrained(
         model_name_or_path: str,
         model_type: str,
+        recipe: Optional[Union[str, Path]] = None,
         **kwargs,
     ) -> Module:
         """
@@ -373,6 +401,13 @@ class SparseAutoModel:
             model_name_or_path,
             **kwargs,
         )
+        recipe = resolve_recipe(recipe, model_name_or_path)
+        if recipe:
+            apply_recipe_structure_to_model(
+                model=model,
+                model_path=model_name_or_path,
+                recipe_path=recipe,
+            )
         log_model_load(model, model_name_or_path, model_type, delayed)
 
         return model

--- a/src/sparseml/transformers/utils/sparse_model.py
+++ b/src/sparseml/transformers/utils/sparse_model.py
@@ -122,7 +122,6 @@ class SparseAutoModel:
     def masked_language_modeling_from_pretrained(
         model_name_or_path: str,
         model_type: str,
-        recipe: Optional[Union[str, Path]] = None,
         **kwargs,
     ) -> Module:
         """
@@ -149,14 +148,6 @@ class SparseAutoModel:
             model = AutoModelForMaskedLM.from_pretrained(
                 model_name_or_path,
                 **kwargs,
-            )
-
-        recipe = resolve_recipe(recipe, model_name_or_path)
-        if recipe:
-            apply_recipe_structure_to_model(
-                model=model,
-                model_path=model_name_or_path,
-                recipe_path=recipe,
             )
 
         log_model_load(model, model_name_or_path, model_type, delayed)
@@ -201,7 +192,6 @@ class SparseAutoModel:
     def question_answering_from_pretrained(
         model_name_or_path: str,
         model_type: str,
-        recipe: Optional[Union[str, Path]] = None,
         **kwargs,
     ) -> Module:
         """
@@ -224,13 +214,6 @@ class SparseAutoModel:
             model_name_or_path,
             **kwargs,
         )
-        recipe = resolve_recipe(recipe, model_name_or_path)
-        if recipe:
-            apply_recipe_structure_to_model(
-                model=model,
-                model_path=model_name_or_path,
-                recipe_path=recipe,
-            )
         log_model_load(model, model_name_or_path, model_type, delayed)
 
         return model
@@ -271,7 +254,6 @@ class SparseAutoModel:
     def text_classification_from_pretrained(
         model_name_or_path: str,
         model_type: str = "model",
-        recipe: Optional[Union[str, Path]] = None,
         **kwargs,
     ) -> Module:
         """
@@ -294,15 +276,6 @@ class SparseAutoModel:
             model_name_or_path,
             **kwargs,
         )
-
-        recipe = resolve_recipe(recipe, model_name_or_path)
-        if recipe:
-            apply_recipe_structure_to_model(
-                model=model,
-                model_path=model_name_or_path,
-                recipe_path=recipe,
-            )
-
         log_model_load(model, model_name_or_path, model_type, delayed)
 
         return model
@@ -378,7 +351,6 @@ class SparseAutoModel:
     def token_classification_from_pretrained(
         model_name_or_path: str,
         model_type: str,
-        recipe: Optional[Union[str, Path]] = None,
         **kwargs,
     ) -> Module:
         """
@@ -401,13 +373,6 @@ class SparseAutoModel:
             model_name_or_path,
             **kwargs,
         )
-        recipe = resolve_recipe(recipe, model_name_or_path)
-        if recipe:
-            apply_recipe_structure_to_model(
-                model=model,
-                model_path=model_name_or_path,
-                recipe_path=recipe,
-            )
         log_model_load(model, model_name_or_path, model_type, delayed)
 
         return model

--- a/src/sparseml/version.py
+++ b/src/sparseml/version.py
@@ -19,7 +19,7 @@ Functionality for storing and setting the version info for SparseML
 from datetime import date
 
 
-version_base = "1.7.1"
+version_base = "1.7.2"
 is_release = False  # change to True to set the generated version as a release version
 
 


### PR DESCRIPTION
## Feature Description

Enabling one-shot for non `text-generation` models in 1.7. Changes:
- user can now override the `labels`, by providing their own `labels` in the input dataset. This is crucial, since the labels must match the actual output of the model (`text-generation` models expect `(batch_size, num_tokens, vocab_size)` outputs, other `transformers` may expect for instance `(batch_size, num_classes)`.

## Example Use

```python
from sparseml.transformers import oneshot, SparseAutoModel
from datasets import load_dataset
from transformers import AutoConfig, AutoTokenizer, AutoModel, AutoModelForSequenceClassification
from typing import Union
from evaluate import evaluator
from sparseml import export
import sparseml.core.session as session_manager

# Part 1: Setup
model_name = "cardiffnlp/twitter-roberta-base-sentiment-latest"
dataset_name = "tweet_eval"
dataset_subname = "sentiment"
num_calibration_samples = 512 # number of samples to use for calibration
num_evaluation_samples = 3000 # number of samples to use for evaluation
save_dir_oneshot = "./oneshot_output" # directory to save the oneshot model

model = AutoModelForSequenceClassification.from_pretrained(model_name)
config = AutoConfig.from_pretrained(model_name)
tokenizer = AutoTokenizer.from_pretrained(model_name)

dataset_train = load_dataset(dataset_name, dataset_subname, split="train").shuffle(seed=420).select(range(num_calibration_samples))
dataset_test = load_dataset(dataset_name, dataset_subname, split="test").shuffle(seed=420).select(range(num_evaluation_samples))

# Part 2: Preparing the recipe and applying one-shot
recipe = """
test_stage:
  obcq_modifiers:
    QuantizationModifier:
      ignore:
        - LayerNorm
        - GELUActivation
      scheme_overrides:
        Embedding:
          input_activations: null
          weights:
            num_bits: 8
            symmetric: false
        Linear:
          input_activations:
            num_bits: 8
            symmetric: false
          weights:
            num_bits: 8
            symmetric: true
    SparseGPTModifier:
      sparsity: 0.0
      quantize: true
      targets: ["re:roberta.encoder.layer.\\\d+$"]
"""

def preprocessing_func(data):
    result = tokenizer(data["text"], padding="max_length", truncation=True)
    # oneshot assumes that the labels are in the "labels" key
    result["labels"] = data["label"]
    return result

oneshot(
    model=model,
    dataset=dataset_train,
    recipe=recipe,
    preprocessing_func = preprocessing_func,
    output_dir=save_dir_oneshot,
    num_calibration_samples = num_calibration_samples,
    # remove the label column from the dataset (we have labels instead)
    remove_columns = ["label"],
)
```