### PR TITLE
Restrict NumPy Version <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
 
 _deps = [
     "pyyaml>=5.0.0",
-    "numpy>=1.17.0",
+    "numpy>=1.17.0,<2.0",
     "matplotlib>=3.0.0",
     "merge-args>=0.1.0",
     "onnx>=1.5.0,<1.15.0",


### PR DESCRIPTION
NumPy 2.0 released on June 16th, it broke some dependencies in SparseML. For the 1.8 release, I think its best we just restrict the version to < 2.0 since the error is in tensorboard rather than our code

### Testing

This error was being hit in multiple test suites, restricting the numpy version fixes the problem.
```
tests/sparseml/core/logger/test_logger.py:40: in <module>
    TensorBoardLogger(),
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/sparseml/core/logger/logger.py:505: in __init__
    raise tensorboard_import_error
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/sparseml/core/logger/logger.py:42: in <module>
    from torch.utils.tensorboard import SummaryWriter
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/torch/utils/tensorboard/__init__.py:12: in <module>
    from .writer import FileWriter, SummaryWriter  # noqa: F401
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/torch/utils/tensorboard/writer.py:13: in <module>
    from tensorboard.summary.writer.event_file_writer import EventFileWriter
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/tensorboard/summary/__init__.py:22: in <module>
    from tensorboard.summary import v1  # noqa: F401
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/tensorboard/summary/v1.py:23: in <module>
    from tensorboard.plugins.histogram import summary as _histogram_summary
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/tensorboard/plugins/histogram/summary.py:35: in <module>
    from tensorboard.plugins.histogram import summary_v2
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/tensorboard/plugins/histogram/summary_v2.py:35: in <module>
    from tensorboard.util import tensor_util
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/tensorboard/util/tensor_util.py:20: in <module>
    from tensorboard.compat.tensorflow_stub import dtypes, compat, tensor_shape
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/tensorboard/compat/tensorflow_stub/__init__.py:22: in <module>
    from .dtypes import as_dtype  # noqa
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/tensorboard/compat/tensorflow_stub/dtypes.py:[32](https://github.com/neuralmagic/sparseml/actions/runs/9549548577/job/26319412607#step:13:33)6: in <module>
    np.bool8: (False, True),
/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/numpy/__init__.py:410: in __getattr__
    raise AttributeError("module {!r} has no attribute "
E   AttributeError: module 'numpy' has no attribute 'bool8'
```