### PR TITLE
Fix errors introduced by GPTQ UX

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -164,6 +164,16 @@ jobs:
         run: pip3 install -U pip && pip3 install setuptools sparsezoo/
       - name: "Clean sparsezoo directory"
         run: rm -r sparsezoo/
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: "neuralmagic/compressed-tensors"
+          path: "compressed-tensors"
+          ref: ${{needs.test-setup.outputs.branch}}
+      - name: "⚙️ Install compressed-tensors dependencies"
+        run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
+      - name: "Clean compressed-tensors directory"
+        run: rm -r compressed-tensors/
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev,torchvision,onnxruntime,transformers]
       - name: "🔬 Running pytorch tests"
@@ -193,6 +203,16 @@ jobs:
         run: pip3 install -U pip && pip3 install setuptools sparsezoo/
       - name: "Clean sparsezoo directory"
         run: rm -r sparsezoo/
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: "neuralmagic/compressed-tensors"
+          path: "compressed-tensors"
+          ref: ${{needs.test-setup.outputs.branch}}
+      - name: "⚙️ Install compressed-tensors dependencies"
+        run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
+      - name: "Clean compressed-tensors directory"
+        run: rm -r compressed-tensors/
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev,torchvision,onnxruntime,transformers]
       - name: "🔬 Running pytorch tests"

--- a/src/sparseml/modifiers/quantization/gptq/pytorch.py
+++ b/src/sparseml/modifiers/quantization/gptq/pytorch.py
@@ -20,9 +20,9 @@ import torch
 from sparseml.core.model import ModifiableModel
 from sparseml.core.state import State
 from sparseml.modifiers.quantization.gptq.base import GPTQModifier
+from sparseml.modifiers.quantization.gptq.utils.gptq_wrapper import GPTQWrapper
 from sparseml.modifiers.utils.layer_compressor import LayerCompressor
 from sparseml.modifiers.utils.pytorch_helpers import run_calibration_forward
-from sparseml.modifiers.quantization.gptq.utils.gptq_wrapper import GPTQWrapper
 
 
 __all__ = ["GPTQModifierPyTorch"]

--- a/src/sparseml/modifiers/quantization/gptq/pytorch.py
+++ b/src/sparseml/modifiers/quantization/gptq/pytorch.py
@@ -22,7 +22,7 @@ from sparseml.core.state import State
 from sparseml.modifiers.quantization.gptq.base import GPTQModifier
 from sparseml.modifiers.utils.layer_compressor import LayerCompressor
 from sparseml.modifiers.utils.pytorch_helpers import run_calibration_forward
-from src.sparseml.modifiers.quantization.gptq.utils.gptq_wrapper import GPTQWrapper
+from sparseml.modifiers.quantization.gptq.utils.gptq_wrapper import GPTQWrapper
 
 
 __all__ = ["GPTQModifierPyTorch"]

--- a/src/sparseml/modifiers/quantization/gptq/pytorch.py
+++ b/src/sparseml/modifiers/quantization/gptq/pytorch.py
@@ -117,13 +117,7 @@ class GPTQModifierPyTorch(GPTQModifier):
 
         for idx, (name, layer) in enumerate(self.compressible_layers_.items()):
             _LOGGER.info(f"Preparing {name} for compression")
-            if isinstance(self.sparsity, Dict):
-                layer_sparsity = self.sparsity[name]
-            elif isinstance(self.sparsity, List):
-                layer_sparsity = self.sparsity[idx]
-            else:  # float
-                layer_sparsity = self.sparsity
-            args = self._pruning_arguments(layer_sparsity)
+            args = self._pruning_arguments()
             comp_cls = self._compression_class()
             compressor = LayerCompressor(comp_cls, self.model, layer, idx, name, args)
             if not self.sequential_update:

--- a/tests/sparseml/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
+++ b/tests/sparseml/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
@@ -98,7 +98,9 @@ class TestCreateDefaultQuantModifier(unittest.TestCase):
             default_config_group_name
         ]
         self.assertEqual(should_be_default_quant_scheme.input_activations.num_bits, 8)
-        assert not should_be_default_quant_scheme.input_activations.symmetric
+        # input activations are symmetric by default in vLLMQuantizationModifier
+        assert should_be_default_quant_scheme.input_activations.symmetric
+        
         self.assertEqual(should_be_default_quant_scheme.weights.num_bits, 8)
         assert should_be_default_quant_scheme.weights.symmetric
 

