### PR TITLE
limit sparsezoo and deepsparse deps to 1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,11 @@ _deps = [
     "protobuf>=3.12.2,<=3.20.3",
     "click>=7.1.2,!=8.0.0",  # latest version < 8.0 + blocked version with reported bug
 ]
-_nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_nm_deps}"]
+_nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}>={1.7.0}"]
 _deepsparse_deps = [
-    f"{'deepsparse' if is_release else 'deepsparse-nightly'}~={version_nm_deps}"
+    f"{'deepsparse' if is_release else 'deepsparse-nightly'}>={1.7.0}"
 ]
-_deepsparse_ent_deps = [f"deepsparse-ent~={version_nm_deps}"]
+_deepsparse_ent_deps = [f"deepsparse-ent>={1.7.0}"]
 
 _onnxruntime_deps = ["onnxruntime>=1.0.0"]
 _clip_deps = ["open_clip_torch==2.20.0"]


### PR DESCRIPTION
no near term releases are planned for these dependencies so we won't require a hard sync on minor version. minimum supported will remain frozen at 1.7.0