### PR TITLE
Update Quantization Logging to New Framework

### DIFF
--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -823,7 +823,8 @@ def get_quantized_layers(module: Module) -> List[Tuple[str, Module]]:
     quantized_layers = []
     for (name, mod) in module.named_modules():
         if hasattr(mod, "quantization_scheme"):
-            if mod.quantization_scheme.weights is not None:
+            weight_scheme = getattr(mod.quantization_scheme, "weights", None)
+            if weight_scheme is not None:
                 quantized_layers.append((name, mod))
 
     return quantized_layers

--- a/src/sparseml/pytorch/utils/helpers.py
+++ b/src/sparseml/pytorch/utils/helpers.py
@@ -824,7 +824,7 @@ def get_quantized_layers(module: Module) -> List[Tuple[str, Module]]:
     for (name, mod) in module.named_modules():
         if hasattr(mod, "quantization_scheme"):
             weight_scheme = getattr(mod.quantization_scheme, "weights", None)
-            if weight_scheme is not None:
+            if weight_scheme is not None and hasattr(mod, "weight"):
                 quantized_layers.append((name, mod))
 
     return quantized_layers

--- a/src/sparseml/transformers/finetune/session_mixin.py
+++ b/src/sparseml/transformers/finetune/session_mixin.py
@@ -500,15 +500,22 @@ class SessionManagerMixIn:
             f"Sparsification info for {type(self.model).__name__}: "
             f"{sparsification_info.params_total} total params. "
         )
+        sparsity_percent_formatted = "{:.2f}".format(
+            sparsification_info.params_prunable_sparse_percent
+        )
         _LOGGER.info(
             f"There are {sparsification_info.params_prunable_total} prunable "
-            f"params which have {sparsification_info.params_prunable_sparse_percent} "
+            f"params which have {sparsity_percent_formatted}% "
             "avg sparsity."
+        )
+
+        quant_percent_formatted = "{:.2f}".format(
+            sparsification_info.params_quantized_percent
         )
         _LOGGER.info(
             f"There are {sparsification_info.params_quantizable} quantizable "
             f"params, with a quantization percentage of "
-            f"{sparsification_info.params_quantized_percent}."
+            f"{quant_percent_formatted}%."
         )
 
     def _prepare_model_for_fsdp(self):

--- a/tests/sparseml/export/transformers/test_generative_transformers.py
+++ b/tests/sparseml/export/transformers/test_generative_transformers.py
@@ -131,7 +131,7 @@ class TestEndToEndExport:
 
         recipe = """test_stage:
           quant_modifiers:
-            QuantizationModifier:
+            LegacyQuantizationModifier:
               post_oneshot_calibration: False
               scheme_overrides:
                 Embedding:


### PR DESCRIPTION
The quantization percentage logging has been reporting 0.0% quantization since we switched over to the new framework. This PR updates the calculation to use the new framework. It also cleans up the string formatting and adds Embedding and a prunable/quantizable layer so the percentages are more accurate

### Before
```
2024-05-30 16:04:21 sparseml.transformers.finetune.session_mixin INFO     There are 1034420224 prunable params which have 1.2609391906088643 avg sparsity.
2024-05-30 16:04:21 sparseml.transformers.finetune.session_mixin INFO     There are 1034420224 quantizable params, with a quantization percentage of 0.0.
```

### After
```
2024-05-30 15:57:12 sparseml.transformers.finetune.session_mixin INFO     There are 1099956224 prunable params which have 1.19% avg sparsity.
2024-05-30 15:57:12 sparseml.transformers.finetune.session_mixin INFO     There are 1099956224 quantizable params, with a quantization percentage of 88.08%.
```