### PR TITLE
Fix import typo

### DIFF
--- a/examples/llama7b_sparse_quantized/README.md
+++ b/examples/llama7b_sparse_quantized/README.md
@@ -40,7 +40,7 @@ run the following:
 
 ```
 import torch
-from sparseml import SparseAutoModelForCausalLM
+from sparseml.transformers import SparseAutoModelForCausalLM
 
 model = SparseAutoModelForCausalLM.from_pretrained(output_dir, torch_dtype=torch.bfloat16)
 model.save_pretrained(compressed_output_dir, save_compressed=True)


### PR DESCRIPTION
`from sparseml import SparseAutoModelForCausalLM` errors with:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'SparseAutoModelForCausalLM' from 'sparseml' (/home/eldar/to_delete/sparseml/src/sparseml/__init__.py)
```
I think it should be `from sparseml.transformers import SparseAutoModelForCausalLM`