--- a/tests/sparseml/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
+++ b/tests/sparseml/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
@@ -100,7 +100,7 @@ class TestCreateDefaultQuantModifier(unittest.TestCase):
         self.assertEqual(should_be_default_quant_scheme.input_activations.num_bits, 8)
         # input activations are symmetric by default in vLLMQuantizationModifier
         assert should_be_default_quant_scheme.input_activations.symmetric
-        
+
         self.assertEqual(should_be_default_quant_scheme.weights.num_bits, 8)
         assert should_be_default_quant_scheme.weights.symmetric
 

--- a/tests/sparseml/transformers/obcq/recipes/quant.yaml
+++ b/tests/sparseml/transformers/obcq/recipes/quant.yaml
@@ -23,12 +23,10 @@ test_stage:
           weights:
             num_bits: 8
             symmetric: False
-    SparseGPTModifier:
-      sparsity: 0.0
+    GPTQModifier:
       block_size: 128
       sequential_update: False
       percdamp: 0.01
-      mask_structure: "0:0"
       targets: [
         "model.layers.0",
         "model.layers.1",
@@ -36,16 +34,4 @@ test_stage:
         "model.layers.3",
         "model.layers.4",
         "model.layers.5"
-      ]
-      GPTQModifier:
-        block_size: 128
-        sequential_update: False
-        percdamp: 0.01
-        targets: [
-          "model.layers.0",
-          "model.layers.1",
-          "model.layers.2",
-          "model.layers.3",
-          "model.layers.4",
-          "model.layers.5"
-        ]  
+      ]  

--- a/tests/sparseml/transformers/obcq/recipes/quant_and_sparse.yaml
+++ b/tests/sparseml/transformers/obcq/recipes/quant_and_sparse.yaml
@@ -24,12 +24,10 @@ test_stage:
           weights:
             num_bits: 8
             symmetric: False
-    SparseGPTModifier:
-      sparsity: 0.5
+    GPTQModifier:
       block_size: 128
       sequential_update: False
       percdamp: 0.01
-      mask_structure: "0:0"
       targets: [
         "model.layers.0",
         "model.layers.1",
@@ -38,10 +36,12 @@ test_stage:
         "model.layers.4",
         "model.layers.5"
       ]
-    GPTQModifier:
+    SparseGPTModifier:
+      sparsity: 0.5
       block_size: 128
       sequential_update: False
       percdamp: 0.01
+      mask_structure: "0:0"
       targets: [
         "model.layers.0",
         "model.layers.1",

--- a/tests/sparseml/transformers/obcq/test_sgpt_defaults.py
+++ b/tests/sparseml/transformers/obcq/test_sgpt_defaults.py
@@ -21,7 +21,7 @@ from tests.testing_utils import requires_torch
 
 @pytest.mark.integration
 @requires_torch
-class TestSGPTDefualts(unittest.TestCase):
+class TestSGPTDefaults(unittest.TestCase):
     def test_sgpt_defaults(self):
         from sparseml.core.framework import Framework
         from sparseml.core.state import State
@@ -31,17 +31,8 @@ class TestSGPTDefualts(unittest.TestCase):
         sparsegpt_modifier_only_sparsity = SparseGPTModifier(
             framework=Framework.pytorch, **kwargs
         )
-        assert not sparsegpt_modifier_only_sparsity.quantize
         self.assertEqual(sparsegpt_modifier_only_sparsity.block_size, 128)
         self.assertEqual(sparsegpt_modifier_only_sparsity.sparsity, 0.5)
-
-        kwargs = {"quantize": True}
-        sparsegpt_modifier_only_quant = SparseGPTModifier(
-            framework=Framework.pytorch, **kwargs
-        )
-        assert sparsegpt_modifier_only_quant.quantize
-        self.assertEqual(sparsegpt_modifier_only_quant.block_size, 128)
-        self.assertEqual(sparsegpt_modifier_only_quant.sparsity, 0.0)
 
         # fail if we don't pass a sparsity or enable quantization
         kwargs = {}


### PR DESCRIPTION
This PR makes main green again by:

1) Install compressed tensors from source wherever transformers deps are needed
2) Apply a commit that was missed (for transformers tests)